### PR TITLE
Fix My Events tab

### DIFF
--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -96,7 +96,7 @@ export default function ProfilePage() {
   // Tabs
   const [activeTab, setActiveTab] = useState('upcoming');
 
-  const [username, setUsername] = useState(profile?.username || '');
+  const [username, setUsername] = useState(profile?.username || profile?.slug || '');
   const [imageUrl, setImageUrl] = useState(profile?.image_url || '');
   const [cultures, setCultures] = useState(cultureTags);
   const [editingName, setEditingName] = useState(false);
@@ -104,6 +104,10 @@ export default function ProfilePage() {
   const [showCultureModal, setShowCultureModal] = useState(false);
   const [savedEvents, setSavedEvents] = useState([]);
   const [loadingSaved, setLoadingSaved] = useState(false);
+  const [myEvents, setMyEvents] = useState([]);
+  const [loadingMyEvents, setLoadingMyEvents] = useState(false);
+  const [followingEvents, setFollowingEvents] = useState([]);
+  const [loadingFollowing, setLoadingFollowing] = useState(false);
   const [toast, setToast] = useState('');
   const fileRef = useRef(null);
 
@@ -128,7 +132,7 @@ export default function ProfilePage() {
   }, [activeTab, user]);
 
   useEffect(() => {
-    setUsername(profile?.username || '');
+    setUsername(profile?.username || profile?.slug || '');
     setImageUrl(profile?.image_url || '');
   }, [profile]);
 
@@ -291,6 +295,119 @@ export default function ProfilePage() {
     })();
   }, [user]);
 
