### PR TITLE
Fix overflow in RecurringEventPage

### DIFF
--- a/src/RecurringEventPage.jsx
+++ b/src/RecurringEventPage.jsx
@@ -124,7 +124,7 @@ export default function RecurringEventPage() {
         <meta name="description" content={series.description || ''} />
       </Helmet>
 
-      <div className="flex flex-col min-h-screen bg-white">
+      <div className="flex flex-col min-h-screen bg-white overflow-x-hidden">
         <Navbar />
 
         <main className="flex-grow">


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on recurring events page by adding `overflow-x-hidden`

## Testing
- `npm run lint` *(fails: couldn't find an ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68878140c680832ca27aa351f37b9b57