### PR TITLE
Add hero subheading to highlight account benefits

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -140,10 +140,14 @@ function App() {
             DIG INTO PHILLY
           </h1>
 
-          <div className="mt-4 border-b border-gray-200 pb-4">
-            <nav className="inline-flex items-center text-sm uppercase font-bold text-indigo-600">
-              {/* Big Board */}
-              <Link to="/board" className="flex items-center space-x-1 hover:underline">
+    <p className="text-xl text-gray-700 text-center mt-2">
+      Create a free account to save events, follow hosts, and get a daily e-mail digest.
+    </p>
+
+    <div className="mt-4 border-b border-gray-200 pb-4">
+      <nav className="inline-flex items-center text-sm uppercase font-bold text-indigo-600">
+        {/* Big Board */}
+        <Link to="/board" className="flex items-center space-x-1 hover:underline">
                 <span role="img" aria-label="bulletin board">📌</span>
                 <span>Big Board</span>
                 <span className="bg-yellow-400 text-white text-[10px] font-bold px-1 rounded">NEW</span>


### PR DESCRIPTION
## Summary
- Add a new subheading below the "DIG INTO PHILLY" heading encouraging users to create a free account
- Style the subheading with Tailwind classes for readability and alignment

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: 146 problems; console not defined, missing deps, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689530dafc94832c8acbddbe05ce7115