### PR TITLE
feat: highlight tradition events with star badge

### DIFF
--- a/src/EventsGrid.jsx
+++ b/src/EventsGrid.jsx
@@ -1,6 +1,7 @@
 // src/EventsGrid.jsx
 import React, { useEffect, useState } from 'react';
 import { supabase } from './supabaseClient';
+import { FaStar } from 'react-icons/fa';
 
 const EventsGrid = ({ neighborhood }) => {
   const [events, setEvents] = useState([]);
@@ -101,6 +102,12 @@ const EventsGrid = ({ neighborhood }) => {
                     <div className="absolute top-3 left-3 bg-black text-white text-sm font-bold px-3 py-1 rounded-full">
                       {tag}
                     </div>
+                    {evt.isTradition && (
+                      <div className="absolute top-3 right-3 border-2 border-yellow-400 bg-yellow-100 text-yellow-800 text-xs font-bold px-2 py-1 rounded-full flex items-center gap-1">
+                        <FaStar className="text-yellow-500" />
+                        Tradition
+                      </div>
+                    )}
                   </div>
                   <div className="p-8 flex flex-col justify-center flex-grow">
                     <h3 className="text-2xl md:text-3xl font-bold text-indigo-800 mb-4 line-clamp-2 text-center">

--- a/src/HeroLanding.jsx
+++ b/src/HeroLanding.jsx
@@ -4,6 +4,7 @@ import { supabase } from './supabaseClient';
 import { AuthContext } from './AuthProvider';
 import { Link, useNavigate } from 'react-router-dom';
 import useEventFavorite from './utils/useEventFavorite';
+import { FaStar } from 'react-icons/fa';
 
 function FavoriteState({ event_id, source_table, children }) {
   const state = useEventFavorite({ event_id, source_table });
@@ -154,6 +155,11 @@ export default function HeroLanding() {
                                 In the plans!
                               </div>
                             )}
+
+                            <div className="absolute bottom-3 right-3 border-2 border-yellow-400 bg-yellow-100 text-yellow-800 text-xs font-bold px-2 py-1 rounded-full z-20 flex items-center gap-1">
+                              <FaStar className="text-yellow-500" />
+                              Tradition
+                            </div>
 
                             <h3 className="absolute bottom-16 left-4 right-4 text-center text-white text-3xl font-[Barrio] font-bold z-20 leading-tight">
                               {evt['E Name']}

--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -30,6 +30,7 @@ import 'mapbox-gl/dist/mapbox-gl.css'
 import RecurringEventsScroller from './RecurringEventsScroller'
 import useEventFavorite from './utils/useEventFavorite.js'
 import { AuthContext } from './AuthProvider'
+import { FaStar } from 'react-icons/fa';
 
 
 
@@ -788,10 +789,10 @@ useEffect(() => {
   // Big Board first, then Traditions, then All Events
 const allPagedEvents = [
     ...bigBoardEvents,
-    ...sportsEvents,
-    ...recurringOccs,  
     ...traditionEvents,
-    ...groupEvents, 
+    ...sportsEvents,
+    ...recurringOccs,
+    ...groupEvents,
     ...events
   ].slice((page - 1) * EVENTS_PER_PAGE, page * EVENTS_PER_PAGE);
 
@@ -1201,7 +1202,8 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
                   </div>
                 )}
                 {evt.isTradition && (
-                  <div className="absolute inset-x-0 bottom-0 bg-yellow-500 text-white text-xs uppercase text-center py-1">
+                  <div className="absolute inset-x-0 bottom-0 border-2 border-yellow-400 bg-yellow-100 text-yellow-800 text-xs uppercase font-semibold text-center py-1 flex items-center justify-center gap-1">
+                    <FaStar className="text-yellow-500" />
                     Tradition
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Reorder paged events so traditions follow big board submissions
- Give tradition events a star badge with border to stand out
- Add the star-styled badge to HeroLanding and EventsGrid for consistency

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: console is not defined in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689644647664832cb93279a02b7109c2