### PR TITLE
Add profile page hero and settings tabs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+import js from '@eslint/js';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    plugins: { react, 'react-hooks': reactHooks, 'react-refresh': reactRefresh },
+    settings: { react: { version: '18.2' } },
+    rules: {
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+    ignores: ['dist'],
+  },
+];

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "@eslint/js": "^8.56.0",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.3",
     "vite": "^5.0.8"

--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -1,167 +1,179 @@
-// src/ProfilePage.jsx
-import React, { useContext, useEffect, useState } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
-import { supabase } from './supabaseClient'
-import { AuthContext } from './AuthProvider'
-import Navbar from './Navbar'
-import Footer from './Footer'
-import SavedEventsScroller from './SavedEventsScroller.jsx'
-import { RRule } from 'rrule'
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import imageCompression from 'browser-image-compression';
+import { supabase } from './supabaseClient';
+import { AuthContext } from './AuthProvider';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import SavedEventCard from './SavedEventCard.jsx';
+import useProfile from './utils/useProfile';
+import useProfileTags from './utils/useProfileTags';
+import { RRule } from 'rrule';
+import { Link, useNavigate } from 'react-router-dom';
+
+function CultureModal({ initial = [], onSave, onClose }) {
+  const [tags, setTags] = useState([]);
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState(new Set(initial));
+
+  useEffect(() => {
+    supabase
+      .from('culture_tags')
+      .select('id,name,emoji')
+      .order('name', { ascending: true })
+      .then(({ data }) => setTags(data || []));
+  }, []);
+
+  const toggle = id => {
+    setSelected(prev => {
+      const s = new Set(prev);
+      s.has(id) ? s.delete(id) : s.add(id);
+      return s;
+    });
+  };
+
+  const handleSave = () => {
+    onSave(Array.from(selected));
+  };
+
+  const filtered = tags.filter(t =>
+    t.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+      <div className="bg-white rounded-lg p-4 max-h-[80vh] overflow-y-auto w-80 space-y-3">
+        <div className="flex justify-between items-center">
+          <h2 className="font-semibold">Select Cultures</h2>
+          <button onClick={onClose} className="text-xl">×</button>
+        </div>
+        <input
+          className="w-full border p-1"
+          placeholder="Search"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <div className="space-y-1">
+          {filtered.map(t => (
+            <label key={t.id} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={selected.has(t.id)}
+                onChange={() => toggle(t.id)}
+              />
+              <span>{t.emoji} {t.name}</span>
+            </label>
+          ))}
+        </div>
+        <button
+          onClick={handleSave}
+          className="mt-2 bg-indigo-600 text-white px-4 py-1 rounded"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export default function ProfilePage() {
-  const { user } = useContext(AuthContext)
-  const navigate = useNavigate()
+  const { user } = useContext(AuthContext);
+  const { profile, updateProfile } = useProfile();
+  const { tags: cultureTags, saveTags } = useProfileTags('culture');
 
-  // ── Tag subscriptions ────────────────────────────────────
-  const [allTags, setAllTags] = useState([])
-  const [subs, setSubs] = useState(new Set())
+  const navigate = useNavigate();
 
-  // ── Account settings ─────────────────────────────────────
-  const [email, setEmail] = useState('')
-  const [updating, setUpdating] = useState(false)
-  const [status, setStatus] = useState('')
-  const [deleting, setDeleting] = useState(false)
+  // Tag subscriptions for email digests
+  const [allTags, setAllTags] = useState([]);
+  const [subs, setSubs] = useState(new Set());
 
-  // ── Favorites / Tabs ─────────────────────────────────────
-  const [activeTab, setActiveTab] = useState('upcoming')
-  const [savedEvents, setSavedEvents] = useState([])
-  const [loadingSaved, setLoadingSaved] = useState(false)
+  // Account settings
+  const [email, setEmail] = useState('');
+  const [updating, setUpdating] = useState(false);
+  const [status, setStatus] = useState('');
+  const [deleting, setDeleting] = useState(false);
 
-  // ── Styles for tag pills ─────────────────────────────────
-  const pillStyles = [
-    'bg-green-100 text-indigo-800',
-    'bg-teal-100 text-teal-800',
-    'bg-pink-100 text-pink-800',
-    'bg-blue-100 text-blue-800',
-    'bg-orange-100 text-orange-800',
-    'bg-yellow-100 text-yellow-800',
-    'bg-purple-100 text-purple-800',
-    'bg-red-100 text-red-800',
-  ]
+  // Tabs
+  const [activeTab, setActiveTab] = useState('upcoming');
 
-  // ── Load initial data ────────────────────────────────────
+  const [username, setUsername] = useState(profile?.username || '');
+  const [imageUrl, setImageUrl] = useState(profile?.image_url || '');
+  const [cultures, setCultures] = useState(cultureTags);
+  const [editingName, setEditingName] = useState(false);
+  const [changingPic, setChangingPic] = useState(false);
+  const [showCultureModal, setShowCultureModal] = useState(false);
+  const [savedEvents, setSavedEvents] = useState([]);
+  const [loadingSaved, setLoadingSaved] = useState(false);
+  const [toast, setToast] = useState('');
+  const fileRef = useRef(null);
+
+  // Load tags and subscriptions on mount
   useEffect(() => {
-    if (!user) return
-    setEmail(user.email)
-
-    // all tags
+    if (!user) return;
+    setEmail(user.email);
     supabase
       .from('tags')
       .select('id,name,slug')
       .order('name', { ascending: true })
       .then(({ data, error }) => {
-        if (error) console.error(error)
-        else setAllTags(data || [])
-      })
-
-    // user's subscriptions
+        if (!error) setAllTags(data || []);
+      });
     supabase
       .from('user_subscriptions')
       .select('tag_id')
       .eq('user_id', user.id)
       .then(({ data, error }) => {
-        if (error) console.error(error)
-        else setSubs(new Set((data || []).map(r => r.tag_id)))
-      })
-  }, [user])
+        if (!error) setSubs(new Set((data || []).map(r => r.tag_id)));
+      });
+  }, [activeTab, user]);
 
