### PR TITLE
Add event comments section across detail pages

### DIFF
--- a/src/BigBoardEventPage.jsx
+++ b/src/BigBoardEventPage.jsx
@@ -10,6 +10,7 @@ import PostFlyerModal from './PostFlyerModal';
 import FloatingAddButton from './FloatingAddButton';
 import TriviaTonightBanner from './TriviaTonightBanner';
 import useEventFavorite from './utils/useEventFavorite';
+import CommentsSection from './CommentsSection';
 
 export default function BigBoardEventPage() {
   const { slug } = useParams();
@@ -714,6 +715,11 @@ export default function BigBoardEventPage() {
               />
             </div>
           </div>
+
+          <CommentsSection
+            source_table="big_board_events"
+            event_id={event.id}
+          />
 
           {/* More Upcoming Community Submissions */}
           <div className="max-w-5xl mx-auto mt-12 border-t border-gray-200 pt-8 px-4 pb-12">

--- a/src/CommentsSection.jsx
+++ b/src/CommentsSection.jsx
@@ -1,0 +1,169 @@
+import React, { useState, useRef, useContext } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthContext } from './AuthProvider';
+import useEventComments from './utils/useEventComments';
+
+export default function CommentsSection({ source_table, event_id }) {
+  const { user } = useContext(AuthContext);
+  const {
+    comments,
+    addComment,
+    editComment,
+    deleteComment,
+  } = useEventComments({ source_table, event_id });
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const listRef = useRef(null);
+  const [expanded, setExpanded] = useState({});
+  const [editingId, setEditingId] = useState(null);
+  const [editContent, setEditContent] = useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!user) return;
+    const text = content.trim();
+    if (!text) return;
+    setSubmitting(true);
+    await addComment(text);
+    setContent('');
+    setSubmitting(false);
+    setTimeout(() => {
+      listRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, 100);
+  };
+
+  const startEdit = comment => {
+    setEditingId(comment.id);
+    setEditContent(comment.content);
+  };
+
+  const handleEditSubmit = async e => {
+    e.preventDefault();
+    if (!editingId) return;
+    const text = editContent.trim();
+    if (!text) {
+      setEditingId(null);
+      return;
+    }
+    const { error } = await editComment(editingId, text);
+    if (!error) {
+      setEditingId(null);
+    }
+  };
+
+  const handleDelete = async id => {
+    await deleteComment(id);
+  };
+
+  const toggle = id => {
+    setExpanded(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  return (
+    <section className="max-w-4xl mx-auto mt-12 px-4" ref={listRef}>
+      <h2 className="text-2xl font-semibold text-gray-800 mb-6">Comments</h2>
+      {comments.length === 0 ? (
+        <p className="text-gray-500">No comments yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {comments.map(c => {
+            const isLong = c.content.length > 300;
+            const isExpanded = expanded[c.id];
+            const canModify = user?.id === c.user_id;
+            return (
+              <div key={c.id} className="bg-white rounded-xl shadow p-4">
+                {editingId === c.id ? (
+                  <form onSubmit={handleEditSubmit} className="space-y-2">
+                    <textarea
+                      value={editContent}
+                      onChange={e => setEditContent(e.target.value)}
+                      rows={3}
+                      className="w-full border rounded-lg px-3 py-2"
+                    />
+                    <div className="flex space-x-2">
+                      <button
+                        type="submit"
+                        className="bg-indigo-600 text-white px-3 py-1 rounded"
+                      >
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setEditingId(null)}
+                        className="bg-gray-200 px-3 py-1 rounded"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </form>
+                ) : (
+                  <>
+                    <p className={isExpanded ? 'mb-2' : 'mb-2 line-clamp-3'}>{c.content}</p>
+                    {isLong && (
+                      <button
+                        onClick={() => toggle(c.id)}
+                        className="text-xs text-indigo-600 mb-2"
+                      >
+                        {isExpanded ? 'Show less' : 'Read more'}
+                      </button>
+                    )}
+                    <div className="flex justify-between items-center">
+                      <time className="text-xs text-gray-500">
+                        {new Date(c.created_at).toLocaleString()}
+                      </time>
+                      {canModify && (
+                        <div className="space-x-2 text-xs">
+                          <button
+                            onClick={() => startEdit(c)}
+                            className="text-indigo-600"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => handleDelete(c.id)}
+                            className="text-red-600"
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mt-6">
+        {user ? (
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <textarea
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              disabled={submitting}
+              rows={3}
+              className="w-full border rounded-lg px-3 py-2"
+              placeholder="Share your thoughts…"
+            />
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full bg-indigo-600 text-white py-2 rounded disabled:opacity-50"
+            >
+              {submitting ? 'Posting…' : 'Post Comment'}
+            </button>
+          </form>
+        ) : (
+          <p className="text-sm text-center">
+            <Link to="/login" className="text-indigo-600 hover:underline">
+              Log in
+            </Link>{' '}
+            to leave a comment
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/GroupEventDetailPage.jsx
+++ b/src/GroupEventDetailPage.jsx
@@ -8,6 +8,7 @@ import Footer from './Footer'
 import GroupProgressBar from './GroupProgressBar'
 import { AuthContext } from './AuthProvider'
 import EventFavorite from './EventFavorite.jsx'
+import CommentsSection from './CommentsSection'
 
 const pillStyles = [
   'bg-red-100 text-red-800',
@@ -462,6 +463,11 @@ if (ev.image_url) {
           </div>
         </div>
       </div>
+
+      <CommentsSection
+        source_table="group_events"
+        event_id={evt.id}
+      />
 
       {/* full-width community subs */}
       <section className="w-full bg-neutral-100 py-12">

--- a/src/MainEventsDetail.jsx
+++ b/src/MainEventsDetail.jsx
@@ -12,6 +12,7 @@ import FloatingAddButton from './FloatingAddButton';
 import SubmitEventSection from './SubmitEventSection';
 import TaggedEventScroller from './TaggedEventsScroller';
 import useEventFavorite from './utils/useEventFavorite';
+import CommentsSection from './CommentsSection';
 
 // parse "YYYY-MM-DD" into local Date
 function parseLocalYMD(str) {
@@ -606,6 +607,11 @@ export default function MainEventsDetail() {
               )}
           </div>
           </div>
+
+          <CommentsSection
+            source_table="all_events"
+            event_id={event.id}
+          />
 
           {relatedEvents.length > 0 && venueData && (
             <section className="max-w-4xl mx-auto mt-12 px-4">

--- a/src/RecurringEventPage.jsx
+++ b/src/RecurringEventPage.jsx
@@ -11,6 +11,7 @@ import PostFlyerModal from './PostFlyerModal';
 import FloatingAddButton from './FloatingAddButton';
 import SubmitEventSection from './SubmitEventSection';
 import useEventFavorite from './utils/useEventFavorite';
+import CommentsSection from './CommentsSection';
 
 export default function RecurringEventPage() {
   const { slug, date } = useParams();
@@ -386,20 +387,25 @@ export default function RecurringEventPage() {
               >
                 Share
               </button>
-            </div>
-
-            {/* Right side: capped-height image */}
-            <div>
-              <img
-                src={series.image_url}
-                alt={series.name}
-                className="w-full h-auto max-h-[60vh] object-contain rounded-lg shadow-lg"
-              />
-            </div>
           </div>
 
-          {/* Upcoming Dates */}
-          <div className="max-w-5xl mx-auto mt-12 border-t border-gray-200 pt-8 px-4 pb-12">
+          {/* Right side: capped-height image */}
+          <div>
+            <img
+              src={series.image_url}
+              alt={series.name}
+              className="w-full h-auto max-h-[60vh] object-contain rounded-lg shadow-lg"
+            />
+          </div>
+        </div>
+
+        <CommentsSection
+          source_table="recurring_events"
+          event_id={series.id}
+        />
+
+        {/* Upcoming Dates */}
+        <div className="max-w-5xl mx-auto mt-12 border-t border-gray-200 pt-8 px-4 pb-12">
             <h2 className="text-2xl text-center font-semibold text-gray-800 mb-6">
               Upcoming Dates
             </h2>

--- a/src/utils/useEventComments.js
+++ b/src/utils/useEventComments.js
@@ -1,0 +1,114 @@
+import { useState, useEffect, useContext } from 'react';
+import { supabase } from '../supabaseClient';
+import { AuthContext } from '../AuthProvider';
+
+export default function useEventComments({ source_table, event_id }) {
+  const { user } = useContext(AuthContext);
+  const [comments, setComments] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const BAD_WORDS = [
+    'fuck',
+    'shit',
+    'bitch',
+    'asshole',
+    'nigger',
+    'nigga',
+    'cunt',
+    'faggot',
+    'bastard',
+  ];
+
+  const hasProfanity = text => {
+    const lower = text.toLowerCase();
+    return BAD_WORDS.some(w => lower.includes(w));
+  };
+
+  const fetchComments = async () => {
+    if (!source_table || !event_id) {
+      setComments([]);
+      return;
+    }
+    setLoading(true);
+    let query = supabase
+      .from('event_comments')
+      .select('*')
+      .eq('source_table', source_table)
+      .order('created_at', { ascending: false });
+    if (source_table === 'all_events') query = query.eq('event_int_id', event_id);
+    else query = query.eq('event_id', event_id);
+    const { data, error } = await query;
+    if (!error) setComments(data || []);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchComments();
+  }, [source_table, event_id]);
+
+  const addComment = async content => {
+    const text = content.trim();
+    if (!user || !text) return;
+    if (hasProfanity(text)) {
+      return { error: { message: 'Inappropriate language detected' } };
+    }
+    const payload = {
+      user_id: user.id,
+      source_table,
+      content: text,
+      ...(source_table === 'all_events'
+        ? { event_int_id: event_id }
+        : { event_id }),
+    };
+    const { data, error } = await supabase
+      .from('event_comments')
+      .insert([payload])
+      .select('*')
+      .single();
+    if (!error && data) {
+      setComments(prev => [data, ...prev]);
+    }
+    return { data, error };
+  };
+
+  const editComment = async (id, content) => {
+    const text = content.trim();
+    if (!user || !text) return;
+    if (hasProfanity(text)) {
+      return { error: { message: 'Inappropriate language detected' } };
+    }
+    const { data, error } = await supabase
+      .from('event_comments')
+      .update({ content: text })
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .select('*')
+      .single();
+    if (!error && data) {
+      setComments(prev => prev.map(c => (c.id === id ? data : c)));
+    }
+    return { data, error };
+  };
+
+  const deleteComment = async id => {
+    if (!user) return;
+    const { error } = await supabase
+      .from('event_comments')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id);
+    if (!error) {
+      setComments(prev => prev.filter(c => c.id !== id));
+    }
+    return { error };
+  };
+
+  return {
+    comments,
+    addComment,
+    editComment,
+    deleteComment,
+    loading,
+    refresh: fetchComments,
+  };
+}


### PR DESCRIPTION
## Summary
- create reusable `useEventComments` hook
- add `CommentsSection` component
- integrate comments into recurring, group, big board and main event detail pages
- allow users to edit and delete their own comments
- filter out profane language on submission

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_688aa6dd2c60832c9ed43bd1d2cd900e