### PR TITLE
Link to Philly traditions in events header

### DIFF
--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -962,6 +962,12 @@ if (loading) {
     : base
 }
 
+// derive tradition names and slugs for display
+const traditionNamesAndSlugs = traditionEvents.map(ev => ({
+  name: ev.title,
+  slug: ev.slug,
+}));
+
 
 
     let pageTitle;
@@ -1098,6 +1104,17 @@ if (loading) {
   <h2 className="text-3xl font-semibold mb-4 text-[#28313e]">
     {headerText}
   </h2>
+
+  {traditionNamesAndSlugs.length > 0 && (
+    <p className="mb-4 text-[#28313e]">
+      The traditions? {traditionNamesAndSlugs.map((t, idx) => (
+        <React.Fragment key={t.slug}>
+          <Link to={`/events/${t.slug}`}>{t.name}</Link>
+          {idx < traditionNamesAndSlugs.length - 1 ? ', ' : ''}
+        </React.Fragment>
+      ))}
+    </p>
+  )}
 
   {!loading && (
     <>


### PR DESCRIPTION
## Summary
- compute tradition names and slugs for the current view
- list linked tradition events below the headline when available

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid option '--ext')
- `npx eslint .` (fails: 144 errors, 2 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68962cf1b718832cbdecd0d3a9000bae