-  // ── Toggle one tag subscription ──────────────────────────
-  const toggleSub = async (tagId) => {
-    if (!user) return
-    if (subs.has(tagId)) {
-      await supabase
-        .from('user_subscriptions')
-        .delete()
-        .match({ user_id: user.id, tag_id: tagId })
-      setSubs(s => { s.delete(tagId); return new Set(s) })
-    } else {
-      await supabase
-        .from('user_subscriptions')
-        .insert({ user_id: user.id, tag_id: tagId })
-      setSubs(s => new Set(s).add(tagId))
-    }
-  }
-
-  // ── Account actions ─────────────────────────────────────
-  const updateEmail = async () => {
-    setUpdating(true)
-    setStatus('')
-    const { error } = await supabase.auth.updateUser({ email })
-    if (error) setStatus(`❌ ${error.message}`)
-    else setStatus('✅ Check your inbox to confirm email change.')
-    setUpdating(false)
-  }
-
-  const sendPasswordReset = async () => {
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: 'https://www.ourphilly.org/update-password',
-    })
-    if (error) alert('Error: ' + error.message)
-    else alert('Password reset link sent.')
-  }
-
-  const handleDeleteAccount = async () => {
-    if (!window.confirm('Delete your account permanently?')) return
-    setDeleting(true)
-    const { error } = await supabase.functions.invoke('delete_user_account')
-    if (error) {
-      alert('Could not delete: ' + error.message)
-      setDeleting(false)
-    } else {
-      await supabase.auth.signOut()
-      navigate('/')
-    }
-  }
-
-  // ── Load saved events when showing Upcoming tab ──────────
   useEffect(() => {
-    if (activeTab !== 'upcoming' || !user) return
-    setLoadingSaved(true)
-    ;(async () => {
+    setUsername(profile?.username || '');
+    setImageUrl(profile?.image_url || '');
+  }, [profile]);
+
+  useEffect(() => {
+    setCultures(cultureTags);
+  }, [cultureTags]);
+
+  useEffect(() => {
+    if (activeTab !== 'upcoming' || !user) return;
+    setLoadingSaved(true);
+    (async () => {
       const { data: favs, error } = await supabase
         .from('event_favorites')
         .select('event_id,event_int_id,event_uuid,source_table')
-        .eq('user_id', user.id)
+        .eq('user_id', user.id);
       if (error) {
-        console.error('favorites fetch error', error)
-        setSavedEvents([])
-        setLoadingSaved(false)
-        return
+        setSavedEvents([]);
+        setLoadingSaved(false);
+        return;
       }
-
-      const idsByTable = {}
+      const idsByTable = {};
       favs.forEach(r => {
-        const tbl = r.source_table
-        let id
-        if (tbl === 'all_events') id = r.event_int_id
-        else if (tbl === 'events') id = r.event_id
-        else id = r.event_uuid
-        if (!id) return
-        idsByTable[tbl] = idsByTable[tbl] || []
-        idsByTable[tbl].push(id)
-      })
-
-      const all = []
-
+        const tbl = r.source_table;
+        let id;
+        if (tbl === 'all_events') id = r.event_int_id;
+        else if (tbl === 'events') id = r.event_id;
+        else id = r.event_uuid;
+        if (!id) return;
+        idsByTable[tbl] = idsByTable[tbl] || [];
+        idsByTable[tbl].push(id);
+      });
+      const all = [];
       if (idsByTable.all_events?.length) {
         const { data } = await supabase
           .from('all_events')
           .select('id,name,slug,image,start_date,start_time,venues:venue_id(name,slug)')
-          .in('id', idsByTable.all_events)
+          .in('id', idsByTable.all_events);
         data?.forEach(e => {
-          all.push({
-            ...e,
-            title: e.name,
-            source_table: 'all_events'
-          })
-        })
+          all.push({ ...e, title: e.name, source_table: 'all_events' });
+        });
       }
-
       if (idsByTable.events?.length) {
         const { data } = await supabase
           .from('events')
           .select('id,slug,"E Name","E Image",Dates')
-          .in('id', idsByTable.events)
+          .in('id', idsByTable.events);
         data?.forEach(e => {
           all.push({
             id: e.id,
@@ -169,24 +181,23 @@ export default function ProfilePage() {
             title: e['E Name'],
             image: e['E Image'],
             start_date: e.Dates,
-            source_table: 'events'
-          })
-        })
+            source_table: 'events',
+          });
+        });
       }
