### PR TITLE
Add admin comments page

### DIFF
--- a/src/AdminActivity.jsx
+++ b/src/AdminActivity.jsx
@@ -1,5 +1,6 @@
 // src/AdminActivity.jsx
 import React, { useEffect, useState, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import { supabase } from './supabaseClient';
 import { AuthContext } from './AuthProvider';
 import Navbar from './Navbar';
@@ -67,6 +68,11 @@ export default function AdminActivity() {
       <Navbar />
       <main className="flex-grow max-w-screen-xl mx-auto p-6">
         <h1 className="text-4xl font-[Barrio] mb-8 text-center">Activity Feed</h1>
+        <div className="mb-6 text-center">
+          <Link to="/admin" className="text-indigo-600 hover:underline">
+            ← Back to Dashboard
+          </Link>
+        </div>
         {loading ? (
           <p className="text-center">Loading…</p>
         ) : (

--- a/src/AdminClaimRequests.jsx
+++ b/src/AdminClaimRequests.jsx
@@ -1,7 +1,7 @@
 // /src/AdminClaimRequests.jsx
 
 import React, { useEffect, useState, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { supabase } from './supabaseClient';
 import Navbar from './Navbar';
 import Footer from './Footer';
@@ -110,6 +110,11 @@ const AdminClaimRequests = () => {
         <h1 className="text-4xl font-[Barrio] text-gray-800 mb-8 text-center">
           Group Claim Requests
         </h1>
+        <div className="mb-6 text-center">
+          <Link to="/admin" className="text-indigo-600 hover:underline">
+            ← Back to Dashboard
+          </Link>
+        </div>
 
         {loadingData ? (
           <div className="text-center py-20">Loading requests...</div>

--- a/src/AdminComments.jsx
+++ b/src/AdminComments.jsx
@@ -1,0 +1,119 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from './supabaseClient';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import { AuthContext } from './AuthProvider';
+
+export default function AdminComments() {
+  const { user } = useContext(AuthContext);
+  const [loadingAuth, setLoadingAuth] = useState(true);
+  const [loadingData, setLoadingData] = useState(true);
+  const [comments, setComments] = useState([]);
+  const [users, setUsers] = useState({});
+  const [events, setEvents] = useState({});
+
+  useEffect(() => {
+    if (user !== undefined) setLoadingAuth(false);
+  }, [user]);
+
+  const fetchComments = async () => {
+    setLoadingData(true);
+    const { data, error } = await supabase
+      .from('event_comments')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(50);
+    if (error) {
+      console.error('Error loading comments:', error);
+      setLoadingData(false);
+      return;
+    }
+    setComments(data);
+
+    const evIds = [
+      ...new Set(data.map(c => c.event_id || c.event_int_id).filter(Boolean)),
+    ];
+    if (evIds.length) {
+      const { data: evRows } = await supabase
+        .from('events')
+        .select('id, "E Name"')
+        .in('id', evIds);
+      const map = {};
+      evRows?.forEach(e => { map[e.id] = e['E Name']; });
+      setEvents(map);
+    }
+
+    const userIds = [...new Set(data.map(c => c.user_id))];
+    if (userIds.length) {
+      const { data: uRows } = await supabase
+        .from('users')
+        .select('id, email')
+        .in('id', userIds);
+      const map = {};
+      uRows?.forEach(u => { map[u.id] = u.email; });
+      setUsers(map);
+    }
+    setLoadingData(false);
+  };
+
+  useEffect(() => { if (!loadingAuth) fetchComments(); }, [loadingAuth]);
+
+  const deleteComment = async id => {
+    if (!window.confirm('Delete this comment?')) return;
+    await supabase.from('event_comments').delete().eq('id', id);
+    setComments(c => c.filter(cm => cm.id !== id));
+  };
+
+  if (loadingAuth) {
+    return <div className="text-center py-20">Checking auth…</div>;
+  }
+  if (user.email !== 'bill@solar-states.com') {
+    return <div className="text-center py-20 text-red-600">Access denied.</div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-50 pt-20 flex flex-col">
+      <Navbar />
+      <main className="flex-grow max-w-screen-xl mx-auto px-4 py-10">
+        <h1 className="text-4xl font-[Barrio] text-center mb-8">Comments</h1>
+        <div className="mb-6 text-center">
+          <Link to="/admin" className="text-indigo-600 hover:underline">
+            ← Back to Dashboard
+          </Link>
+        </div>
+        {loadingData ? (
+          <p className="text-center">Loading…</p>
+        ) : (
+          <div className="space-y-6">
+            {comments.map(c => (
+              <div key={c.id} className="bg-white p-4 rounded-lg shadow">
+                <div className="flex justify-between">
+                  <div>
+                    <p className="text-sm text-gray-500">
+                      {new Date(c.created_at).toLocaleString()}
+                    </p>
+                    <p className="text-sm">User: {users[c.user_id] || c.user_id}</p>
+                    {(c.event_id || c.event_int_id) && (
+                      <p className="text-sm">
+                        Event: {events[c.event_id || c.event_int_id] || (c.event_id || c.event_int_id)}
+                      </p>
+                    )}
+                    <p className="mt-2 whitespace-pre-wrap">{c.content}</p>
+                  </div>
+                  <button
+                    onClick={() => deleteComment(c.id)}
+                    className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded self-start"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/AdminDashboard.jsx
+++ b/src/AdminDashboard.jsx
@@ -1,37 +1,195 @@
 // src/AdminDashboard.jsx
 import React, { useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+  Filler,
+} from 'chart.js';
 import { AuthContext } from './AuthProvider';
+import { supabase } from './supabaseClient';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import {
+  Users,
+  ClipboardList,
+  Star,
+  Folder,
+  MessageSquareText,
+} from 'lucide-react';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+  Filler,
+);
 
 export default function AdminDashboard() {
   const { user } = useContext(AuthContext);
   const [authorized, setAuthorized] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [metrics, setMetrics] = useState(null);
+  const [signupSeries, setSignupSeries] = useState({ labels: [], data: [] });
 
   // only you (bill@solar-states.com) should see these links
   useEffect(() => {
-    if (user?.email === 'bill@solar-states.com') setAuthorized(true);
+    if (user?.email === 'bill@solar-states.com') {
+      setAuthorized(true);
+      loadMetrics();
+    }
   }, [user]);
+
+  async function loadMetrics() {
+    setLoading(true);
+    const today = new Date();
+    const weekAgo = new Date();
+    weekAgo.setDate(today.getDate() - 6);
+
+    const [u, g, c, r, cm, signups] = await Promise.all([
+      supabase.from('users').select('*', { count: 'exact', head: true }),
+      supabase.from('groups').select('*', { count: 'exact', head: true }),
+      supabase
+        .from('group_claim_requests')
+        .select('*', { count: 'exact', head: true })
+        .eq('status', 'Pending'),
+      supabase.from('reviews').select('*', { count: 'exact', head: true }),
+      supabase.from('event_comments').select('*', { count: 'exact', head: true }),
+      supabase
+        .from('users')
+        .select('id, created_at')
+        .gte('created_at', weekAgo.toISOString()),
+    ]);
+
+    setMetrics({
+      users: u.count || 0,
+      groups: g.count || 0,
+      claims: c.count || 0,
+      reviews: r.count || 0,
+      comments: cm.count || 0,
+    });
+
+    const counts = Array(7).fill(0);
+    signups.data?.forEach((uRec) => {
+      const d = new Date(uRec.created_at);
+      d.setHours(0, 0, 0, 0);
+      const idx = Math.floor((d - weekAgo) / (1000 * 60 * 60 * 24));
+      if (idx >= 0 && idx < 7) counts[idx] += 1;
+    });
+    const labels = Array.from({ length: 7 }).map((_, i) => {
+      const d = new Date(weekAgo);
+      d.setDate(weekAgo.getDate() + i);
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    });
+    setSignupSeries({ labels, data: counts });
+    setLoading(false);
+  }
 
   if (!authorized) {
     return <div className="text-center py-20 text-gray-500">Access denied.</div>;
   }
 
+  if (loading || !metrics) {
+    return <div className="text-center py-20">Loading dashboard…</div>;
+  }
+
+  const chartData = {
+    labels: signupSeries.labels,
+    datasets: [
+      {
+        label: 'Signups',
+        data: signupSeries.data,
+        fill: true,
+        backgroundColor: 'rgba(99,102,241,0.2)',
+        borderColor: 'rgba(99,102,241,1)',
+        tension: 0.3,
+      },
+    ],
+  };
+
+  const chartOptions = {
+    plugins: { legend: { display: false } },
+    responsive: true,
+    maintainAspectRatio: false,
+  };
+
   return (
     <div className="min-h-screen bg-neutral-50 pt-20 flex flex-col">
       <Navbar />
-      <main className="flex-grow max-w-screen-xl mx-auto p-6">
-        <h1 className="text-4xl font-[Barrio] mb-8 text-center">Admin Dashboard</h1>
-        <ul className="space-y-4 text-lg">
-          <li><Link to="/admin/users" className="text-indigo-600 hover:underline">Manage Users</Link></li>
-          <li><Link to="/admin/claims" className="text-indigo-600 hover:underline">Group Claim Requests</Link></li>
-          <li><Link to="/admin/reviews" className="text-indigo-600 hover:underline">Manage Reviews</Link></li>
-          <li><Link to="/admin/updates" className="text-indigo-600 hover:underline">Manage Group Updates</Link></li>
-          <li><Link to="/admin/activity" className="text-indigo-600 hover:underline">Activity Feed</Link></li>
-        </ul>
+      <main className="flex-grow max-w-screen-xl mx-auto p-6 space-y-8">
+        <h1 className="text-4xl font-[Barrio] text-center mb-4">Admin Cockpit</h1>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <MetricCard
+            icon={<Users className="w-6 h-6" />}
+            label="Users"
+            value={metrics.users}
+            link="/admin/users"
+          />
+          <MetricCard
+            icon={<Folder className="w-6 h-6" />}
+            label="Groups"
+            value={metrics.groups}
+            link="/admin/updates"
+          />
+          <MetricCard
+            icon={<ClipboardList className="w-6 h-6" />}
+            label="Pending Claims"
+            value={metrics.claims}
+            link="/admin/claims"
+          />
+          <MetricCard
+            icon={<Star className="w-6 h-6" />}
+            label="Reviews"
+            value={metrics.reviews}
+            link="/admin/reviews"
+          />
+          <MetricCard
+            icon={<MessageSquareText className="w-6 h-6" />}
+            label="Comments"
+            value={metrics.comments}
+            link="/admin/comments"
+          />
+        </div>
+
+        <div className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-xl font-semibold mb-4">Signups Last 7 Days</h2>
+          <div className="h-64">
+            <Line data={chartData} options={chartOptions} />
+          </div>
+        </div>
+
+        <div className="text-center">
+          <Link to="/admin/activity" className="text-indigo-600 hover:underline">
+            View Recent Activity
+          </Link>
+        </div>
       </main>
       <Footer />
     </div>
+  );
+}
+
+function MetricCard({ icon, label, value, link }) {
+  return (
+    <Link
+      to={link}
+      className="bg-white rounded-lg shadow p-4 flex items-center space-x-4 hover:shadow-md transition"
+    >
+      {icon}
+      <div>
+        <p className="text-sm text-gray-500">{label}</p>
+        <p className="text-2xl font-bold">{value}</p>
+      </div>
+    </Link>
   );
 }

--- a/src/AdminGroupUpdates.jsx
+++ b/src/AdminGroupUpdates.jsx
@@ -1,5 +1,6 @@
 // src/AdminGroupUpdates.jsx
 import React, { useEffect, useState, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import { supabase } from './supabaseClient';
 import Navbar from './Navbar';
 import Footer from './Footer';
@@ -110,6 +111,11 @@ export default function AdminGroupUpdates() {
 
       <main className="flex-grow max-w-screen-xl mx-auto px-4 py-10">
         <h1 className="text-4xl font-[Barrio] text-center mb-8">Admin: Group Updates</h1>
+        <div className="mb-6 text-center">
+          <Link to="/admin" className="text-indigo-600 hover:underline">
+            ← Back to Dashboard
+          </Link>
+        </div>
 
         {loadingData ? (
           <p className="text-center">Loading updates…</p>

--- a/src/AdminReviews.jsx
+++ b/src/AdminReviews.jsx
@@ -1,5 +1,6 @@
 // src/AdminReviews.jsx
 import React, { useEffect, useState, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import { supabase } from './supabaseClient';
 import Navbar from './Navbar';
 import Footer from './Footer';
@@ -97,6 +98,11 @@ export default function AdminReviews() {
       <Navbar />
       <main className="flex-grow max-w-screen-xl mx-auto px-4 py-10">
         <h1 className="text-4xl font-[Barrio] text-center mb-8">User Reviews</h1>
+        <div className="mb-6 text-center">
+          <Link to="/admin" className="text-indigo-600 hover:underline">
+            ← Back to Dashboard
+          </Link>
+        </div>
 
         {loadingData ? (
           <p className="text-center">Loading reviews…</p>

--- a/src/AdminUsers.jsx
+++ b/src/AdminUsers.jsx
@@ -1,5 +1,6 @@
 // src/AdminUsers.jsx
 import React, { useEffect, useState, useContext } from 'react';
+import { Link } from 'react-router-dom';
 import { supabase } from './supabaseClient';
 import { AuthContext } from './AuthProvider';
 import Navbar from './Navbar';
@@ -69,6 +70,11 @@ export default function AdminUsers() {
         <h1 className="text-4xl font-[Barrio] text-gray-800 mb-8 text-center">
           User Management
         </h1>
+        <div className="mb-6 text-center">
+          <Link to="/admin" className="text-indigo-600 hover:underline">
+            ← Back to Dashboard
+          </Link>
+        </div>
 
         {loading ? (
           <p className="text-center">Loading users…</p>

--- a/src/Bulletin.jsx
+++ b/src/Bulletin.jsx
@@ -12,7 +12,11 @@ import EventFavorite from './EventFavorite.jsx';
 const parseDate = (datesStr) => {
   if (!datesStr) return null;
   const [first] = datesStr.split(/through|–|-/);
-  return new Date(first.trim());
+  const parts = first.trim().split('/');
+  if (parts.length !== 3) return null;
+  const [m, d, y] = parts.map(Number);
+  const dt = new Date(y, m - 1, d);
+  return isNaN(dt) ? null : dt;
 };
 const formatShortDate = (d) =>
   d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
@@ -61,7 +65,9 @@ export default function Bulletin({ previewCount = Infinity }) {
         const dynamic = data
           .map((e) => {
             const start = parseDate(e.Dates);
+            if (!start) return null;
             const end = parseDate(e['End Date']) || start;
+            if (!end) return null;
             const sd = new Date(start);
             sd.setHours(0, 0, 0, 0);
             const ed = new Date(end);
@@ -91,7 +97,7 @@ export default function Bulletin({ previewCount = Infinity }) {
 
             return { ...e, start: sd, end: ed, updateText };
           })
-          .filter((evt) => evt.end >= today0)
+          .filter((evt) => evt && evt.end >= today0)
           .slice(0, 15);
 
         // Prepare special fixed entries

--- a/src/EventsPageHero.jsx
+++ b/src/EventsPageHero.jsx
@@ -14,10 +14,13 @@ const teamSlugs = [
 
 // ─── Helpers ──────────────────────────────────────────────
 const parseDate = (datesStr) => {
-  if (!datesStr) return null
-  const [first] = datesStr.split(/through|–|-/)
-  const [m, d, y] = first.trim().split('/')
-  return new Date(+y, +m - 1, +d)
+  if (!datesStr) return null;
+  const [first] = datesStr.split(/through|–|-/);
+  const parts = first.trim().split('/');
+  if (parts.length !== 3) return null;
+  const [m, d, y] = parts.map(Number);
+  const dt = new Date(y, m - 1, d);
+  return isNaN(dt) ? null : dt;
 }
 
 /**
@@ -78,10 +81,12 @@ export default function EventsPageHero() {
       const enhanced = data
         .map(e => {
           const start = parseDate(e.Dates)
-          const end   = e['End Date'] ? parseDate(e['End Date']) : start
+          if (!start) return null
+          const end = e['End Date'] ? parseDate(e['End Date']) : start
+          if (!end) return null
           return { ...e, start, end, isActive: start <= today && today <= end }
         })
-        .filter(e => e.end >= today)
+        .filter(e => e && e.end >= today)
         .sort((a,b) =>
           a.isActive === b.isActive
             ? a.start - b.start

--- a/src/HeroLanding.jsx
+++ b/src/HeroLanding.jsx
@@ -14,8 +14,11 @@ export default function HeroLanding() {
   const parseDate = datesStr => {
     if (!datesStr) return null;
     const [first] = datesStr.split(/through|–|-/);
-    const [m, d, y] = first.trim().split('/');
-    return new Date(+y, +m - 1, +d);
+    const parts = first.trim().split('/');
+    if (parts.length !== 3) return null;
+    const [m, d, y] = parts.map(Number);
+    const dt = new Date(y, m - 1, d);
+    return isNaN(dt) ? null : dt;
   };
 
   const getBubble = (start, isActive) => {
@@ -53,7 +56,9 @@ export default function HeroLanding() {
       const enhanced = data
         .map(e => {
           const start = parseDate(e.Dates);
+          if (!start) return null;
           const end   = e['End Date'] ? parseDate(e['End Date']) : start;
+          if (!end) return null;
           return {
             ...e,
             start,
@@ -61,7 +66,7 @@ export default function HeroLanding() {
             isActive: start <= today && today <= end,
           };
         })
-        .filter(e => e.end >= today)
+        .filter(e => e && e.end >= today)
         .sort((a, b) =>
           a.isActive === b.isActive
             ? a.start - b.start

--- a/src/MonthlyEvents.jsx
+++ b/src/MonthlyEvents.jsx
@@ -15,7 +15,11 @@ const MonthlyEvents = () => {
   const parseDate = (datesStr) => {
     if (!datesStr) return null;
     const [first] = datesStr.split(/through|–|-/);
-    return new Date(first.trim());
+    const parts = first.trim().split('/');
+    if (parts.length !== 3) return null;
+    const [m, d, y] = parts.map(Number);
+    const dt = new Date(y, m - 1, d);
+    return isNaN(dt) ? null : dt;
   };
 
   // format start/end into "Apr 1 – Apr 30" or "May 5"
@@ -52,7 +56,9 @@ const MonthlyEvents = () => {
       const enhanced = data
         .map(e => {
           const start = parseDate(e.Dates);
+          if (!start) return null;
           const end = parseDate(e['End Date']) || start;
+          if (!end) return null;
           return {
             ...e,
             start,
@@ -61,7 +67,7 @@ const MonthlyEvents = () => {
             displayDate: formatDisplayDate(start, end),
           };
         })
-        .filter(e => e.end >= today)
+        .filter(e => e && e.end >= today)
         .slice(0, 12);
 
       setEvents(enhanced);

--- a/src/SocialVideoCarousel.jsx
+++ b/src/SocialVideoCarousel.jsx
@@ -8,8 +8,11 @@ import { Link } from 'react-router-dom'
 const parseDate = datesStr => {
   if (!datesStr) return null
   const [first] = datesStr.split(/through|–|-/)
-  const [m, d, y] = first.trim().split('/')
-  return new Date(+y, +m - 1, +d)
+  const parts = first.trim().split('/')
+  if (parts.length !== 3) return null
+  const [m, d, y] = parts.map(Number)
+  const dt = new Date(y, m - 1, d)
+  return isNaN(dt) ? null : dt
 }
 const parseISODateLocal = str => {
   const [y, m, d] = str.split('-').map(Number)

--- a/src/VenuePage.jsx
+++ b/src/VenuePage.jsx
@@ -15,7 +15,11 @@ function UpcomingSidebarBulletin({ previewCount = 10 }) {
   const parseDate = (datesStr) => {
     if (!datesStr) return null;
     const [first] = datesStr.split(/through|–|-/);
-    return new Date(first.trim());
+    const parts = first.trim().split('/');
+    if (parts.length !== 3) return null;
+    const [m, d, y] = parts.map(Number);
+    const dt = new Date(y, m - 1, d);
+    return isNaN(dt) ? null : dt;
   };
   const formatShortDate = (d) =>
     d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
@@ -32,7 +36,9 @@ function UpcomingSidebarBulletin({ previewCount = 10 }) {
         const dynamic = data
           .map((e) => {
             const start = parseDate(e.Dates);
+            if (!start) return null;
             const end = parseDate(e['End Date']) || start;
+            if (!end) return null;
             const sd = new Date(start); sd.setHours(0, 0, 0, 0);
             const ed = new Date(end);   ed.setHours(0, 0, 0, 0);
             const single = !e['End Date'] || e['End Date'].trim() === e.Dates.trim();
@@ -54,7 +60,7 @@ function UpcomingSidebarBulletin({ previewCount = 10 }) {
             }
             return { ...e, start: sd, end: ed, updateText };
           })
-          .filter((evt) => evt.end >= today0 && !!evt.updateText)
+          .filter((evt) => evt && evt.end >= today0 && !!evt.updateText)
           .slice(0, previewCount);
 
         setEvents(dynamic);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -32,6 +32,7 @@ import AdminReviews from './AdminReviews';
 import AdminGroupUpdates from './AdminGroupUpdates.jsx';
 import AdminDashboard from './AdminDashboard.jsx';
 import AdminActivity from './AdminActivity.jsx';
+import AdminComments from './AdminComments.jsx';
 import SocialVideoCarousel from './SocialVideoCarousel.jsx';
 import BigBoardEventPage  from './BigBoardEventPage';
 import BigBoardCarousel from './BigBoardCarousel.jsx';
@@ -93,6 +94,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/admin/users" element={<AdminUsers />} />
           <Route path="/admin/reviews" element={<AdminReviews />} />
           <Route path="/admin/updates" element={<AdminGroupUpdates />} />
+          <Route path="/admin/comments" element={<AdminComments />} />
           <Route path="/admin" element={<AdminDashboard />} />
           <Route path="/admin/activity" element={<AdminActivity />} />
           <Route path="/social-video" element={<SocialVideoCarousel />} />


### PR DESCRIPTION
## Summary
- add `/admin/comments` route to manage event comments
- display total comment count in dashboard metrics
- skip events with invalid dates and guard date parsing
- show comments page listing comments with delete buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688c06000700832ca79517c3ac2f70ea