### PR TITLE
feat: highlight upcoming traditions on homepage

### DIFF
--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -19,12 +19,12 @@ import SportsEventsGrid from './SportsEventsGrid';
 import SeasonalEventsGrid from './SeasonalEvents';
 import FloatingAddButton from './FloatingAddButton'
 import PostFlyerModal from './PostFlyerModal'
-import TriviaTonightBanner from './TriviaTonightBanner';
 import TrendingTags from './TrendingTags';
 import NewsletterSection from './NewsletterSection';
 import { Share2 } from 'lucide-react';
 import { RRule } from 'rrule';
 import TaggedEventScroller from './TaggedEventsScroller';
+import UpcomingTraditionsScroller from './UpcomingTraditionsScroller';
 const EventsMap = lazy(() => import('./EventsMap'));
 import 'mapbox-gl/dist/mapbox-gl.css'
 import RecurringEventsScroller from './RecurringEventsScroller'
@@ -995,11 +995,11 @@ if (loading) {
       return (
         <>
           <Helmet>
-            <title>Build Your Philly Digest | Our Philly</title>
+            <title>Make Your Philly Plans | Our Philly</title>
             <link rel="icon" type="image/x-icon" href="/favicon.ico" />
             <meta
               name="description"
-              content="Subscribe to your personalized Philly digest—get a daily roundup of the best events, traditions, and community happenings delivered straight to your inbox."
+              content="Discover events and add them to your plans, subscribe to tags for daily e-mail roundups of what's coming, and more."
             />
           </Helmet>
       
@@ -1010,16 +1010,16 @@ if (loading) {
             </div>
       
             {/* Hero */}
-            <div className="relative w-full max-w-screen-3xl mx-auto pt-14 text-center overflow-hidden">
+            <div className="relative w-full max-w-screen-3xl mx-auto pt-14 text-center overflow-hidden bg-gray-50">
               {/* falling pills background */}
               <FallingPills  />
       
               <div className="relative inline-block text-center z-10">
                 <h1 className="text-6xl sm:text-5xl md:text-8xl font-[Barrio] font-black text-indigo-900 mb-4">
-                  Build Your Philly Digest
+                  Make Your Philly Plans
                 </h1>
                 <p className="text-lg sm:text-xl text-gray-700 max-w-2xl mx-auto">
-                  Pick your favorite tags and get a curated daily email of Philly’s top events, traditions, and community happenings.
+                  Discover events and add them to your plans, subscribe to tags for daily e-mail roundups of what's coming, and more.
                 </p>
                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none -z-10">
                   <span className="absolute w-full h-px bg-white opacity-20" />
@@ -1031,10 +1031,14 @@ if (loading) {
                 </div>
               </div>
       
-              <div className="max-w-screen-xl mx-auto px-4 py-2 z-10">
+              <div className="max-w-screen-xl mx-auto px-4 py-2 z-10 text-left">
                 <TrendingTags />
-                <TriviaTonightBanner />
+                <UpcomingTraditionsScroller />
               </div>
+            </div>
+
+            <div className="mt-12 text-center">
+              <h2 className="text-4xl sm:text-5xl font-[Barrio] font-black text-indigo-900">PICK YOUR DATES!</h2>
             </div>
 
             {/* ─── Pills + Date Picker + Event Count ─── */}

--- a/src/TrendingTags.jsx
+++ b/src/TrendingTags.jsx
@@ -40,7 +40,7 @@ export default function TrendingTags() {
   if (!tags.length) return null
 
   return (
-    <div className="container mx-auto px-2 py-3 bg-white rounded-lg shadow-sm">
+    <div className="container mx-auto px-2 py-3 bg-gray-50 rounded-lg shadow-sm">
       <div className="flex items-center">
         {/* fixed label */}
         <span className="text-sm sm:text-xl font-bold text-gray-700 mr-4 flex-shrink-0">

--- a/src/UpcomingTraditionsScroller.jsx
+++ b/src/UpcomingTraditionsScroller.jsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState, useContext } from 'react';
+import { supabase } from './supabaseClient';
+import { AuthContext } from './AuthProvider';
+import { Link, useNavigate } from 'react-router-dom';
+import useEventFavorite from './utils/useEventFavorite';
+import { FaStar } from 'react-icons/fa';
+
+function FavoriteState({ event_id, source_table, children }) {
+  const state = useEventFavorite({ event_id, source_table });
+  return children(state);
+}
+
+export default function UpcomingTraditionsScroller() {
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const parseDate = datesStr => {
+    if (!datesStr) return null;
+    const [first] = datesStr.split(/through|–|-/);
+    const parts = first.trim().split('/');
+    if (parts.length !== 3) return null;
+    const [m, d, y] = parts.map(Number);
+    const dt = new Date(y, m - 1, d);
+    return isNaN(dt) ? null : dt;
+  };
+
+  const relativeDayLabel = (start, end) => {
+    if (!start) return '';
+    const today = new Date(); today.setHours(0, 0, 0, 0);
+    const s = new Date(start); s.setHours(0, 0, 0, 0);
+    const e = end ? new Date(end) : s; e.setHours(0, 0, 0, 0);
+
+    if (today >= s && today <= e) return 'Today';
+    const diff = Math.floor((s - today) / 86400000);
+    if (diff === 1) return 'Tomorrow';
+    const weekday = s.toLocaleDateString('en-US', { weekday: 'long' });
+    if (diff > 1 && diff < 7) return `This ${weekday}`;
+    if (diff >= 7 && diff < 14) return `Next ${weekday}`;
+    return weekday;
+  };
+
+  useEffect(() => {
+    (async () => {
+      const today = new Date(); today.setHours(0, 0, 0, 0);
+      const { data, error } = await supabase
+        .from('events')
+        .select(`id, slug, "E Name", Dates, "End Date", "E Image"`)
+        .order('Dates', { ascending: true });
+      if (error) {
+        console.error('Error loading events:', error);
+        setLoading(false);
+        return;
+      }
+      const upcoming = data
+        .map(e => {
+          const start = parseDate(e.Dates);
+          if (!start) return null;
+          const end = e['End Date'] ? parseDate(e['End Date']) : start;
+          if (!end) return null;
+          return { ...e, start, end };
+        })
+        .filter(e => e && e.end >= today)
+        .sort((a, b) => a.start - b.start)
+        .slice(0, 20);
+      setEvents(upcoming);
+      setLoading(false);
+    })();
+  }, []);
+
+  return (
+    <div className="mt-8">
+      <h3 className="text-xl font-[Barrio] text-indigo-900 mb-1">HIGHLIGHT: Upcoming Philly Traditions</h3>
+      <p className="text-gray-700 mb-4">These events happen every year and are coming up!</p>
+      {loading ? (
+        <p className="text-center">Loading…</p>
+      ) : !events.length ? (
+        <p className="text-center">No upcoming traditions.</p>
+      ) : (
+        <div className="overflow-x-auto scrollbar-hide">
+          <div className="flex gap-4 pb-2">
+            {events.map(evt => (
+              <FavoriteState key={evt.id} event_id={evt.id} source_table="events">
+                {({ isFavorite, toggleFavorite, loading }) => {
+                  const handleToggle = async e => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (!user) {
+                      navigate('/login');
+                      return;
+                    }
+                    await toggleFavorite();
+                  };
+                  return (
+                    <div className="w-40 flex-shrink-0 flex flex-col">
+                      <Link
+                        to={`/events/${evt.slug}`}
+                        className={`block relative w-full h-24 rounded-lg overflow-hidden shadow ${
+                          isFavorite ? 'ring-2 ring-indigo-600' : ''
+                        }`}
+                      >
+                        <img src={evt['E Image']} alt={evt['E Name']} className="w-full h-full object-cover" />
+                        <div className="absolute top-1 left-1 bg-yellow-400 text-white p-1 rounded-full">
+                          <FaStar className="w-3 h-3" />
+                        </div>
+                      </Link>
+                      <div className="mt-2 h-20 flex flex-col items-center justify-between text-center">
+                        <h4 className="text-sm font-semibold text-gray-800 line-clamp-2">{evt['E Name']}</h4>
+                        <p className="text-xs text-gray-500">{relativeDayLabel(evt.start, evt.end)}</p>
+                      </div>
+                      <button
+                        onClick={handleToggle}
+                        disabled={loading}
+                        className={`mt-2 w-full border border-indigo-600 rounded-md py-1 text-xs font-semibold transition-colors ${
+                          isFavorite
+                            ? 'bg-indigo-600 text-white'
+                            : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'
+                        }`}
+                      >
+                        {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                      </button>
+                    </div>
+                  );
+                }}
+              </FavoriteState>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- refresh homepage hero copy and styling
- add upcoming traditions scroller with centered cards and relative date labels
- insert "PICK YOUR DATES!" heading before main event filters
- remove trivia banner from hero
- refine tradition date labels to match HeroLanding and sync trending tag background color
- add purple ring to upcoming tradition cards when added to plans

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: 147 problems)*


------
https://chatgpt.com/codex/tasks/task_e_6896641970e4832c871962fa86f81b22