### PR TITLE
Shrink video promo items for mobile

### DIFF
--- a/src/AdminVideoPromo.jsx
+++ b/src/AdminVideoPromo.jsx
@@ -99,23 +99,23 @@ export default function AdminVideoPromo() {
         playsInline
       />
       <div className="absolute inset-0 bg-black/50" />
-      <div className="relative z-10 pt-20 max-w-2xl mx-auto px-4">
-        <h1 className="text-center text-5xl font-[Barrio] mb-4">UPCOMING PHILLY TRADITIONS</h1>
+      <div className="relative z-10 pt-10 max-w-2xl mx-auto px-4">
+        <h1 className="text-center text-2xl font-[Barrio] mb-2">UPCOMING PHILLY TRADITIONS</h1>
         {events.map(ev => (
           <div
             key={ev.id}
-            className="flex items-center gap-4 py-3 border-b border-white/30 last:border-none"
+            className="flex items-center gap-2 py-1 border-b border-white/30 last:border-none"
           >
             {ev.image && (
               <img
                 src={ev.image}
                 alt=""
-                className="w-24 h-16 object-cover rounded"
+                className="w-12 h-8 object-cover rounded"
               />
             )}
             <div>
-              <div className="text-xl font-semibold text-gray-100">{ev.name}</div>
-              <div className="text-base text-gray-300">{ev.displayDate}</div>
+              <div className="text-sm font-semibold text-gray-100">{ev.name}</div>
+              <div className="text-xs text-gray-300">{ev.displayDate}</div>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Halve header and item sizes in the video promo admin page
- Compact promo rows with smaller images and tighter spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_688fcf8db160832c9506b2a712adc77c