### PR TITLE
Invite sign-ups on event pages

### DIFF
--- a/src/BigBoardEventPage.jsx
+++ b/src/BigBoardEventPage.jsx
@@ -493,7 +493,7 @@ export default function BigBoardEventPage() {
 
           {!user && (
             <div className="w-full bg-indigo-600 text-white text-center py-4 text-xl sm:text-2xl">
-              <Link to="/login" className="underline font-semibold">Log in</Link> to add to your Plans
+              <Link to="/login" className="underline font-semibold">Log in</Link> or <Link to="/signup" className="underline font-semibold">sign up</Link> free to add to your Plans
             </div>
           )}
 

--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -425,7 +425,7 @@ export default function EventDetailPage() {
         </div>
         {!user && (
           <div className="w-full bg-indigo-600 text-white text-center py-4 text-xl sm:text-2xl">
-            <Link to="/login" className="underline font-semibold">Log in</Link> to add to your Plans
+            <Link to="/login" className="underline font-semibold">Log in</Link> or <Link to="/signup" className="underline font-semibold">sign up</Link> free to add to your Plans
           </div>
         )}
         {reviewPhotoUrls.length > 0 && (

--- a/src/GroupEventDetailPage.jsx
+++ b/src/GroupEventDetailPage.jsx
@@ -269,7 +269,7 @@ if (ev.image_url) {
       />
       {!user && (
         <div className="w-full bg-indigo-600 text-white text-center py-4 text-xl sm:text-2xl">
-          <Link to="/login" className="underline font-semibold">Log in</Link> to add to your Plans
+          <Link to="/login" className="underline font-semibold">Log in</Link> or <Link to="/signup" className="underline font-semibold">sign up</Link> free to add to your Plans
         </div>
       )}
 

--- a/src/MainEventsDetail.jsx
+++ b/src/MainEventsDetail.jsx
@@ -461,6 +461,12 @@ export default function MainEventsDetail() {
             </div>
           </div>
 
+          {!user && (
+            <div className="w-full bg-indigo-600 text-white text-center py-4 text-xl sm:text-2xl">
+              <Link to="/login" className="underline font-semibold">Log in</Link> or <Link to="/signup" className="underline font-semibold">sign up</Link> free to add to your Plans
+            </div>
+          )}
+
           {reviewPhotos.length > 0 && (
             <ReviewPhotoGrid photos={reviewPhotos} />
           )}

--- a/src/RecurringEventPage.jsx
+++ b/src/RecurringEventPage.jsx
@@ -292,7 +292,7 @@ export default function RecurringEventPage() {
 
           {!user && (
             <div className="w-full bg-indigo-600 text-white text-center py-4 text-xl sm:text-2xl">
-              <Link to="/login" className="underline font-semibold">Log in</Link> to add to your Plans
+              <Link to="/login" className="underline font-semibold">Log in</Link> or <Link to="/signup" className="underline font-semibold">sign up</Link> free to add to your Plans
             </div>
           )}
 

--- a/src/SeasonalEventDetailPage.jsx
+++ b/src/SeasonalEventDetailPage.jsx
@@ -178,7 +178,7 @@ const SeasonalEventDetailPage = () => {
 
       {!user && (
         <div className="w-full bg-indigo-600 text-white text-center py-4 text-xl sm:text-2xl">
-          <Link to="/login" className="underline font-semibold">Log in</Link> to add to your Plans
+          <Link to="/login" className="underline font-semibold">Log in</Link> or <Link to="/signup" className="underline font-semibold">sign up</Link> free to add to your Plans
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Update event detail pages to prompt visitors to log in or sign up to add events to Plans
- Include `/signup` link alongside existing login link in banners
- Cover all event sources, including the all_events detail page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/EventDetailPage.jsx src/RecurringEventPage.jsx src/SeasonalEventDetailPage.jsx src/GroupEventDetailPage.jsx src/BigBoardEventPage.jsx src/MainEventsDetail.jsx` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_68951d62f5e8832c891c14695bf17376