### PR TITLE
Fix recurring event links in Plans

### DIFF
--- a/src/SavedEventCard.jsx
+++ b/src/SavedEventCard.jsx
@@ -49,7 +49,7 @@ export default function SavedEventCard({ event }) {
         : source_table === 'group_events'
           ? `/groups/${group?.slug}/events/${id}`
           : source_table === 'recurring_events'
-            ? `/series/${slug}`
+            ? `/series/${slug}/${start_date}`
             : source_table === 'all_events'
               ? `/${venues?.slug || ''}/${slug}`
               : '/'

--- a/src/SavedEventsScroller.jsx
+++ b/src/SavedEventsScroller.jsx
@@ -54,7 +54,7 @@ export default function SavedEventsScroller({ events = [] }) {
                 : source_table === 'group_events'
                   ? `/groups/${group?.slug}/events/${id}`
                   : source_table === 'recurring_events'
-                    ? `/series/${slug}`
+                    ? `/series/${slug}/${start_date}`
                     : source_table === 'all_events'
                       ? `/${venues?.slug || ''}/${slug}`
                       : '/'


### PR DESCRIPTION
## Summary
- ensure recurring event links in saved event views include the selected date

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6893d453ebc4832ca84a3443ef01aeef