### PR TITLE
Add scrollers and cleanup EventDetailPage

### DIFF
--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -8,6 +8,9 @@ import { AuthContext } from './AuthProvider';
 import { Helmet } from 'react-helmet';
 import FloatingAddButton from './FloatingAddButton';
 import PostFlyerModal from './PostFlyerModal';
+import SimilarEventsScroller from './SimilarEventsScroller';
+import TaggedGroupsScroller from './TaggedGroupsScroller';
+import TaggedEventScroller from './TaggedEventsScroller';
 import {
   getMyEventFavorites,
   addEventFavorite,
@@ -351,12 +354,6 @@ export default function EventDetailPage() {
                 Share
               </button>
             </div>
-            <button
-              onClick={handleShare}
-              className="bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded"
-            >
-              Share
-            </button>
             {eventTags.length > 0 && (
               <div className="flex flex-wrap justify-center gap-2 mt-2">
                 {eventTags.map((tag, i) => (
@@ -381,25 +378,18 @@ export default function EventDetailPage() {
                 <p className="text-gray-700">{event['E Description']}</p>
               </div>
             )}
-            {event.longDescription && (
-              <div className="mb-6">
-                <h2 className="text-2xl font-semibold text-gray-900 mb-2">About this tradition</h2>
-                <p className="text-gray-700">{event.longDescription}</p>
-              </div>
-            )}
-            {event['E Link'] && (
-              <div className="mb-6">
-                <h2 className="text-xl font-semibold text-gray-900 mb-2">More Info</h2>
-                <a
-                  href={event['E Link']}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-indigo-600 hover:underline"
-                >
-                  Visit Site
-                </a>
-              </div>
-            )}
+            <div className="mb-6 flex items-center space-x-3 bg-gray-50 border rounded-lg p-3">
+              <button
+                onClick={toggleFav}
+                disabled={toggling}
+                className="text-2xl"
+              >
+                {myFavId ? '❤️' : '🤍'}
+              </button>
+              <span className="text-gray-700">
+                {favCount} people have favorited this
+              </span>
+            </div>
           </div>
           <div>
             {event['E Image'] && (
@@ -411,6 +401,15 @@ export default function EventDetailPage() {
             )}
           </div>
         </div>
+
+        <SimilarEventsScroller
+          tagSlugs={eventTags.map(t => t.slug)}
+          excludeId={event.id}
+        />
+
+        <TaggedGroupsScroller tags={eventTags} />
+
+        <TaggedEventScroller tags={['nomnomslurp']} header="#NomNomSlurp Upcoming" />
 
         {/* Reviews */}
         <section className="max-w-4xl mx-auto py-12 px-4">

--- a/src/SimilarEventsScroller.jsx
+++ b/src/SimilarEventsScroller.jsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from './supabaseClient';
+import { Link } from 'react-router-dom';
+
+export default function SimilarEventsScroller({ tagSlugs = [], excludeId }) {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const parseDate = (str) => {
+    if (!str) return null;
+    if (str.includes('/')) {
+      const [m, d, y] = str.split('/').map(Number);
+      return new Date(y, m - 1, d);
+    }
+    const [y, m, d] = str.split('-').map(Number);
+    return new Date(y, m - 1, d);
+  };
+
+  const fetchEvents = async () => {
+    if (!tagSlugs.length) { setEvents([]); setLoading(false); return; }
+    setLoading(true);
+    try {
+      const { data: tagRows } = await supabase
+        .from('tags')
+        .select('id')
+        .in('slug', tagSlugs);
+      const tagIds = (tagRows || []).map(t => t.id);
+      if (!tagIds.length) { setEvents([]); setLoading(false); return; }
+
+      const { data: taggings } = await supabase
+        .from('taggings')
+        .select('taggable_id')
+        .eq('taggable_type', 'events')
+        .in('tag_id', tagIds);
+
+      const ids = [...new Set((taggings || []).map(t => t.taggable_id))]
+        .filter(id => id !== excludeId);
+      if (!ids.length) { setEvents([]); setLoading(false); return; }
+
+      const { data: evRows } = await supabase
+        .from('events')
+        .select('id, slug, "E Name", "E Image", Dates, "End Date"')
+        .in('id', ids);
+
+      const today = new Date(); today.setHours(0,0,0,0);
+      const upcoming = (evRows || [])
+        .map(ev => {
+          const start = parseDate(ev.Dates);
+          const end = ev['End Date'] ? parseDate(ev['End Date']) : start;
+          return { ...ev, start, end };
+        })
+        .filter(ev => ev.start && ev.end >= today)
+        .sort((a,b) => a.start - b.start)
+        .slice(0,6);
+      setEvents(upcoming);
+    } catch (err) {
+      console.error('Error loading similar events:', err);
+      setEvents([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchEvents(); }, [tagSlugs.join(','), excludeId]);
+
+  const getBubble = (start) => {
+    const today = new Date(); today.setHours(0,0,0,0);
+    const diff = Math.round((start - today) / (1000*60*60*24));
+    if (diff === 0) return 'Today';
+    if (diff === 1) return 'Tomorrow';
+    if (diff > 1 && diff < 7)
+      return `This ${start.toLocaleDateString('en-US',{ weekday:'long' })}`;
+    if (diff >= 7 && diff < 14)
+      return `Next ${start.toLocaleDateString('en-US',{ weekday:'long' })}`;
+    return start.toLocaleDateString('en-US',{ month:'short', day:'numeric' });
+  };
+
+  return (
+    <section className="py-8 max-w-screen-xl mx-auto">
+      <h2 className="text-center text-2xl font-semibold text-gray-800 mb-4">
+        More traditions like this
+      </h2>
+      {loading ? (
+        <p className="text-center text-gray-500">Loading…</p>
+      ) : events.length === 0 ? (
+        <p className="text-center text-gray-600">No similar events.</p>
+      ) : (
+        <div className="overflow-x-auto scrollbar-hide">
+          <div className="flex gap-4 pb-4 px-2">
+            {events.map(ev => (
+              <Link
+                key={ev.id}
+                to={`/events/${ev.slug}`}
+                className="relative w-[240px] h-[340px] flex-shrink-0 rounded-xl overflow-hidden shadow-lg hover:shadow-xl transition-transform hover:scale-105 bg-white"
+              >
+                {ev['E Image'] && (
+                  <img
+                    src={ev['E Image']}
+                    alt={ev['E Name']}
+                    className="absolute inset-0 w-full h-full object-cover"
+                  />
+                )}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+                <h3 className="absolute bottom-16 left-3 right-3 text-center text-white text-xl font-bold z-20 leading-tight">
+                  {ev['E Name']}
+                </h3>
+                <span className="absolute bottom-4 left-1/2 transform -translate-x-1/2 bg-indigo-600 text-white text-sm font-semibold px-3 py-1 rounded-full z-20">
+                  {getBubble(ev.start)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/TaggedGroupsScroller.jsx
+++ b/src/TaggedGroupsScroller.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from './supabaseClient';
+
+export default function TaggedGroupsScroller({ tags = [] }) {
+  const [selected, setSelected] = useState(tags[0]?.slug || '');
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!selected) { setGroups([]); setLoading(false); return; }
+    setLoading(true);
+    (async () => {
+      try {
+        const { data: tagRow } = await supabase
+          .from('tags')
+          .select('id')
+          .eq('slug', selected)
+          .single();
+        const tagId = tagRow?.id;
+        if (!tagId) { setGroups([]); setLoading(false); return; }
+        const { data: taggings } = await supabase
+          .from('taggings')
+          .select('taggable_id')
+          .eq('taggable_type', 'groups')
+          .eq('tag_id', tagId);
+        const ids = (taggings || []).map(t => t.taggable_id);
+        if (!ids.length) { setGroups([]); setLoading(false); return; }
+        const { data: groupRows } = await supabase
+          .from('groups')
+          .select('id, Name, slug, imag, Type')
+          .in('id', ids)
+          .limit(12);
+        setGroups(groupRows || []);
+      } catch (err) {
+        console.error('Error loading tagged groups:', err);
+        setGroups([]);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [selected]);
+
+  if (!tags.length) return null;
+
+  return (
+    <section className="py-8 max-w-screen-xl mx-auto">
+      <h2 className="text-center text-2xl font-semibold text-gray-800 mb-4">
+        More groups like this
+      </h2>
+      <div className="flex flex-wrap justify-center gap-2 mb-4">
+        {tags.map((t, i) => (
+          <button
+            key={t.slug}
+            onClick={() => setSelected(t.slug)}
+            className={`${selected === t.slug ? 'bg-indigo-600 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'} px-3 py-1 rounded-full text-sm font-semibold`}
+          >
+            #{t.name}
+          </button>
+        ))}
+      </div>
+      {loading ? (
+        <p className="text-center text-gray-500">Loading…</p>
+      ) : groups.length === 0 ? (
+        <p className="text-center text-gray-600">No groups found.</p>
+      ) : (
+        <div className="overflow-x-auto scrollbar-hide">
+          <div className="flex gap-4 pb-4 px-2">
+            {groups.map(g => (
+              <Link
+                key={g.id}
+                to={`/groups/${g.slug}`}
+                className="flex-none w-[200px] sm:w-[240px] bg-white border rounded-xl overflow-hidden shadow hover:shadow-lg transition"
+              >
+                <div className="h-32 bg-gray-100">
+                  {g.imag && (
+                    <img src={g.imag} alt={g.Name} className="w-full h-full object-cover" />
+                  )}
+                </div>
+                <div className="p-3 text-center">
+                  <h3 className="text-sm font-semibold text-gray-900 truncate">{g.Name}</h3>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- create SimilarEventsScroller for tagged tradition suggestions
- create TaggedGroupsScroller to browse related groups
- tidy EventDetailPage hero buttons
- show heart count box and insert new scrollers

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c3b2ef28832cb0ddec8626fb6f69