+  useEffect(() => {
+    if (activeTab !== 'my-events' || !user) return;
+    setLoadingMyEvents(true);
+    (async () => {
+      const today = new Date().toISOString().slice(0, 10);
+      const all = [];
+
+      const { data: myPosts, error: postErr } = await supabase
+        .from('big_board_posts')
+        .select(
+          'image_url,big_board_events!big_board_events_post_id_fkey(id,slug,title,start_date,start_time)'
+        )
+        .eq('user_id', user.id)
+        .gte('big_board_events.start_date', today)
+        .order('start_date', { foreignTable: 'big_board_events', ascending: true });
+      if (postErr) console.error(postErr);
+      (myPosts || []).forEach(p => {
+        const ev = p.big_board_events?.[0];
+        if (!ev) return;
+        let img = '';
+        if (p.image_url) {
+          const { data: { publicUrl } } = supabase.storage
+            .from('big-board')
+            .getPublicUrl(p.image_url);
+          img = publicUrl;
+        }
+        all.push({
+          id: ev.id,
+          slug: ev.slug,
+          title: ev.title,
+          start_date: ev.start_date,
+          start_time: ev.start_time,
+          image: img,
+          source_table: 'big_board_events',
+        });
+      });
+
+      const { data: ge, error: geErr } = await supabase
+        .from('group_events')
+        .select('id,slug,title,start_date,start_time,groups(slug,imag)')
+        .eq('user_id', user.id)
+        .gte('start_date', today)
+        .order('start_date', { ascending: true });
+      if (geErr) console.error(geErr);
+      (ge || []).forEach(ev => {
+        all.push({
+          id: ev.id,
+          slug: ev.slug,
+          title: ev.title,
+          start_date: ev.start_date,
+          start_time: ev.start_time,
+          image: ev.groups?.imag || ev.groups?.[0]?.imag || '',
+          group: ev.groups ? { slug: ev.groups.slug } : ev.groups?.[0] ? { slug: ev.groups[0].slug } : null,
+          source_table: 'group_events',
+        });
+      });
+
+      const parseISO = str => {
+        const [y, m, d] = str.split('-').map(Number);
+        return new Date(y, m - 1, d);
+      };
+      const todayObj = new Date();
+      todayObj.setHours(0, 0, 0, 0);
+      const upcoming = all
+        .map(ev => ({ ...ev, _d: parseISO(ev.start_date) }))
+        .filter(ev => ev._d && ev._d >= todayObj)
+        .sort((a, b) => a._d - b._d)
+        .map(({ _d, ...rest }) => rest);
+      setMyEvents(upcoming);
+      setLoadingMyEvents(false);
+    })();
+  }, [activeTab, user]);
+
+  useEffect(() => {
+    if (activeTab !== 'following' || !user) return;
+    setLoadingFollowing(true);
+    (async () => {
+      const { data, error } = await supabase
+        .from('user_follow_events')
+        .select('*')
+        .eq('follower_id', user.id)
+        .order('start_date', { ascending: true });
+      if (error) {
+        console.error(error);
+        setFollowingEvents([]);
+        setLoadingFollowing(false);
+        return;
+      }
+      const mapped = (data || []).map(ev => {
+        let img = ev.image_url || '';
+        if (ev.source === 'big_board' && img) {
+          const { data: { publicUrl } } = supabase.storage
+            .from('big-board')
+            .getPublicUrl(img);
+          img = publicUrl;
+        }
+        return {
+          id: ev.event_id,
+          slug: ev.slug,
+          title: ev.title,
+          start_date: ev.start_date,
+          start_time: ev.start_time,
+          image: img,
+          source_table: ev.source === 'big_board'
+            ? 'big_board_events'
+            : 'group_events',
+        };
+      });
+      setFollowingEvents(mapped);
+      setLoadingFollowing(false);
+    })();
+  }, [activeTab, user]);
+
   const handleFileChange = async e => {
     const file = e.target.files?.[0];
     if (!file || !user) return;
@@ -451,12 +568,20 @@ export default function ProfilePage() {
                 </button>
               </div>
             ) : (
-              <h2
-                className="text-3xl font-bold cursor-pointer"
-                onClick={() => setEditingName(true)}
-              >
-                {username || 'Set username'}
-              </h2>
+              <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 justify-center sm:justify-start">
+                <h2 className="text-3xl font-bold">{username || profile?.slug || 'Username'}</h2>
+                <button
+                  onClick={() => setEditingName(true)}
+                  className="text-sm underline"
+                >
+                  Edit username
+                </button>
+                {profile?.slug && (
+                  <Link to={`/u/${profile.slug}`} className="text-sm underline">
+                    View public profile
+                  </Link>
+                )}
+              </div>
             )}
             <div className="mt-2 flex flex-wrap justify-center sm:justify-start items-center gap-1">
               {cultures.map(c => (
@@ -471,7 +596,7 @@ export default function ProfilePage() {
                 onClick={() => setShowCultureModal(true)}
                 className="ml-2 text-sm underline"
               >
-                Edit
+                edit your cultures!
               </button>
             </div>
           </div>
@@ -484,7 +609,19 @@ export default function ProfilePage() {
             onClick={() => setActiveTab('upcoming')}
             className={`pb-1 ${activeTab === 'upcoming' ? 'border-b-2 border-indigo-600 text-indigo-600 font-semibold' : 'text-gray-600'}`}
           >
-            Upcoming
+            Upcoming Plans
+          </button>
+          <button
+            onClick={() => setActiveTab('my-events')}
+            className={`pb-1 ${activeTab === 'my-events' ? 'border-b-2 border-indigo-600 text-indigo-600 font-semibold' : 'text-gray-600'}`}
+          >
+            My Events
+          </button>
+          <button
+            onClick={() => setActiveTab('following')}
+            className={`pb-1 ${activeTab === 'following' ? 'border-b-2 border-indigo-600 text-indigo-600 font-semibold' : 'text-gray-600'}`}
+          >
+            Following
           </button>
           <button
             onClick={() => setActiveTab('settings')}
@@ -568,6 +705,38 @@ export default function ProfilePage() {
             ) : (
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 {savedEvents.map(ev => (
+                  <SavedEventCard key={`${ev.source_table}-${ev.id}`} event={ev} />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        {activeTab === 'my-events' && (
+          <section>
+            {loadingMyEvents ? (
+              <div className="py-20 text-center text-gray-500">Loading…</div>
+            ) : myEvents.length === 0 ? (
+              <div className="py-20 text-center text-gray-500">You have not created an event. Create an event.</div>
+            ) : (
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+                {myEvents.map(ev => (
+                  <SavedEventCard key={`${ev.source_table}-${ev.id}`} event={ev} />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+
+        {activeTab === 'following' && (
+          <section>
+            {loadingFollowing ? (
+              <div className="py-20 text-center text-gray-500">Loading…</div>
+            ) : followingEvents.length === 0 ? (
+              <div className="py-20 text-center text-gray-500">No upcoming events.</div>
+            ) : (
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+                {followingEvents.map(ev => (
                   <SavedEventCard key={`${ev.source_table}-${ev.id}`} event={ev} />
                 ))}
               </div>

--- a/src/PublicProfilePage.jsx
+++ b/src/PublicProfilePage.jsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState, useContext } from 'react';
+import { useParams } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import SavedEventCard from './SavedEventCard.jsx';
+import { supabase } from './supabaseClient';
+import { AuthContext } from './AuthProvider';
+import useFollow from './utils/useFollow';
+
+export default function PublicProfilePage() {
+  const { slug } = useParams();
+  const { user } = useContext(AuthContext);
+  const [profile, setProfile] = useState(null);
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!slug) return;
+    supabase
+      .from('profiles')
+      .select('id,username,image_url,slug')
+      .eq('slug', slug)
+      .single()
+      .then(({ data }) => {
+        setProfile(data || null);
+      });
+  }, [slug]);
+
+  const { isFollowing, toggleFollow, loading: followLoading } = useFollow(profile?.id);
+
+  useEffect(() => {
+    if (!profile) return;
+    const load = async () => {
+      setLoading(true);
+      const today = new Date().toISOString().slice(0, 10);
+      const all = [];
+
+      // big board events via posts
+      const { data: myPosts, error: postErr } = await supabase
+        .from('big_board_posts')
+        .select(
+          'image_url,big_board_events!big_board_events_post_id_fkey(id,slug,title,start_date,start_time)'
+        )
+        .eq('user_id', profile.id)
+        .gte('big_board_events.start_date', today)
+        .order('start_date', { foreignTable: 'big_board_events', ascending: true });
+      if (postErr) console.error(postErr);
+      (myPosts || []).forEach(p => {
+        const ev = p.big_board_events?.[0];
+        if (!ev) return;
+        let img = '';
+        if (p.image_url) {
+          const { data: { publicUrl } } = supabase.storage
+            .from('big-board')
+            .getPublicUrl(p.image_url);
+          img = publicUrl;
+        }
+        all.push({
+          id: ev.id,
+          slug: ev.slug,
+          title: ev.title,
+          start_date: ev.start_date,
+          start_time: ev.start_time,
+          image: img,
+          source_table: 'big_board_events',
+        });
+      });
+
+      // group events
+        const { data: ge, error: geErr } = await supabase
+          .from('group_events')
+          .select('id,slug,title,start_date,start_time,groups(slug,imag)')
+          .eq('user_id', profile.id)
+          .gte('start_date', today)
+          .order('start_date', { ascending: true });
+        if (geErr) console.error(geErr);
+        ge?.forEach(ev => {
+        all.push({
+          id: ev.id,
+          slug: ev.slug,
+          title: ev.title,
+          start_date: ev.start_date,
+          start_time: ev.start_time,
+          image: ev.groups?.imag || ev.groups?.[0]?.imag || '',
+          group: ev.groups ? { slug: ev.groups.slug } : ev.groups?.[0] ? { slug: ev.groups[0].slug } : null,
+          source_table: 'group_events',
+        });
+      });
+
+      const parseISO = str => {
+        const [y,m,d] = str.split('-').map(Number);
+        return new Date(y, m-1, d);
+      };
+      const todayObj = new Date();
+      todayObj.setHours(0,0,0,0);
+      const upcoming = all
+        .map(ev => ({ ...ev, _d: parseISO(ev.start_date) }))
+        .filter(ev => ev._d && ev._d >= todayObj)
+        .sort((a,b) => a._d - b._d)
+        .map(({ _d, ...rest }) => rest);
+      setEvents(upcoming);
+      setLoading(false);
+    };
+    load();
+  }, [profile]);
+
+  if (profile === null) {
+    return (
+      <div className="min-h-screen bg-neutral-50 pb-12 pt-20">
+        <Navbar />
+        <div className="py-20 text-center">Profile not found.</div>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-50 pb-12 pt-20">
+      <Navbar />
+      <header className="bg-gradient-to-r from-indigo-700 to-purple-600 text-white">
+        <div className="max-w-screen-md mx-auto px-4 py-10 flex flex-col items-center gap-4">
+          {profile.image_url ? (
+            <img src={profile.image_url} alt="avatar" className="w-32 h-32 rounded-full object-cover" />
+          ) : (
+            <div className="w-32 h-32 rounded-full bg-gray-300" />
+          )}
+          <h1 className="text-3xl font-bold">{profile.username || profile.slug}</h1>
+          {user && user.id !== profile.id && (
+            <button
+              onClick={toggleFollow}
+              disabled={followLoading}
+              className="border border-white rounded px-4 py-1 hover:bg-white hover:text-indigo-700 transition"
+            >
+              {isFollowing ? 'Unfollow' : 'Follow'}
+            </button>
+          )}
+        </div>
+      </header>
+      <div className="max-w-screen-md mx-auto px-4 py-12">
+        <h2 className="text-2xl font-semibold mb-4">Upcoming Events</h2>
+        {loading ? (
+          <div className="py-20 text-center text-gray-500">Loading…</div>
+        ) : events.length === 0 ? (
+          <div className="py-20 text-center text-gray-500">No upcoming events.</div>
+        ) : (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {events.map(ev => (
+              <SavedEventCard key={`${ev.source_table}-${ev.id}`} event={ev} />
+            ))}
+          </div>
+        )}
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,7 +12,8 @@ import GroupDetailPage from './GroupDetailPage.jsx'
 import GroupTypePage from './GroupTypePage.jsx'
 import LoginPage from './LoginPage.jsx'
 import SignUpPage from './SignUpPage.jsx'
-import ProfilePage from './ProfilePage.jsx'; 
+import ProfilePage from './ProfilePage.jsx';
+import PublicProfilePage from './PublicProfilePage.jsx';
 import { AuthProvider } from './AuthProvider.jsx'
 import MomentsExplorer from './MomentsExplorer.jsx' 
 import EventDetailPage from './EventDetailPage.jsx'
@@ -77,6 +78,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignUpPage />} />
           <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/u/:slug" element={<PublicProfilePage />} />
           <Route path="/moments" element={<MomentsExplorer />} />
           <Route path="/moments/:id" element={<MomentsExplorer />} />
           <Route path="/events" element={<MonthlyEvents />} />

--- a/src/utils/useFollow.js
+++ b/src/utils/useFollow.js
@@ -1,0 +1,41 @@
+import { useState, useEffect, useContext } from 'react';
+import { supabase } from '../supabaseClient';
+import { AuthContext } from '../AuthProvider';
+
+export default function useFollow(profileId) {
+  const { user } = useContext(AuthContext);
+  const [followId, setFollowId] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user || !profileId) { setFollowId(null); return; }
+    supabase
+      .from('user_follows')
+      .select('id')
+      .eq('follower_id', user.id)
+      .eq('followed_id', profileId)
+      .maybeSingle()
+      .then(({ data, error }) => {
+        if (!error) setFollowId(data ? data.id : null);
+      });
+  }, [user, profileId]);
+
+  const toggleFollow = async () => {
+    if (!user || !profileId) return;
+    setLoading(true);
+    if (followId) {
+      await supabase.from('user_follows').delete().eq('id', followId);
+      setFollowId(null);
+    } else {
+      const { data } = await supabase
+        .from('user_follows')
+        .insert({ follower_id: user.id, followed_id: profileId })
+        .select('id')
+        .single();
+      if (data) setFollowId(data.id);
+    }
+    setLoading(false);
+  };
+
+  return { isFollowing: Boolean(followId), toggleFollow, loading };
+}


### PR DESCRIPTION
## Summary
- load "My Events" from the user's own big board posts rather than all events
- display only events created by the profile user on public pages
- fix ordering of nested event queries

## Testing
- `npx eslint .` *(failed to run: 138 errors and 2 warnings)*
- `npm run lint` *(failed: invalid option `--ext`)*
- `npm test` *(failed: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c92c87aa4832c990e99bd02ade044