### PR TITLE
Implement full-screen hero for event page

### DIFF
--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -297,29 +297,40 @@ export default function EventDetailPage() {
 
       <main className="flex-grow">
         {/* Hero */}
-        <div className="relative">
-          <div
-            className="w-full h-[40vh] bg-cover bg-center"
-            style={{ backgroundImage: `url(${event['E Image']})` }}
-          />
-          <button
-            onClick={toggleFav}
-            disabled={toggling}
-            className="absolute top-6 right-6 text-4xl drop-shadow-lg"
-          >
-            {myFavId ? '❤️' : '🤍'} <span className="text-2xl">{favCount}</span>
-          </button>
+        <div
+          className="relative w-full h-screen bg-cover bg-center flex items-end"
+          style={{ backgroundImage: `url(${event['E Image']})` }}
+        >
+          <div className="absolute inset-0 bg-gradient-to-b from-black/50 to-black/80" />
+          <div className="relative z-10 w-full max-w-4xl mx-auto p-6 pb-12 text-white">
+            <h1 className="text-4xl font-bold mb-2">{event['E Name']}</h1>
+            <p className="text-lg mb-4">
+              {displayDate}
+              {event.time && ` — ${event.time}`}
+            </p>
+            <div className="flex items-center gap-4">
+              <button
+                onClick={toggleFav}
+                disabled={toggling}
+                className="text-4xl"
+              >
+                {myFavId ? '❤️' : '🤍'} <span className="text-2xl">{favCount}</span>
+              </button>
+              <button
+                onClick={handleShare}
+                className="bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded"
+              >
+                Share
+              </button>
+            </div>
+          </div>
         </div>
 
         {/* Overlapping Card */}
         <div className="max-w-4xl mx-auto bg-white shadow-xl rounded-xl p-8 -mt-24 transform">
-          <div className="text-center space-y-4">
-            <h1 className="text-4xl font-bold">{event['E Name']}</h1>
-            <p className="text-lg font-medium">
-              {displayDate}
-              {event.time && ` — ${event.time}`}
-            </p>
-          </div>
+          {event['E Description'] && (
+            <p className="text-center text-gray-700 text-lg">{event['E Description']}</p>
+          )}
         </div>
 
         {/* Description & Image */}
@@ -350,12 +361,6 @@ export default function EventDetailPage() {
                 </a>
               </div>
             )}
-            <button
-              onClick={handleShare}
-              className="w-full bg-green-600 text-white py-3 rounded-lg shadow hover:bg-green-700 transition"
-            >
-              Share
-            </button>
           </div>
           <div>
             {event['E Image'] && (

--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -302,37 +302,27 @@ export default function EventDetailPage() {
           style={{ backgroundImage: `url(${event['E Image']})` }}
         >
           <div className="absolute inset-0 bg-gradient-to-b from-black/50 to-black/80" />
-          <div className="relative z-10 w-full max-w-4xl mx-auto p-6 pb-12 text-white">
-            <h1 className="text-4xl font-bold mb-2">{event['E Name']}</h1>
-            <p className="text-lg mb-4">
+          <button
+            onClick={toggleFav}
+            disabled={toggling}
+            className="absolute top-6 left-6 z-10 text-4xl"
+          >
+            {myFavId ? '❤️' : '🤍'} <span className="text-2xl">{favCount}</span>
+          </button>
+          <div className="relative z-10 w-full max-w-4xl mx-auto p-6 pb-12 text-white text-center">
+            <h1 className="text-6xl font-[Barrio] mb-4">{event['E Name']}</h1>
+            <p className="text-xl mb-6">
               {displayDate}
               {event.time && ` — ${event.time}`}
             </p>
-            <div className="flex items-center gap-4">
-              <button
-                onClick={toggleFav}
-                disabled={toggling}
-                className="text-4xl"
-              >
-                {myFavId ? '❤️' : '🤍'} <span className="text-2xl">{favCount}</span>
-              </button>
-              <button
-                onClick={handleShare}
-                className="bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded"
-              >
-                Share
-              </button>
-            </div>
+            <button
+              onClick={handleShare}
+              className="bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded"
+            >
+              Share
+            </button>
           </div>
         </div>
-
-        {/* Overlapping Card */}
-        <div className="max-w-4xl mx-auto bg-white shadow-xl rounded-xl p-8 -mt-24 transform">
-          {event['E Description'] && (
-            <p className="text-center text-gray-700 text-lg">{event['E Description']}</p>
-          )}
-        </div>
-
         {/* Description & Image */}
         <div className="max-w-4xl mx-auto mt-12 px-4 grid grid-cols-1 lg:grid-cols-2 gap-8">
           <div>


### PR DESCRIPTION
## Summary
- convert event detail hero banner into a full-screen section
- overlay event info, favorite and share buttons on hero
- use gradient overlay for readability
- repurpose overlapping card to display event description

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68879c647d3c832c9e015bc48be2d18a