### PR TITLE
Fix share card images and improve plan card buttons

### DIFF
--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -783,8 +783,13 @@ export default function ProfilePage() {
 
         {activeTab === 'upcoming' && (
           <section>
-            <div className="flex justify-end mb-4">
-              <button onClick={() => navigate(`/u/${profile?.slug}/plans-card`)} className="px-3 py-1 text-sm border rounded">View upcoming plans card</button>
+            <div className="mb-4">
+              <button
+                onClick={() => navigate(`/u/${profile?.slug}/plans-card`)}
+                className="w-full px-4 py-2 text-sm font-semibold bg-indigo-600 text-white rounded hover:bg-indigo-700 transition"
+              >
+                View upcoming plans card
+              </button>
             </div>
             {loadingSaved ? (
               <div className="py-20 text-center text-gray-500">Loading…</div>

--- a/src/UpcomingPlansCard.jsx
+++ b/src/UpcomingPlansCard.jsx
@@ -213,6 +213,7 @@ export default function UpcomingPlansCard() {
       const { toBlob } = await import('https://esm.sh/html-to-image');
       const blob = await toBlob(card, {
         pixelRatio: 2,
+        cacheBust: true,
         // Exclude elements (like the close and share buttons) marked with data-no-export
         filter: node => !(node instanceof HTMLElement && node.dataset.noExport !== undefined),
       });
@@ -299,10 +300,10 @@ export default function UpcomingPlansCard() {
         )}
         <button
           onClick={handleShare}
-          className="self-end mt-4 text-sm px-4 py-2 bg-indigo-600 text-white rounded"
+          className="w-full mt-4 text-sm py-2 bg-indigo-600 text-white rounded"
           data-no-export
         >
-          Share
+          SHARE YOUR PLAN CARD
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- include images when exporting upcoming plans card for sharing
- make share action button full-width and more descriptive
- enlarge profile page button linking to upcoming plans card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_688ff0c6f040832cbc0ade5ea099a9ed