### PR TITLE
Fix share card images and improve plan card buttons

### DIFF
--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -783,8 +783,13 @@ export default function ProfilePage() {
 
         {activeTab === 'upcoming' && (
           <section>
-            <div className="flex justify-end mb-4">
-              <button onClick={() => navigate(`/u/${profile?.slug}/plans-card`)} className="px-3 py-1 text-sm border rounded">View upcoming plans card</button>
+            <div className="mb-4">
+              <button
+                onClick={() => navigate(`/u/${profile?.slug}/plans-card`)}
+                className="w-full px-4 py-2 text-sm font-semibold bg-indigo-600 text-white rounded hover:bg-indigo-700 transition"
+              >
+                View upcoming plans card
+              </button>
             </div>
             {loadingSaved ? (
               <div className="py-20 text-center text-gray-500">Loading…</div>

--- a/src/UpcomingPlansCard.jsx
+++ b/src/UpcomingPlansCard.jsx
@@ -206,16 +206,47 @@ export default function UpcomingPlansCard() {
     load();
   }, [slug]);
 
+  const embedImages = async node => {
+    const imgs = Array.from(node.getElementsByTagName('img'));
+    const originals = [];
+    await Promise.all(
+      imgs.map(async img => {
+        if (img.src.startsWith('data:')) return;
+        originals.push([img, img.src]);
+        try {
+          const res = await fetch(img.src);
+          const blob = await res.blob();
+          const reader = new FileReader();
+          const dataUrl = await new Promise(resolve => {
+            reader.onload = () => resolve(reader.result);
+            reader.readAsDataURL(blob);
+          });
+          img.src = dataUrl;
+        } catch (e) {
+          console.warn('embed image', e);
+        }
+      })
+    );
+    return () => {
+      originals.forEach(([img, src]) => {
+        img.src = src;
+      });
+    };
+  };
+
   const handleShare = async () => {
     const card = document.getElementById('plans-card');
     if (!card) return;
     try {
       const { toBlob } = await import('https://esm.sh/html-to-image');
+      const cleanup = await embedImages(card);
       const blob = await toBlob(card, {
         pixelRatio: 2,
+        cacheBust: true,
         // Exclude elements (like the close and share buttons) marked with data-no-export
         filter: node => !(node instanceof HTMLElement && node.dataset.noExport !== undefined),
       });
+      cleanup();
       if (!blob) throw new Error('image generation failed');
       const file = new File([blob], 'plans.png', { type: 'image/png' });
       if (navigator.canShare && navigator.canShare({ files: [file] })) {
@@ -299,10 +330,10 @@ export default function UpcomingPlansCard() {
         )}
         <button
           onClick={handleShare}
-          className="self-end mt-4 text-sm px-4 py-2 bg-indigo-600 text-white rounded"
+          className="w-full mt-4 text-sm py-2 bg-indigo-600 text-white rounded"
           data-no-export
         >
-          Share
+          SHARE YOUR PLAN CARD
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- include images when exporting upcoming plans card for sharing
- make share action button full-width and more descriptive
- enlarge profile page button linking to upcoming plans card
- inline remote images before capture so shared card shows them

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_688ff0c6f040832cbc0ade5ea099a9ed