-
       if (idsByTable.big_board_events?.length) {
         const { data } = await supabase
           .from('big_board_events')
           .select('id,slug,title,start_date,start_time,big_board_posts!big_board_posts_event_id_fkey(image_url)')
-          .in('id', idsByTable.big_board_events)
+          .in('id', idsByTable.big_board_events);
         data?.forEach(ev => {
-          let img = ''
-          const path = ev.big_board_posts?.[0]?.image_url || ''
+          let img = '';
+          const path = ev.big_board_posts?.[0]?.image_url || '';
           if (path) {
             const { data: { publicUrl } } = supabase.storage
               .from('big-board')
-              .getPublicUrl(path)
-            img = publicUrl
+              .getPublicUrl(path);
+            img = publicUrl;
           }
           all.push({
             id: ev.id,
@@ -195,16 +206,15 @@ export default function ProfilePage() {
             start_date: ev.start_date,
             start_time: ev.start_time,
             image: img,
-            source_table: 'big_board_events'
-          })
-        })
+            source_table: 'big_board_events',
+          });
+        });
       }
-
       if (idsByTable.group_events?.length) {
         const { data } = await supabase
           .from('group_events')
           .select('id,slug,title,start_date,start_time,groups(Name,slug,imag)')
-          .in('id', idsByTable.group_events)
+          .in('id', idsByTable.group_events);
         data?.forEach(ev => {
           all.push({
             id: ev.id,
@@ -214,76 +224,168 @@ export default function ProfilePage() {
             start_time: ev.start_time,
             image: ev.groups?.[0]?.imag || '',
             group: ev.groups?.[0] ? { slug: ev.groups[0].slug } : null,
-            source_table: 'group_events'
-          })
-        })
+            source_table: 'group_events',
+          });
+        });
       }
