### PR TITLE
feat: display seasonal tag details

### DIFF
--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -1471,8 +1471,9 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
       
             {/* ─── Recent Activity ─── */}
             <RecentActivity />
-            <TaggedEventScroller tags={['arts']}  header="#Arts Coming Soon"/>
-            <TaggedEventScroller tags={['nomnomslurp']}  header="#NomNomSlurp Next Up"/>
+            <TaggedEventScroller tags={['peco-multicultural']} header="#PECO Multicultural"/>
+            <TaggedEventScroller tags={['arts']} header="#Arts Coming Soon"/>
+            <TaggedEventScroller tags={['nomnomslurp']} header="#NomNomSlurp Next Up"/>
             <RecurringEventsScroller windowStart={startOfWeek} windowEnd={endOfWeek} eventType="open_mic" header="Karaoke, Bingo, Open Mics Coming Up..." />
 
             {/* ─── Hero Banner ─── */}

--- a/src/TagPage.jsx
+++ b/src/TagPage.jsx
@@ -9,6 +9,7 @@ import SubmitGroupModal from './SubmitGroupModal'
 import PostFlyerModal from './PostFlyerModal'
 import { Helmet } from 'react-helmet'
 import { RRule } from 'rrule'
+import { Clock } from 'lucide-react'
 
 // ── Helpers to parse dates ────────────────────────────────────────
 function parseISODateLocal(str) {
@@ -431,6 +432,14 @@ export default function TagPage() {
         <div className="mt-20 bg-gradient-to-r from-red-50 to-indigo-50 border-b">
           <div className="max-w-screen-xl mx-auto px-4 py-10 text-center">
             <h1 className="text-4xl font-[barrio] text-gray-800 mb-4">#{tag.name}</h1>
+            {tag.is_seasonal && (
+              <div className="flex justify-center mb-4">
+                <div className="flex items-center gap-1 bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full text-xs font-semibold">
+                  <Clock className="w-4 h-4" />
+                  Limited-Time Tag
+                </div>
+              </div>
+            )}
             {tag.description && (
               <p className="max-w-2xl mx-auto text-gray-700 mb-6">{tag.description}</p>
             )}

--- a/src/TaggedEventsScroller.jsx
+++ b/src/TaggedEventsScroller.jsx
@@ -1,16 +1,20 @@
 // src/TaggedEventsScroller.jsx
-import React, { useState, useEffect, useContext, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { supabase } from './supabaseClient';
-import { AuthContext } from './AuthProvider';
 import { Link } from 'react-router-dom';
+import { Clock } from 'lucide-react';
 
 export default function TaggedEventsScroller({
   tags = [],             // array of tag slugs to pull events from
   header = 'Upcoming Events',
 }) {
-  const { user } = useContext(AuthContext);
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [tagMeta, setTagMeta] = useState({
+    isSeasonal: false,
+    description: '',
+    name: '',
+  });
 
   // only re-run when the **content** of tags changes
   const tagsKey = useMemo(
@@ -48,10 +52,19 @@ export default function TaggedEventsScroller({
         // 1) lookup tag IDs
         const { data: tagRows, error: tagErr } = await supabase
           .from('tags')
-          .select('id')
+          .select('id, name, is_seasonal, description')
           .in('slug', tags);
         if (tagErr) throw tagErr;
         const tagIds = (tagRows || []).map(t => t.id);
+        if (tagRows && tagRows.length) {
+          setTagMeta({
+            isSeasonal: tagRows.some(t => t.is_seasonal),
+            description: tagRows[0]?.description || '',
+            name: tagRows[0]?.name || '',
+          });
+        } else {
+          setTagMeta({ isSeasonal: false, description: '', name: '' });
+        }
         if (!tagIds.length) {
           setItems([]);
           return;
@@ -223,12 +236,29 @@ export default function TaggedEventsScroller({
     })();
   }, [tagsKey]);
 
+  const sectionClass = tagMeta.isSeasonal
+    ? 'relative w-full bg-gradient-to-r from-purple-50 to-pink-100 border-y-4 border-purple-300 py-16 px-4 overflow-hidden'
+    : 'relative w-full bg-white border-b border-gray-200 py-16 px-4 overflow-hidden';
+
   return (
-    <section className="relative w-full bg-white border-b border-gray-200 py-16 px-4 overflow-hidden">
+    <section className={sectionClass}>
       <div className="relative max-w-screen-xl mx-auto text-center z-20">
-        <h2 className="text-2xl sm:text-4xl font-[barrio] font-bold text-gray-700 mb-6">
-          {header}
-        </h2>
+        <div className="flex items-center justify-center gap-2 mb-6">
+          <h2 className="text-2xl sm:text-4xl font-[barrio] font-bold text-gray-700">
+            {header}
+          </h2>
+          {tagMeta.isSeasonal && (
+            <div className="flex items-center gap-2 bg-purple-200 text-purple-900 px-4 py-1.5 rounded-full text-sm sm:text-base font-semibold">
+              <Clock className="w-5 h-5" />
+              Limited-Time Tag
+            </div>
+          )}
+        </div>
+        {tagMeta.isSeasonal && tagMeta.description && (
+          <div className="max-w-2xl mx-auto bg-white border-2 border-purple-300 text-gray-800 p-4 rounded-lg shadow mb-8">
+            {tagMeta.description}
+          </div>
+        )}
         {loading ? (
           <p>Loading…</p>
         ) : !items.length ? (
@@ -245,14 +275,26 @@ export default function TaggedEventsScroller({
                   <Link
                     key={`${evt.id}-${evt.start}`}
                     to={evt.href}
-                    className="relative w-[260px] h-[380px] flex-shrink-0 rounded-2xl overflow-hidden shadow-lg"
+                    className={`relative w-[260px] h-[380px] flex-shrink-0 rounded-2xl overflow-hidden shadow-lg ${
+                      tagMeta.isSeasonal ? 'ring-4 ring-purple-300' : ''
+                    }`}
                   >
                     <img
                       src={evt.imageUrl}
                       alt={evt.title}
-                      className="absolute inset-0 w-full h-full object-cover" 
+                      className="absolute inset-0 w-full h-full object-cover"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent z-10" />
+                    {tagMeta.isSeasonal && tagMeta.name && (
+                      <div className="absolute top-4 left-4 z-30 text-[10px] sm:text-xs font-medium text-gray-800">
+                        <span className="flex items-center gap-1">
+                          <span className="bg-purple-600 text-white px-2 py-0.5 rounded-full whitespace-nowrap">
+                            {tagMeta.name}
+                          </span>
+                          <span className="bg-white/80 px-2 py-1 rounded-full">Series</span>
+                        </span>
+                      </div>
+                    )}
                     <h3 className="absolute bottom-16 left-4 right-4 text-center text-white text-3xl font-bold z-20 leading-tight">
                       {evt.title}
                     </h3>


### PR DESCRIPTION
## Summary
- show seasonal description and special icon in tagged event scroller
- highlight seasonal tags with limited-time callout on tag page
- add PECO Multicultural scroller on home page
- enlarge seasonal "Limited-Time Tag" badge and switch to a purple theme
- mark seasonal event cards as part of the tag series with a simplified "#Tag Series" label

## Testing
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npx eslint .` *(fails: 140 problems (138 errors, 2 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688f5495b1e4832c977f7bd148f6c404