### PR TITLE
Add plans footer to event scrollers

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "generate-sitemap": "node scripts/generate-sitemap.js"
   },

--- a/src/HeroLanding.jsx
+++ b/src/HeroLanding.jsx
@@ -1,15 +1,17 @@
 // src/HeroLanding.jsx
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import { supabase } from './supabaseClient';
-import { AuthContext } from './AuthProvider';
 import { Link } from 'react-router-dom';
-import EventFavorite from './EventFavorite.jsx';
+import useEventFavorite from './utils/useEventFavorite';
+
+function FavoriteState({ event_id, source_table, children }) {
+  const state = useEventFavorite({ event_id, source_table });
+  return children(state);
+}
 
 export default function HeroLanding() {
-  const { user } = useContext(AuthContext);
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [favCounts, setFavCounts] = useState({});
 
   const parseDate = datesStr => {
     if (!datesStr) return null;
@@ -78,22 +80,6 @@ export default function HeroLanding() {
     })();
   }, []);
 
-  useEffect(() => {
-    if (!events.length) return;
-    (async () => {
-      const ids = events.map(e => e.id);
-      const { data } = await supabase
-        .from('event_favorites')
-        .select('event_id')
-        .in('event_id', ids);
-      const counts = {};
-      data.forEach(r => (counts[r.event_id] = (counts[r.event_id] || 0) + 1));
-      setFavCounts(counts);
-    })();
-  }, [events]);
-
-  // Favorites handled individually in EventFavorite component
-
   return (
     <section className="relative w-full bg-white border-b border-gray-200 py-16 px-4 overflow-hidden">
       <img
@@ -122,59 +108,63 @@ export default function HeroLanding() {
             <div className="flex gap-4 pb-4">
               {events.map(evt => {
                 const { text, color, pulse } = getBubble(evt.start, evt.isActive);
-                const count = favCounts[evt.id] || 0;
                 const showWeekendBadge =
                   isThisWeekend(evt.start) && [5, 6, 0].includes(evt.start.getDay());
 
                 return (
-                  <Link
+                  <FavoriteState
                     key={evt.id}
-                    to={`/events/${evt.slug}`}
-                    className="relative w-[260px] h-[380px] flex-shrink-0 rounded-2xl overflow-hidden shadow-lg"
+                    event_id={evt.id}
+                    source_table="events"
                   >
-                    <img
-                      src={evt['E Image']}
-                      alt={evt['E Name']}
-                      className="absolute inset-0 w-full h-full object-cover"
-                    />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent z-10" />
+                    {({ isFavorite, toggleFavorite, loading }) => (
+                      <div className="flex-shrink-0 w-[260px]">
+                        <Link
+                          to={`/events/${evt.slug}`}
+                          className={`relative w-[260px] h-[380px] flex-shrink-0 rounded-2xl overflow-hidden shadow-lg ${isFavorite ? 'ring-2 ring-indigo-600' : ''}`}
+                        >
+                          <img
+                            src={evt['E Image']}
+                            alt={evt['E Name']}
+                            className="absolute inset-0 w-full h-full object-cover"
+                          />
+                          <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent z-10" />
 
-                    {showWeekendBadge && (
-                      <span className="absolute top-3 left-3 bg-yellow-400 text-black text-xs font-bold px-2 py-1 rounded-full z-20">
-                        Weekend Pick
-                      </span>
+                          {showWeekendBadge && (
+                            <span className="absolute top-3 left-3 bg-yellow-400 text-black text-xs font-bold px-2 py-1 rounded-full z-20">
+                              Weekend Pick
+                            </span>
+                          )}
+
+                          <h3 className="absolute bottom-16 left-4 right-4 text-center text-white text-3xl font-[Barrio] font-bold z-20 leading-tight">
+                            {evt['E Name']}
+                          </h3>
+
+                          <span
+                            className={`
+                              absolute bottom-6 left-1/2 transform -translate-x-1/2
+                              ${color} text-white text-base font-bold px-6 py-1 rounded-full
+                              whitespace-nowrap min-w-[6rem]
+                              ${pulse ? 'animate-pulse' : ''} z-20
+                            `}
+                          >
+                            {text}
+                          </span>
+                        </Link>
+                        <button
+                          onClick={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            toggleFavorite();
+                          }}
+                          disabled={loading}
+                          className={`mt-2 w-full border border-indigo-600 rounded-md py-2 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+                        >
+                          {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                        </button>
+                      </div>
                     )}
-
-                    <EventFavorite
-                      event_id={evt.id}
-                      source_table="events"
-                      count={count}
-                      onCountChange={delta =>
-                        setFavCounts(c => ({ ...c, [evt.id]: (c[evt.id] || 0) + delta }))
-                      }
-                      className="absolute top-3 right-3 z-20 text-2xl text-white"
-                    />
-                    {count > 0 && (
-                      <span className="absolute top-10 right-3 text-sm font-semibold text-white z-20">
-                        {count}
-                      </span>
-                    )}
-
-                    <h3 className="absolute bottom-16 left-4 right-4 text-center text-white text-3xl font-[Barrio] font-bold z-20 leading-tight">
-                      {evt['E Name']}
-                    </h3>
-
-                    <span
-                      className={`
-                        absolute bottom-6 left-1/2 transform -translate-x-1/2
-                        ${color} text-white text-base font-bold px-6 py-1 rounded-full
-                        whitespace-nowrap min-w-[6rem]
-                        ${pulse ? 'animate-pulse' : ''} z-20
-                      `}
-                    >
-                      {text}
-                    </span>
-                  </Link>
+                  </FavoriteState>
                 );
               })}
             </div>


### PR DESCRIPTION
## Summary
- allow tagging events scroller cards to be added to user plans
- highlight favorited events with border ring and footer button
- extend plans button support to recurring, hero landing, and big board scrollers
- update lint script for ESLint 9 compatibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 141 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689071977020832cada7d4e8370f010c