### PR TITLE
Protect plan card route and handle CORS for image export

### DIFF
--- a/src/ProtectedPlansCard.jsx
+++ b/src/ProtectedPlansCard.jsx
@@ -1,0 +1,45 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+import UpcomingPlansCard from './UpcomingPlansCard.jsx';
+import { AuthContext } from './AuthProvider.jsx';
+import { supabase } from './supabaseClient.js';
+
+export default function ProtectedPlansCard() {
+  const { slug } = useParams();
+  const { user } = useContext(AuthContext);
+  const [userSlug, setUserSlug] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchSlug() {
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('slug')
+        .eq('id', user.id)
+        .single();
+      if (!error) {
+        setUserSlug(data?.slug);
+      }
+      setLoading(false);
+    }
+    fetchSlug();
+  }, [user]);
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (loading) {
+    return null;
+  }
+
+  if (userSlug !== slug) {
+    return <div>Not authorized</div>;
+  }
+
+  return <UpcomingPlansCard />;
+}

--- a/src/UpcomingPlansCard.jsx
+++ b/src/UpcomingPlansCard.jsx
@@ -214,7 +214,10 @@ export default function UpcomingPlansCard() {
         if (img.src.startsWith('data:')) return;
         originals.push([img, img.src]);
         try {
-          const res = await fetch(img.src);
+          const res = await fetch(img.src, { mode: 'cors' });
+          if (!res.ok) {
+            throw new Error(`Failed to fetch ${img.src}: ${res.status}`);
+          }
           const blob = await res.blob();
           const reader = new FileReader();
           const dataUrl = await new Promise(resolve => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,7 +14,7 @@ import LoginPage from './LoginPage.jsx'
 import SignUpPage from './SignUpPage.jsx'
 import ProfilePage from './ProfilePage.jsx';
 import PublicProfilePage from './PublicProfilePage.jsx';
-import UpcomingPlansCard from './UpcomingPlansCard.jsx';
+import ProtectedPlansCard from './ProtectedPlansCard.jsx';
 import { AuthProvider } from './AuthProvider.jsx'
 import MomentsExplorer from './MomentsExplorer.jsx' 
 import EventDetailPage from './EventDetailPage.jsx'
@@ -80,7 +80,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignUpPage />} />
           <Route path="/profile" element={<ProfilePage />} />
-          <Route path="/u/:slug/plans-card" element={<UpcomingPlansCard />} />
+          <Route path="/u/:slug/plans-card" element={<ProtectedPlansCard />} />
           <Route path="/u/:slug" element={<PublicProfilePage />} />
           <Route path="/moments" element={<MomentsExplorer />} />
           <Route path="/moments/:id" element={<MomentsExplorer />} />


### PR DESCRIPTION
## Summary
- Restrict plan card view to the authenticated owner only.
- Fetch images with explicit CORS handling before exporting plan cards.

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint .` (fails: parsing errors)
- `curl -s -D - -o /dev/null https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images/bulletin-board-2.jpeg` (HTTP/1.1 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689110604e74832c9de6ec85854f504a