### PR TITLE
Clarify guest messaging and signup prompts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, lazy, Suspense } from 'react';
+import React, { useState, useEffect, lazy, Suspense, useContext } from 'react';
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import GroupsList from './GroupsList';
 import MonthlyEvents from './MonthlyEvents';
@@ -38,6 +38,7 @@ import NewsletterBar from './NewsletterBar';
 import RecentActivity from './RecentActivity';
 import BigBoardEventsGrid from './BigBoardEventsGrid';
 import CityHolidayAlert from './CityHolidayAlert';
+import { AuthContext } from './AuthProvider';
 import MoreEventsBanner from './MoreEventsBanner';
 
 
@@ -45,6 +46,7 @@ import MoreEventsBanner from './MoreEventsBanner';
 
 
 function App() {
+  const { user } = useContext(AuthContext);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedType, setSelectedType] = useState('');
   const [allTypes, setAllTypes] = useState([]);
@@ -139,6 +141,11 @@ function App() {
     <h1 className="text-5xl sm:text-6xl md:text-8xl font-[Barrio] font-black text-black">
             DIG INTO PHILLY
           </h1>
+          {!user && (
+            <p className="mt-3 text-lg text-gray-700">
+              Save events, follow hosts, get a weekly digest.
+            </p>
+          )}
 
           <div className="mt-4 border-b border-gray-200 pb-4">
             <nav className="inline-flex items-center text-sm uppercase font-bold text-indigo-600">

--- a/src/BigBoardEventPage.jsx
+++ b/src/BigBoardEventPage.jsx
@@ -528,6 +528,11 @@ export default function BigBoardEventPage() {
               </div>
             </div>
           </div>
+          {!user && (
+            <div className="bg-indigo-50 text-center text-sm py-2">
+              <Link to="/login" className="text-indigo-600 font-semibold">Log in</Link> to add to your Plans.
+            </div>
+          )}
 
           {poster && (
             <div className="max-w-4xl mx-auto mt-6 px-4">

--- a/src/CommentsSection.jsx
+++ b/src/CommentsSection.jsx
@@ -215,10 +215,14 @@ export default function CommentsSection({ source_table, event_id }) {
           </form>
         ) : (
           <p className="text-sm text-center">
-            <Link to="/login" className="text-indigo-600 hover:underline">
-              Log in
+            <Link to="/signup" className="text-indigo-600 hover:underline">
+              Sign up
             </Link>{' '}
-            to leave a comment
+            or{' '}
+            <Link to="/login" className="text-indigo-600 hover:underline">
+              log in
+            </Link>{' '}
+            to join the conversation
           </p>
         )}
       </div>

--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -235,7 +235,11 @@ export default function EventDetailPage() {
 
   // ─── Favorite toggle ─────────────────────────────────────────────────
   const toggleFav = async () => {
-    if (!user || !event) return;
+    if (!user) {
+      alert('Sign up or log in to save events to your Plans.');
+      return;
+    }
+    if (!event) return;
     const wasFav = isFavorite;
     await toggleFavorite();
     setFavCount(c => (wasFav ? c - 1 : c + 1));
@@ -270,7 +274,7 @@ export default function EventDetailPage() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    if (!user) return alert('Log in to leave a review.');
+    if (!user) return alert('Sign up or log in to leave a review.');
     setSubmitting(true);
     const photoUrls = [];
     for (let file of photoFiles) {
@@ -418,6 +422,11 @@ export default function EventDetailPage() {
             )}
         </div>
         </div>
+        {!user && (
+          <div className="bg-indigo-50 text-center text-sm py-2">
+            <Link to="/login" className="text-indigo-600 font-semibold">Log in</Link> to add to your Plans.
+          </div>
+        )}
         {reviewPhotoUrls.length > 0 && (
           <ReviewPhotoGrid photos={reviewPhotoUrls} />
         )}
@@ -593,7 +602,8 @@ export default function EventDetailPage() {
             )
           ) : (
             <p className="mt-6 text-center text-sm">
-              <Link to="/login" className="text-indigo-600 hover:underline">Log in</Link> to leave a review.
+              <Link to="/signup" className="text-indigo-600 hover:underline">Sign up</Link> or{' '}
+              <Link to="/login" className="text-indigo-600 hover:underline">log in</Link> to leave a review.
             </p>
           )}
 

--- a/src/FAQPage.jsx
+++ b/src/FAQPage.jsx
@@ -1,0 +1,44 @@
+// src/FAQPage.jsx
+import React from 'react';
+import Navbar from './Navbar';
+import Footer from './Footer';
+
+export default function FAQPage() {
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <Navbar />
+      <main className="flex-grow max-w-3xl mx-auto px-4 py-20">
+        <h1 className="text-4xl font-[Barrio] mb-8 text-center">FAQ</h1>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold mb-2">Why should I create an account?</h2>
+          <p className="text-gray-700">
+            An account lets you save events to your Plans, follow hosts, leave reviews, and build a weekly digest of what&rsquo;s coming up in Philly.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold mb-2">How do I list my event?</h2>
+          <p className="text-gray-700">
+            Hosts can post events for free. Sign up, click <span className="font-semibold">Post Event</span> in the navbar, and fill out the details. Your listing appears on the Big Board and can be saved by visitors.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold mb-2">Can I manage my event page?</h2>
+          <p className="text-gray-700">
+            Yes. After posting, you can edit the details or update images. We&rsquo;re working on a claim system so established hosts can take control of existing pages.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-2xl font-semibold mb-2">What is the Plans card?</h2>
+          <p className="text-gray-700">
+            It&rsquo;s a shareable card that shows the events you&rsquo;ve saved. It&rsquo;s perfect for planning weekends with friends or promoting upcoming activities.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -1,7 +1,10 @@
 // src/Footer.jsx
-import React from 'react';
+import React, { useContext } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthContext } from './AuthProvider';
 
 const Footer = () => {
+  const { user } = useContext(AuthContext);
   const year = new Date().getFullYear();
   const heartUrl =
     'https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/sign/group-images/OurPhilly-CityHeart-1.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJncm91cC1pbWFnZXMvT3VyUGhpbGx5LUNpdHlIZWFydC0xLnBuZyIsImlhdCI6MTc0NTYxMjg5OSwiZXhwIjozMzI4MTYxMjg5OX0.NniulJ-CMLkbor5PBSay30rMbFwtGFosxvhAkBKGFbU';
@@ -28,8 +31,21 @@ const Footer = () => {
           <p className="text-sm text-gray-400 mb-4">
             Making community more accessible in the city.
           </p>
+        {user ? (
+          <p className="text-sm text-gray-400 mb-4">
+            <Link to="/profile" className="text-indigo-400 hover:underline">View My Plans</Link> and share your plans card.
+          </p>
+        ) : (
+          <p className="text-sm text-gray-400 mb-4">
+            <Link to="/signup" className="text-indigo-400 hover:underline">Sign up</Link> to save events and get a weekly digest.
+          </p>
+        )}
 
-          <p className="text-xs text-gray-500">&copy; {year} Our Philly. All rights reserved.</p>
+        <p className="text-sm text-gray-400 mb-4">
+          <Link to="/faq" className="text-indigo-400 hover:underline">FAQ</Link>
+        </p>
+
+        <p className="text-xs text-gray-500">&copy; {year} Our Philly. All rights reserved.</p>
         </div>
 
         {/* empty spacer to align heart */}

--- a/src/GroupDetailPage.jsx
+++ b/src/GroupDetailPage.jsx
@@ -160,6 +160,12 @@ export default function GroupDetailPage() {
 
       <Navbar />
       <GroupProgressBar />
+      {!user && (
+        <div className="bg-indigo-50 text-center text-sm py-2">
+          <Link to="/signup" className="text-indigo-600 font-semibold">Sign up</Link> or{' '}
+          <Link to="/login" className="text-indigo-600 font-semibold">log in</Link> to follow this group and save events to your Plans.
+        </div>
+      )}
 
       {/* ── Header: Cover Banner & Avatar ───────────────────────────────── */}
       <div className="relative">

--- a/src/GroupEventDetailPage.jsx
+++ b/src/GroupEventDetailPage.jsx
@@ -463,6 +463,11 @@ if (ev.image_url) {
           </div>
         </div>
       </div>
+      {!user && (
+        <div className="bg-indigo-50 text-center text-sm py-2">
+          <Link to="/login" className="text-indigo-600 font-semibold">Log in</Link> to add to your Plans.
+        </div>
+      )}
 
       <CommentsSection
         source_table="group_events"

--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -1167,10 +1167,10 @@ if (loading) {
       
               <div className="relative inline-block text-center z-10">
                 <h1 className="text-6xl sm:text-5xl md:text-8xl font-[Barrio] font-black text-indigo-900 mb-4">
-                  Build Your Philly Digest
+                  Make Your Philly Plans
                 </h1>
                 <p className="text-lg sm:text-xl text-gray-700 max-w-2xl mx-auto">
-                  Pick your favorite tags and get a curated daily email of Philly’s top events, traditions, and community happenings.
+                  Save events, follow hosts, and build a weekly digest of what’s happening around town.
                 </p>
                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none -z-10">
                   <span className="absolute w-full h-px bg-white opacity-20" />

--- a/src/MainEventsDetail.jsx
+++ b/src/MainEventsDetail.jsx
@@ -452,6 +452,11 @@ export default function MainEventsDetail() {
               </p>
             </div>
           </div>
+          {!user && (
+            <div className="bg-indigo-50 text-center text-sm py-2">
+              <Link to="/login" className="text-indigo-600 font-semibold">Log in</Link> to add to your Plans.
+            </div>
+          )}
 
           {reviewPhotos.length > 0 && (
             <ReviewPhotoGrid photos={reviewPhotos} />

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -55,7 +55,7 @@ export default function Navbar() {
           <div className="hidden md:flex items-center space-x-8 text-base">
             {/* Primary links */}
             <ul className="flex items-center space-x-6 font-medium">
-              
+
               <li>
                 <button
                   onClick={openPostModal}
@@ -82,6 +82,14 @@ export default function Navbar() {
                   <span>Contact</span>
                 </Link>
               </li>
+              <li>
+                <Link
+                  to="/faq"
+                  className={`flex items-center space-x-1 ${linkClass('/faq')}`}
+                >
+                  <span>FAQ</span>
+                </Link>
+              </li>
             </ul>
 
             {/* Auth */}
@@ -89,7 +97,7 @@ export default function Navbar() {
               {user ? (
                 <>
                   <Link to="/profile" className={linkClass('/profile')}>
-                    Profile
+                    My Plans
                   </Link>
                   <button
                     onClick={handleLogout}
@@ -133,12 +141,15 @@ export default function Navbar() {
             <Link to="/groups" className="block" onClick={() => setMenuOpen(false)}>
               Claim Your Group
             </Link>
-                <Link
-                  to="/contact"
-                  className={`flex items-center space-x-1 ${linkClass('/groups')}`}
-                >
-                  <span>Contact</span>
-                </Link>
+            <Link
+              to="/contact"
+              className={`flex items-center space-x-1 ${linkClass('/groups')}`}
+            >
+              <span>Contact</span>
+            </Link>
+            <Link to="/faq" className="block" onClick={() => setMenuOpen(false)}>
+              FAQ
+            </Link>
             <button
               onClick={openPostModal}
               className="block text-left w-full"
@@ -148,7 +159,7 @@ export default function Navbar() {
             {user ? (
               <>
                 <Link to="/profile" className="block" onClick={() => setMenuOpen(false)}>
-                  Profile
+                  My Plans
                 </Link>
                 <button
                   onClick={handleLogout}

--- a/src/NewsletterSection.jsx
+++ b/src/NewsletterSection.jsx
@@ -50,6 +50,15 @@ export default function NewsletterSection() {
         Join Our Newsletter
       </h2>
 
+      <p className="text-center text-gray-700 mb-4">
+        Follow the tags you love and get a custom weekly digest of Philly events.
+      </p>
+      <img
+        src="https://via.placeholder.com/600x300?text=Digest+Preview"
+        alt="Digest preview"
+        className="mx-auto rounded-lg shadow mb-6"
+      />
+
       {/* inject the form */}
       <div dangerouslySetInnerHTML={{ __html: embed }} />
 

--- a/src/ProfilePage.jsx
+++ b/src/ProfilePage.jsx
@@ -647,6 +647,11 @@ export default function ProfilePage() {
       </header>
 
       <div className="max-w-screen-md mx-auto px-4 py-12 space-y-12">
+        {activeTab === 'upcoming' && (
+          <div className="bg-indigo-50 text-indigo-800 p-3 rounded text-center">
+            Tip: share your Plans card with friends using the share button.
+          </div>
+        )}
         <div className="flex justify-center gap-6 mb-8">
           <button
             onClick={() => setActiveTab('upcoming')}

--- a/src/RecurringEventPage.jsx
+++ b/src/RecurringEventPage.jsx
@@ -326,15 +326,20 @@ export default function RecurringEventPage() {
             </div>
 
             {/* Next arrow */}
-            {nextDate && (
-              <button
-                onClick={() => navigate(`/series/${slug}/${nextDate}`)}
-                className="absolute right-0 top-1/2 -translate-y-1/2 p-3 bg-gray-100 hover:bg-gray-200 rounded-full shadow z-20"
-              >
-                →
-              </button>
-            )}
+          {nextDate && (
+            <button
+              onClick={() => navigate(`/series/${slug}/${nextDate}`)}
+              className="absolute right-0 top-1/2 -translate-y-1/2 p-3 bg-gray-100 hover:bg-gray-200 rounded-full shadow z-20"
+            >
+              →
+            </button>
+          )}
           </div>
+          {!user && (
+            <div className="bg-indigo-50 text-center text-sm py-2">
+              <Link to="/login" className="text-indigo-600 font-semibold">Log in</Link> to add to your Plans.
+            </div>
+          )}
 
           {/* Main content grid */}
           <div className="max-w-4xl mx-auto mt-12 px-4 grid grid-cols-1 lg:grid-cols-2 gap-8">

--- a/src/SeasonalEventDetailPage.jsx
+++ b/src/SeasonalEventDetailPage.jsx
@@ -1,7 +1,7 @@
 // src/SeasonalEventDetailPage.jsx
 
 import React, { useEffect, useState, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { supabase } from './supabaseClient';
 import Navbar from './Navbar';
@@ -60,7 +60,11 @@ const SeasonalEventDetailPage = () => {
   }, [event, user]);
 
   const toggleFavorite = async () => {
-    if (!user || !event) return;
+    if (!user) {
+      window.location.href = '/signup';
+      return;
+    }
+    if (!event) return;
 
     if (isFav) {
       await removeSeasonalFavorite(favId);
@@ -170,6 +174,12 @@ const SeasonalEventDetailPage = () => {
           <span className="text-5xl font-[Barrio]">{favCount}</span>
         </div>
       </div>
+
+      {!user && (
+        <div className="bg-indigo-50 text-center text-sm py-2">
+          <Link to="/login" className="text-indigo-600 font-semibold">Log in</Link> to add to your Plans.
+        </div>
+      )}
 
       <SeasonalEventsGrid />
 

--- a/src/SignUpPage.jsx
+++ b/src/SignUpPage.jsx
@@ -146,10 +146,28 @@ export default function SignUpPage() {
           Sign up for your Digest
         </h1>
         <p className="relative z-10 mb-8 text-center text-gray-700">
-          Subscribe to hashtags to get your custom once-a-week events newsletter
+          Plan your Philly life: save events, comment, and even host your own.
+          Subscribe to hashtags for a custom once-a-week roundup.
         </p>
 
-        <form onSubmit={handleSignUp} className="relative z-10 space-y-6 bg-white p-6 rounded-lg shadow-lg">
+        <div className="relative z-10 mb-8 bg-indigo-50 p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold mb-3 text-center">Why create an account?</h2>
+          <ul className="list-disc list-inside space-y-1 text-gray-700 text-left">
+            <li>Save events to build your personal Plans list</li>
+            <li>Follow hosts & tags for a weekly email digest</li>
+            <li>Leave comments and reviews on events</li>
+            <li>Post your own events or flyers</li>
+          </ul>
+          <div className="mt-4 p-4 bg-white rounded shadow">
+            <p className="text-sm text-gray-500 mb-2">Sample Plans card</p>
+            <div className="border rounded p-3">
+              <div className="font-semibold">🎉 Parade on Market</div>
+              <div className="text-xs text-gray-600">Jan 1 • 10:00 AM</div>
+            </div>
+          </div>
+        </div>
+
+        <form id="signup-form" onSubmit={handleSignUp} className="relative z-10 space-y-6 bg-white p-6 rounded-lg shadow-lg">
           {/* Email */}
           <div>
             <label className="block text-sm font-medium mb-1">Email</label>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -47,6 +47,7 @@ import ScrollToTop from './ScrollToTop'
 import TagPage from './TagPage.jsx'
 import ContactPage from './ContactPage.jsx'
 import RecurringPage from './RecurringEventPage.jsx'
+import FAQPage from './FAQPage.jsx'
 
 
 
@@ -111,6 +112,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/groups/:slug/events/:eventId" element={<GroupEventDetailPage />} />
           <Route path="/tags/:slug" element={<TagPage />} />
           <Route path="/contact" element={<ContactPage />} />
+          <Route path="/faq" element={<FAQPage />} />
           <Route path="/series/:slug/:date" element={<RecurringPage />} />
 
 

--- a/src/utils/useEventFavorite.js
+++ b/src/utils/useEventFavorite.js
@@ -29,7 +29,11 @@ export default function useEventFavorite({ event_id, source_table }) {
   }, [user, event_id, source_table])
 
   const toggleFavorite = async () => {
-    if (!user || !event_id || !source_table) return
+    if (!user) {
+      window.location.href = '/signup'
+      return
+    }
+    if (!event_id || !source_table) return
     setLoading(true)
     let column = 'event_id'
     if (source_table === 'all_events') column = 'event_int_id'

--- a/src/utils/useFollow.js
+++ b/src/utils/useFollow.js
@@ -21,7 +21,11 @@ export default function useFollow(profileId) {
   }, [user, profileId]);
 
   const toggleFollow = async () => {
-    if (!user || !profileId) return;
+    if (!user) {
+      alert('Sign up or log in to follow hosts.');
+      return;
+    }
+    if (!profileId) return;
     setLoading(true);
     if (followId) {
       await supabase.from('user_follows').delete().eq('id', followId);


### PR DESCRIPTION
## Summary
- headline now invites visitors to make their Philly plans
- show a banner on event pages telling guests to log in before adding to Plans
- redirect Add to Plans to the signup page and introduce an FAQ

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6890d466c870832cbedd2bb4b989ea67