### PR TITLE
Add profile customization features

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,26 @@
+import { FlatCompat } from '@eslint/eslintrc'
+import reactRefresh from 'eslint-plugin-react-refresh'
+
+const compat = new FlatCompat({ baseDirectory: import.meta.url })
+
+export default [
+  ...compat.config({
+    env: { browser: true, es2020: true },
+    extends: [
+      'eslint:recommended',
+      'plugin:react/recommended',
+      'plugin:react/jsx-runtime',
+      'plugin:react-hooks/recommended',
+    ],
+    settings: { react: { version: '18.2' } },
+    plugins: { 'react-refresh': reactRefresh },
+    rules: {
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+    },
+  }),
+]
+
+export const ignores = ['dist/**', '.eslintrc.cjs']

--- a/src/CommentsSection.jsx
+++ b/src/CommentsSection.jsx
@@ -98,6 +98,22 @@ export default function CommentsSection({ source_table, event_id }) {
                   </form>
                 ) : (
                   <>
+                    <div className="flex items-center space-x-2 mb-2">
+                      {c.profileImage ? (
+                        <img
+                          src={c.profileImage}
+                          alt="avatar"
+                          className="w-8 h-8 rounded-full object-cover"
+                        />
+                      ) : (
+                        <div className="w-8 h-8 rounded-full bg-gray-200" />
+                      )}
+                      <span className="text-sm font-semibold">{c.username || 'User'}</span>
+                      {c.cultures?.length > 0 && (
+                        <span className="text-xl">{c.cultures.join(' ')}</span>
+                      )}
+                    </div>
+
                     <p className={isExpanded ? 'mb-2' : 'mb-2 line-clamp-3'}>{c.content}</p>
                     {isLong && (
                       <button

--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -1,8 +1,9 @@
 // src/ProfilePage.jsx
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState, useRef } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { supabase } from './supabaseClient'
 import { AuthContext } from './AuthProvider'
+import imageCompression from 'browser-image-compression'
 import Navbar from './Navbar'
 import Footer from './Footer'
 import SavedEventsScroller from './SavedEventsScroller.jsx'
@@ -27,6 +28,16 @@ export default function ProfilePage() {
   const [savedEvents, setSavedEvents] = useState([])
   const [loadingSaved, setLoadingSaved] = useState(false)
 
+  // ── Profile info ─────────────────────────────────────────
+  const [username, setUsername] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
+  const [cultures, setCultures] = useState([])
+  const [editingName, setEditingName] = useState(false)
+  const [savingName, setSavingName] = useState(false)
+  const [changingPic, setChangingPic] = useState(false)
+  const [showCultureModal, setShowCultureModal] = useState(false)
+  const [toast, setToast] = useState(null)
+
   // ── Styles for tag pills ─────────────────────────────────
   const pillStyles = [
     'bg-green-100 text-indigo-800',
@@ -43,6 +54,35 @@ export default function ProfilePage() {
   useEffect(() => {
     if (!user) return
     setEmail(user.email)
+
+    // profile info
+    ;(async () => {
+      const { data: prof } = await supabase
+        .from('profiles')
+        .select('username,image_url')
+        .eq('id', user.id)
+        .single()
+      if (prof) {
+        setUsername(prof.username || '')
+        setImageUrl(prof.image_url || '')
+      }
+
+      const { data: tagRows } = await supabase
+        .from('profile_tags')
+        .select('tag_id')
+        .eq('profile_id', user.id)
+        .eq('tag_type', 'culture')
+      if (tagRows?.length) {
+        const ids = tagRows.map(r => r.tag_id)
+        const { data: cultData } = await supabase
+          .from('culture_tags')
+          .select('id,name,emoji')
+          .in('id', ids)
+        setCultures(cultData || [])
+      } else {
+        setCultures([])
+      }
+    })()
 
     // all tags
     supabase
@@ -82,6 +122,12 @@ export default function ProfilePage() {
     }
   }
 
+  // ── Toast helper ─────────────────────────────────────────
+  const showToast = (msg, type='success') => {
+    setToast({ msg, type })
+    setTimeout(() => setToast(null), 3000)
+  }
+
   // ── Account actions ─────────────────────────────────────
   const updateEmail = async () => {
     setUpdating(true)
@@ -111,6 +157,157 @@ export default function ProfilePage() {
       await supabase.auth.signOut()
       navigate('/')
     }
+  }
+
+  const saveUsername = async () => {
+    if (!user) return
+    setSavingName(true)
+    const { error } = await supabase
+      .from('profiles')
+      .update({ username })
+      .eq('id', user.id)
+    if (error) showToast(error.message, 'error')
+    else {
+      showToast('Username updated!')
+      setEditingName(false)
+    }
+    setSavingName(false)
+  }
+
+  const fileInputRef = useRef(null)
+  const handlePicClick = () => fileInputRef.current?.click()
+  const handleFileChange = async e => {
+    const file = e.target.files?.[0]
+    if (!file || !user) return
+    setChangingPic(true)
+    try {
+      const options = { maxSizeMB: 0.5, maxWidthOrHeight: 256, useWebWorker: true }
+      const compressed = await imageCompression(file, options)
+      const ext = file.name.split('.').pop()?.toLowerCase() || 'jpg'
+      const path = `${user.id}/${Date.now()}.${ext}`
+      const { error: uploadErr } = await supabase.storage
+        .from('profile-images')
+        .upload(path, compressed, { upsert: true, contentType: file.type })
+      if (uploadErr) throw uploadErr
+      const { data: { publicUrl } } = supabase.storage
+        .from('profile-images')
+        .getPublicUrl(path)
+      const { error: updateErr } = await supabase
+        .from('profiles')
+        .update({ image_url: publicUrl })
+        .eq('id', user.id)
+      if (updateErr) throw updateErr
+      setImageUrl(publicUrl)
+      showToast('Picture updated!')
+    } catch (err) {
+      console.error(err)
+      showToast(err.message, 'error')
+    }
+    setChangingPic(false)
+  }
+
+  const CultureModal = () => {
+    const [search, setSearch] = useState('')
+    const [options, setOptions] = useState([])
+    const [selected, setSelected] = useState(new Set(cultures.map(c => c.id)))
+    const [loadingOpts, setLoadingOpts] = useState(false)
+    const [saving, setSaving] = useState(false)
+
+    useEffect(() => {
+      if (!showCultureModal) return
+      setLoadingOpts(true)
+      supabase
+        .from('culture_tags')
+        .select('*')
+        .order('name', { ascending: true })
+        .then(({ data, error }) => {
+          if (!error) setOptions(data || [])
+          setLoadingOpts(false)
+        })
+    }, [showCultureModal])
+
+    const toggle = id => {
+      setSelected(prev => {
+        const set = new Set(prev)
+        set.has(id) ? set.delete(id) : set.add(id)
+        return set
+      })
+    }
+
+    const handleSave = async () => {
+      if (!user) return
+      setSaving(true)
+      const ids = Array.from(selected)
+      const { error: delErr } = await supabase
+        .from('profile_tags')
+        .delete()
+        .eq('profile_id', user.id)
+        .eq('tag_type', 'culture')
+      if (delErr) {
+        showToast(delErr.message, 'error')
+        setSaving(false)
+        return
+      }
+      if (ids.length) {
+        const rows = ids.map(id => ({ profile_id: user.id, tag_id: id, tag_type: 'culture' }))
+        const { error: insErr } = await supabase.from('profile_tags').insert(rows)
+        if (insErr) {
+          showToast(insErr.message, 'error')
+          setSaving(false)
+          return
+        }
+      }
+      const newCult = options.filter(o => selected.has(o.id))
+      setCultures(newCult)
+      showToast('Cultures updated!')
+      setShowCultureModal(false)
+      setSaving(false)
+    }
+
+    if (!showCultureModal) return null
+    return (
+      <div className="fixed inset-0 bg-black/50 z-50 flex flex-col">
+        <div className="bg-white flex-1 overflow-y-auto p-4">
+          <div className="flex mb-4">
+            <input
+              className="flex-1 border rounded px-2 py-1"
+              placeholder="Search…"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
+            <button onClick={() => setShowCultureModal(false)} className="ml-2">✕</button>
+          </div>
+          {loadingOpts ? (
+            <p className="text-center text-gray-500">Loading…</p>
+          ) : (
+            <div className="space-y-2">
+              {options
+                .filter(o => o.name.toLowerCase().includes(search.toLowerCase()))
+                .map(o => (
+                  <label key={o.id} className="flex items-center space-x-2">
+                    <input
+                      type="checkbox"
+                      checked={selected.has(o.id)}
+                      onChange={() => toggle(o.id)}
+                    />
+                    <span className="text-xl">{o.emoji}</span>
+                    <span>{o.name}</span>
+                  </label>
+                ))}
+            </div>
+          )}
+        </div>
+        <div className="p-4 bg-white border-t">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="w-full bg-indigo-600 text-white py-2 rounded disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    )
   }
 
   // ── Load saved events when showing Upcoming tab ──────────
@@ -302,8 +499,72 @@ export default function ProfilePage() {
   return (
     <div className="min-h-screen bg-neutral-50 pb-12">
       <Navbar />
+      {cultures.length > 0 && (
+        <div className="flex justify-center text-3xl mt-4">
+          {cultures.map(c => (
+            <span key={c.id} className="mx-1">{c.emoji}</span>
+          ))}
+        </div>
+      )}
 
-      <div className="max-w-screen-md mx-auto px-4 py-12 mt-12">
+      <div className="max-w-screen-md mx-auto px-4 py-12 mt-6">
+        <div className="flex flex-col items-center mb-8">
+          <div className="relative">
+            {imageUrl ? (
+              <img src={imageUrl} alt="avatar" className="w-24 h-24 rounded-full object-cover" />
+            ) : (
+              <div className="w-24 h-24 rounded-full bg-gray-200" />
+            )}
+            <button
+              onClick={handlePicClick}
+              disabled={changingPic}
+              className="absolute bottom-0 right-0 text-xs bg-white px-2 py-1 rounded shadow"
+            >
+              {changingPic ? 'Uploading…' : 'Change Picture'}
+            </button>
+            <input
+              type="file"
+              accept="image/*"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+              className="hidden"
+            />
+          </div>
+          {editingName ? (
+            <div className="mt-2 flex items-center space-x-2">
+              <input
+                value={username}
+                onChange={e => setUsername(e.target.value)}
+                className="border rounded px-2 py-1"
+              />
+              <button
+                onClick={saveUsername}
+                disabled={savingName}
+                className="bg-indigo-600 text-white px-2 py-1 rounded text-sm"
+              >
+                Save
+              </button>
+              <button onClick={() => setEditingName(false)} className="text-sm">
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <h2
+              onClick={() => setEditingName(true)}
+              className="mt-2 text-2xl font-semibold cursor-pointer"
+            >
+              {username || 'Set username'}
+            </h2>
+          )}
+          <p className="text-sm text-gray-600">{email}</p>
+          <button
+            onClick={() => setShowCultureModal(true)}
+            className="text-sm text-indigo-600 underline mt-2"
+          >
+            Select Cultures
+          </button>
+        </div>
+
         <div className="flex justify-center gap-6 mb-8">
           <button
             onClick={() => setActiveTab('upcoming')}
@@ -405,6 +666,14 @@ export default function ProfilePage() {
         )}
       </div>
 
+      {toast && (
+        <div
+          className={`fixed bottom-4 right-4 text-white px-4 py-2 rounded ${toast.type==='error' ? 'bg-red-600' : 'bg-green-600'}`}
+        >
+          {toast.msg}
+        </div>
+      )}
+      <CultureModal />
       <Footer />
     </div>
   )

--- a/src/utils/useEventComments.js
+++ b/src/utils/useEventComments.js
@@ -1,11 +1,11 @@
-import { useState, useEffect, useContext } from 'react';
-import { supabase } from '../supabaseClient';
-import { AuthContext } from '../AuthProvider';
+import { useState, useEffect, useContext } from 'react'
+import { supabase } from '../supabaseClient'
+import { AuthContext } from '../AuthProvider'
 
 export default function useEventComments({ source_table, event_id }) {
   const { user } = useContext(AuthContext);
-  const [comments, setComments] = useState([]);
-  const [loading, setLoading] = useState(false);
+  const [comments, setComments] = useState([])
+  const [loading, setLoading] = useState(false)
 
   const BAD_WORDS = [
     'fuck',
@@ -24,23 +24,79 @@ export default function useEventComments({ source_table, event_id }) {
     return BAD_WORDS.some(w => lower.includes(w));
   };
 
+  const transform = c => {
+    const profile = c.profiles || {}
+    let img = ''
+    if (profile.image_url) {
+      if (/^https?:/.test(profile.image_url)) {
+        img = profile.image_url
+      } else {
+        const { data: { publicUrl } } = supabase.storage
+          .from('profile-images')
+          .getPublicUrl(profile.image_url)
+        img = publicUrl
+      }
+    }
+    const cultures = (profile.profile_tags || [])
+      .filter(t => t.tag_type === 'culture')
+      .map(t => t.culture_tags?.emoji)
+      .filter(Boolean)
+    return {
+      ...c,
+      username: profile.username,
+      profileImage: img,
+      cultures,
+    }
+  }
+
   const fetchComments = async () => {
     if (!source_table || !event_id) {
-      setComments([]);
-      return;
+      setComments([])
+      return
     }
-    setLoading(true);
+    setLoading(true)
     let query = supabase
       .from('event_comments')
-      .select('*')
+      .select(`*, profiles (username, image_url) `)
       .eq('source_table', source_table)
-      .order('created_at', { ascending: false });
-    if (source_table === 'all_events') query = query.eq('event_int_id', event_id);
-    else query = query.eq('event_id', event_id);
-    const { data, error } = await query;
-    if (!error) setComments(data || []);
-    setLoading(false);
-  };
+      .order('created_at', { ascending: false })
+    if (source_table === 'all_events') query = query.eq('event_int_id', event_id)
+    else query = query.eq('event_id', event_id)
+    const { data, error } = await query
+    if (!error) {
+      const rows = data || []
+      const profileIds = Array.from(new Set(rows.map(r => r.user_id)))
+      const { data: tagRows } = await supabase
+        .from('profile_tags')
+        .select('profile_id,tag_id')
+        .in('profile_id', profileIds)
+        .eq('tag_type', 'culture')
+      let cultById = {}
+      if (tagRows?.length) {
+        const ids = Array.from(new Set(tagRows.map(t => t.tag_id)))
+        const { data: cultures } = await supabase
+          .from('culture_tags')
+          .select('id,emoji')
+          .in('id', ids)
+        cultById = Object.fromEntries((cultures || []).map(c => [c.id, c.emoji]))
+      }
+      const profileCultures = {}
+      tagRows?.forEach(t => {
+        const emoji = cultById[t.tag_id]
+        if (!emoji) return
+        if (!profileCultures[t.profile_id]) profileCultures[t.profile_id] = []
+        profileCultures[t.profile_id].push(emoji)
+      })
+      setComments(rows.map(c => transform({
+        ...c,
+        profiles: {
+          ...c.profiles,
+          profile_tags: (profileCultures[c.user_id] || []).map(e => ({ tag_type: 'culture', culture_tags: { emoji: e } }))
+        }
+      })))
+    }
+    setLoading(false)
+  }
 
   useEffect(() => {
     fetchComments();
@@ -60,15 +116,11 @@ export default function useEventComments({ source_table, event_id }) {
         ? { event_int_id: event_id }
         : { event_id }),
     };
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('event_comments')
       .insert([payload])
-      .select('*')
-      .single();
-    if (!error && data) {
-      setComments(prev => [data, ...prev]);
-    }
-    return { data, error };
+    if (!error) await fetchComments()
+    return { error }
   };
 
   const editComment = async (id, content) => {
@@ -77,17 +129,13 @@ export default function useEventComments({ source_table, event_id }) {
     if (hasProfanity(text)) {
       return { error: { message: 'Inappropriate language detected' } };
     }
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('event_comments')
       .update({ content: text })
       .eq('id', id)
       .eq('user_id', user.id)
-      .select('*')
-      .single();
-    if (!error && data) {
-      setComments(prev => prev.map(c => (c.id === id ? data : c)));
-    }
-    return { data, error };
+    if (!error) await fetchComments()
+    return { error }
   };
 
   const deleteComment = async id => {
@@ -97,10 +145,8 @@ export default function useEventComments({ source_table, event_id }) {
       .delete()
       .eq('id', id)
       .eq('user_id', user.id);
-    if (!error) {
-      setComments(prev => prev.filter(c => c.id !== id));
-    }
-    return { error };
+    if (!error) await fetchComments()
+    return { error }
   };
 
   return {


### PR DESCRIPTION
## Summary
- update comments to show commenter avatars, usernames and culture flag icons
- enhance event comments fetching with profile joins
- add profile avatar and username editing on profile page
- add culture selection modal and toast feedback
- fix profile and comment fetching
- fix avatar upload logic and persist culture tags

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_688b45536d54832ca38065e5375fd331