-
       if (idsByTable.recurring_events?.length) {
         const { data } = await supabase
           .from('recurring_events')
           .select('id,slug,name,address,start_date,start_time,end_date,rrule,image_url')
-          .in('id', idsByTable.recurring_events)
+          .in('id', idsByTable.recurring_events);
         data?.forEach(ev => {
           try {
-            const opts = RRule.parseString(ev.rrule)
-            opts.dtstart = new Date(`${ev.start_date}T${ev.start_time}`)
-            if (ev.end_date) opts.until = new Date(`${ev.end_date}T23:59:59`)
-            const rule = new RRule(opts)
-            const today0 = new Date(); today0.setHours(0,0,0,0)
-            const next = rule.after(today0, true)
+            const opts = RRule.parseString(ev.rrule);
+            opts.dtstart = new Date(`${ev.start_date}T${ev.start_time}`);
+            if (ev.end_date) opts.until = new Date(`${ev.end_date}T23:59:59`);
+            const rule = new RRule(opts);
+            const today0 = new Date();
+            today0.setHours(0, 0, 0, 0);
+            const next = rule.after(today0, true);
             if (next) {
               all.push({
                 id: ev.id,
                 slug: ev.slug,
                 title: ev.name,
                 address: ev.address,
-                start_date: next.toISOString().slice(0,10),
+                start_date: next.toISOString().slice(0, 10),
                 start_time: ev.start_time,
                 image: ev.image_url,
-                source_table: 'recurring_events'
-              })
+                source_table: 'recurring_events',
+              });
             }
           } catch (err) {
-            console.error('rrule parse', err)
+            console.error('rrule parse', err);
           }
-        })
+        });
       }
-
-      const today = new Date(); today.setHours(0,0,0,0)
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
       const parseEventsDate = str => {
-        if (!str) return null
-        const [first] = str.split(/through|–|-/)
-        const [m,d,y] = first.trim().split('/').map(Number)
-        return new Date(y, m-1, d)
-      }
+        if (!str) return null;
+        const [first] = str.split(/through|–|-/);
+        const [m, d, y] = first.trim().split('/').map(Number);
+        return new Date(y, m - 1, d);
+      };
       const parseISODateLocal = str => {
-        if (!str) return null
-        const [y,m,d] = str.split('-').map(Number)
-        return new Date(y, m-1, d)
-      }
-
+        if (!str) return null;
+        const [y, m, d] = str.split('-').map(Number);
+        return new Date(y, m - 1, d);
+      };
       const upcoming = all
         .map(ev => {
           const d = ev.source_table === 'events'
             ? parseEventsDate(ev.start_date)
-            : parseISODateLocal(ev.start_date)
-          return { ...ev, _date: d }
+            : parseISODateLocal(ev.start_date);
+          return { ...ev, _date: d };
         })
         .filter(ev => {
-          if (!ev._date) return false
-          ev._date.setHours(0,0,0,0)
-          return ev._date >= today
-        })
+          if (!ev._date) return false;
+          ev._date.setHours(0, 0, 0, 0);
+          return ev._date >= today;
+        });
+      upcoming.sort((a, b) => a._date - b._date);
+      setSavedEvents(upcoming.map(({ _date, ...rest }) => rest));
+      setLoadingSaved(false);
+    })();
+  }, [user]);
 
-      upcoming.sort((a,b) => a._date - b._date)
+  const handleFileChange = async e => {
+    const file = e.target.files?.[0];
+    if (!file || !user) return;
+    setChangingPic(true);
+    try {
+      const compressed = await imageCompression(file, { maxSizeMB: 1, maxWidthOrHeight: 512 });
+      const ext = file.name.split('.').pop();
+      const path = `${user.id}/${Date.now()}.${ext}`;
+      const { error: uploadError } = await supabase
+        .storage
+        .from('profile-images')
+        .upload(path, compressed, { upsert: true });
+      if (uploadError) throw uploadError;
+      const { data: { publicUrl } } = supabase
+        .storage
+        .from('profile-images')
+        .getPublicUrl(path);
+      await updateProfile({ image_url: publicUrl });
+      setImageUrl(publicUrl);
+      setToast('Image updated');
+    } catch (err) {
+      console.error(err);
+      setToast('Upload failed');
+    }
+    setChangingPic(false);
+  };
 
-      setSavedEvents(upcoming.map(({ _date, ...rest }) => rest))
-      setLoadingSaved(false)
-    })()
-  }, [activeTab, user])
+  const saveName = async () => {
+    await updateProfile({ username });
+    setEditingName(false);
+    setToast('Username saved');
+  };
 
