### PR TITLE
Highlight community benefits on signup

### DIFF
--- a/src/SignUpPage.jsx
+++ b/src/SignUpPage.jsx
@@ -143,11 +143,16 @@ export default function SignUpPage() {
         />
 
         <h1 className="mt-12 relative z-10 text-3xl sm:text-4xl md:text-5xl font-[Barrio] font-black mb-2 text-center">
-          Sign up for your Digest
+          Join Our Philly—save events, follow people and tags, and get a daily digest
         </h1>
-        <p className="relative z-10 mb-8 text-center text-gray-700">
-          Subscribe to hashtags to get your custom once-a-week events newsletter
+        <p className="relative z-10 mb-4 text-center text-gray-700">
+          Create an account to save plans, follow others and tags, and stay in the loop with a daily digest of upcoming events.
         </p>
+        <ul className="relative z-10 mb-8 space-y-2 text-gray-700 list-disc list-inside">
+          <li>Save events to your plan</li>
+          <li>Follow people and tags</li>
+          <li>Post your own events</li>
+        </ul>
 
         <form onSubmit={handleSignUp} className="relative z-10 space-y-6 bg-white p-6 rounded-lg shadow-lg">
           {/* Email */}


### PR DESCRIPTION
## Summary
- Emphasize saving events, following people and tags, and receiving a daily digest on the signup page
- Add bullet list of perks: saving events, following people/tags, and posting events

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-icons)*

------
https://chatgpt.com/codex/tasks/task_e_68952334ff30832c820de1259702dd7f