-  // ── If not logged in ────────────────────────────────────
+  const handleSaveCultures = async ids => {
+    const { error } = await saveTags(ids);
+    if (!error) {
+      setShowCultureModal(false);
+      setToast('Cultures saved');
+    }
+  };
+
+  const toggleSub = async tagId => {
+    if (!user) return;
+    if (subs.has(tagId)) {
+      await supabase
+        .from('user_subscriptions')
+        .delete()
+        .match({ user_id: user.id, tag_id: tagId });
+      setSubs(prev => {
+        prev.delete(tagId);
+        return new Set(prev);
+      });
+    } else {
+      await supabase
+        .from('user_subscriptions')
+        .insert({ user_id: user.id, tag_id: tagId });
+      setSubs(prev => new Set(prev).add(tagId));
+    }
+  };
+
+  const updateEmail = async () => {
+    setUpdating(true);
+    setStatus('');
+    const { error } = await supabase.auth.updateUser({ email });
+    if (error) setStatus(`❌ ${error.message}`);
+    else setStatus('✅ Check your inbox to confirm email change.');
+    setUpdating(false);
+  };
+
+  const sendPasswordReset = async () => {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: 'https://www.ourphilly.org/update-password',
+    });
+    if (error) alert('Error: ' + error.message);
+    else alert('Password reset link sent.');
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!window.confirm('Delete your account permanently?')) return;
+    setDeleting(true);
+    const { error } = await supabase.functions.invoke('delete_user_account');
+    if (error) {
+      alert('Could not delete: ' + error.message);
+      setDeleting(false);
+    } else {
+      await supabase.auth.signOut();
+      navigate('/');
+    }
+  };
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(''), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
   if (!user) {
     return (
       <>
@@ -293,27 +395,94 @@ export default function ProfilePage() {
           <Link to="/login" className="text-indigo-600 hover:underline">
             log in
           </Link>{' '}
-          to manage your subscriptions.
+          to view your profile.
         </div>
       </>
-    )
+    );
   }
 
   return (
-    <div className="min-h-screen bg-neutral-50 pb-12">
+    <div className="min-h-screen bg-neutral-50 pb-12 pt-20">
       <Navbar />
 
-      <div className="max-w-screen-md mx-auto px-4 py-12 mt-12">
+      <header className="bg-gradient-to-r from-indigo-700 to-purple-600 text-white">
+        <div className="max-w-screen-md mx-auto px-4 py-10 flex flex-col sm:flex-row items-center gap-6">
+          <div className="relative">
+            {imageUrl ? (
+              <img src={imageUrl} alt="avatar" className="w-32 h-32 rounded-full object-cover" />
+            ) : (
+              <div className="w-32 h-32 rounded-full bg-gray-300" />
+            )}
+            <input
+              type="file"
+              ref={fileRef}
+              onChange={handleFileChange}
+              className="hidden"
+              accept="image/*"
+            />
+            <button
+              onClick={() => fileRef.current?.click()}
+              className="absolute bottom-0 right-0 text-xs bg-black/60 px-2 py-1 rounded"
+              disabled={changingPic}
+            >
+              {changingPic ? 'Uploading…' : 'Change'}
+            </button>
+          </div>
+
+          <div className="flex-1 text-center sm:text-left">
+            {editingName ? (
+              <div className="flex gap-2 items-center justify-center sm:justify-start">
+                <input
+                  value={username}
+                  onChange={e => setUsername(e.target.value)}
+                  className="border rounded px-2 py-1 text-black"
+                />
+                <button
+                  onClick={saveName}
+                  className="bg-indigo-600 text-white px-2 py-1 rounded"
+                >
+                  Save
+                </button>
+              </div>
+            ) : (
+              <h2
+                className="text-3xl font-bold cursor-pointer"
+                onClick={() => setEditingName(true)}
+              >
+                {username || 'Set username'}
+              </h2>
+            )}
+            <div className="mt-2 flex flex-wrap justify-center sm:justify-start items-center gap-1">
+              {cultures.map(c => (
+                <span key={c.id} className="relative group text-2xl">
+                  {c.emoji}
+                  <span className="absolute bottom-full mb-1 left-1/2 -translate-x-1/2 bg-black text-white text-xs rounded px-1 py-0.5 opacity-0 group-hover:opacity-100 pointer-events-none whitespace-nowrap">
+                    {c.name}
+                  </span>
+                </span>
+              ))}
+              <button
+                onClick={() => setShowCultureModal(true)}
+                className="ml-2 text-sm underline"
+              >
+                Edit
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-screen-md mx-auto px-4 py-12 space-y-12">
         <div className="flex justify-center gap-6 mb-8">
           <button
             onClick={() => setActiveTab('upcoming')}
-            className={`pb-1 ${activeTab==='upcoming' ? 'border-b-2 border-indigo-600 text-indigo-600 font-semibold' : 'text-gray-600'}`}
+            className={`pb-1 ${activeTab === 'upcoming' ? 'border-b-2 border-indigo-600 text-indigo-600 font-semibold' : 'text-gray-600'}`}
           >
             Upcoming
           </button>
           <button
             onClick={() => setActiveTab('settings')}
-            className={`pb-1 ${activeTab==='settings' ? 'border-b-2 border-indigo-600 text-indigo-600 font-semibold' : 'text-gray-600'}`}
+            className={`pb-1 ${activeTab === 'settings' ? 'border-b-2 border-indigo-600 text-indigo-600 font-semibold' : 'text-gray-600'}`}
           >
             Settings
           </button>
@@ -322,32 +491,24 @@ export default function ProfilePage() {
         {activeTab === 'settings' && (
           <div className="space-y-12">
             <header className="text-center">
-              <h1 className="text-4xl mt-8 font-[Barrio] text-indigo-900 mb-2">
-                Your Email Digests
-              </h1>
-              <p className="text-gray-700">
-                Pick the topics you want delivered in your once-a-week roundup.
-              </p>
+              <h1 className="text-4xl mt-8 font-[Barrio] text-indigo-900 mb-2">Your Email Digests</h1>
+              <p className="text-gray-700">Pick the topics you want delivered in your once-a-week roundup.</p>
             </header>
 
             <section>
               <div className="flex flex-wrap justify-center gap-4">
                 {allTags.map((tag, i) => {
-                  const selected = subs.has(tag.id)
+                  const selected = subs.has(tag.id);
+                  const colors = ['bg-green-100 text-indigo-800','bg-teal-100 text-teal-800','bg-pink-100 text-pink-800','bg-blue-100 text-blue-800','bg-orange-100 text-orange-800','bg-yellow-100 text-yellow-800','bg-purple-100 text-purple-800','bg-red-100 text-red-800'];
                   return (
                     <button
                       key={tag.id}
                       onClick={() => toggleSub(tag.id)}
-                      className={`
-                        ${pillStyles[i % pillStyles.length]}
-                        px-6 py-3 text-lg font-bold rounded-full
-                        transition transform hover:scale-105
-                        ${selected ? 'border-4 border-indigo-700' : 'opacity-60 hover:opacity-80'}
-                      `}
+                      className={`${colors[i % colors.length]} px-6 py-3 text-lg font-bold rounded-full transition transform hover:scale-105 ${selected ? 'border-4 border-indigo-700' : 'opacity-60 hover:opacity-80'}`}
                     >
                       #{tag.name}
                     </button>
-                  )
+                  );
                 })}
               </div>
             </section>
@@ -399,13 +560,29 @@ export default function ProfilePage() {
             ) : savedEvents.length === 0 ? (
               <div className="py-20 text-center text-gray-500">No upcoming events saved.</div>
             ) : (
-              <SavedEventsScroller events={savedEvents} />
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+                {savedEvents.map(ev => (
+                  <SavedEventCard key={`${ev.source_table}-${ev.id}`} event={ev} />
+                ))}
+              </div>
             )}
           </section>
         )}
       </div>
-
       <Footer />
+
+      {showCultureModal && (
+        <CultureModal
+          initial={cultures.map(c => c.id)}
+          onSave={handleSaveCultures}
+          onClose={() => setShowCultureModal(false)}
+        />
+      )}
+      {toast && (
+        <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-black text-white px-4 py-2 rounded">
+          {toast}
+        </div>
+      )}
     </div>
-  )
+  );
 }

--- a/src/SavedEventCard.jsx
+++ b/src/SavedEventCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import EventFavorite from './EventFavorite.jsx'
+import useEventFavorite from './utils/useEventFavorite'
 
 function parseISODateLocal(str) {
   if (!str) return null
@@ -62,6 +62,14 @@ export default function SavedEventCard({ event }) {
     : ''
   const bubbleTime = start_time ? ` ${formatTime(start_time)}` : ''
 
+  const { isFavorite, toggleFavorite, loading } = useEventFavorite({ event_id: id, source_table })
+
+  const handleFav = async e => {
+    e.preventDefault()
+    e.stopPropagation()
+    await toggleFavorite()
+  }
+
   return (
     <Link
       to={link}
@@ -78,8 +86,14 @@ export default function SavedEventCard({ event }) {
         {isRecurring
           ? address && <p className="text-sm text-gray-600">at {address}</p>
           : venues?.name && <p className="text-sm text-gray-600">at {venues.name}</p>}
-        <div className="mt-4 w-full bg-gray-100 border-t px-3 py-2 flex justify-center">
-          <EventFavorite event_id={id} source_table={source_table} />
+        <div className="mt-4 w-full bg-gray-100 border-t px-3 py-2">
+          <button
+            onClick={handleFav}
+            disabled={loading}
+            className={`w-full border border-indigo-600 rounded-md py-1 text-sm font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+          >
+            {isFavorite ? 'In the Plans' : 'Add to Plans'}
+          </button>
         </div>
       </div>
     </Link>

--- a/src/utils/useProfile.js
+++ b/src/utils/useProfile.js
@@ -1,0 +1,48 @@
+import { useState, useEffect, useContext } from 'react';
+import { supabase } from '../supabaseClient';
+import { AuthContext } from '../AuthProvider';
+
+export default function useProfile() {
+  const { user } = useContext(AuthContext);
+  const [profile, setProfile] = useState(null);
+
+  const refresh = async () => {
+    if (!user) {
+      setProfile(null);
+      return { data: null, error: null };
+    }
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('*')
+      .eq('id', user.id)
+      .single();
+    if (!error) setProfile(data);
+    return { data, error };
+  };
+
+  useEffect(() => {
+    if (!user) { setProfile(null); return; }
+    (async () => {
+      const { data } = await supabase
+        .from('profiles')
+        .upsert({ id: user.id })
+        .select('*')
+        .single();
+      setProfile(data);
+    })();
+  }, [user]);
+
+  const updateProfile = async updates => {
+    if (!user) return { error: { message: 'No user' } };
+    const { data, error } = await supabase
+      .from('profiles')
+      .update(updates)
+      .eq('id', user.id)
+      .select()
+      .single();
+    if (!error) setProfile(data);
+    return { data, error };
+  };
+
+  return { profile, updateProfile, refresh };
+}

--- a/src/utils/useProfileTags.js
+++ b/src/utils/useProfileTags.js
@@ -1,0 +1,39 @@
+import { useContext, useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient';
+import { AuthContext } from '../AuthProvider';
+
+export default function useProfileTags(tagType = 'culture') {
+  const { user } = useContext(AuthContext);
+  const [tags, setTags] = useState([]);
+
+  const fetchTags = async () => {
+    if (!user) { setTags([]); return { error: null }; }
+    const { data, error } = await supabase
+      .from('profile_tags')
+      .select('tag_id, culture_tags(id,name,emoji)')
+      .eq('profile_id', user.id)
+      .eq('tag_type', tagType);
+    if (!error) {
+      const mapped = (data || []).map(r => r.culture_tags).filter(Boolean);
+      setTags(mapped);
+    }
+    return { error };
+  };
+
+  useEffect(() => { fetchTags(); }, [user, tagType]);
+
+  const saveTags = async ids => {
+    if (!user) return { error: { message: 'No user' } };
+    const { error: delError } = await supabase
+      .from('profile_tags')
+      .delete()
+      .eq('profile_id', user.id)
+      .eq('tag_type', tagType);
+    const inserts = ids.map(id => ({ profile_id: user.id, tag_id: id, tag_type: tagType }));
+    const { error: insError } = await supabase.from('profile_tags').insert(inserts);
+    await fetchTags();
+    return { error: delError || insError };
+  };
+
+  return { tags, saveTags, refresh: fetchTags };
+}


### PR DESCRIPTION
## Summary
- redesign ProfilePage with hero section and emoji tags
- restore Upcoming and Settings tabs
- display saved events in a grid
- add @eslint/js dev dependency
- show tooltip names for profile flags
- make upcoming grid 4 across on desktop
- use Plans toggle button in SavedEventCard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688b5fb06280832c827b3c5ea0b68c71