### PR TITLE
Add traditions FAQ page and notice for event pages

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -19,6 +19,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://ourphilly.org/traditions-faq</loc>
+    <lastmod>2025-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://ourphilly.org/music-hall-at-world-cafe-live/the-quincy-jones-experience</loc>
     <lastmod>2025-06-17</lastmod>
     <changefreq>weekly</changefreq>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -23,6 +23,7 @@ const staticPages = [
   { path: '/',        priority: '1.0', changefreq: 'daily'   },
   { path: '/groups',  priority: '0.6', changefreq: 'weekly'  },
   { path: '/contact', priority: '0.6', changefreq: 'monthly' },
+  { path: '/traditions-faq', priority: '0.6', changefreq: 'monthly' },
 ]
 
 async function buildSitemap() {

--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -466,6 +466,13 @@ export default function EventDetailPage() {
           </div>
         </div>
 
+        {/* Traditions FAQ notice */}
+        <div className="max-w-4xl mx-auto mt-10 px-4">
+          <div className="bg-indigo-50 border border-indigo-200 text-indigo-800 text-center rounded-md p-4">
+            <a href="/traditions-faq" onClick={() => window.gtag && window.gtag('event', 'cta_click', { event_category: 'traditions_faq', event_label: 'events_page_notice' })} className="font-medium underline">Do you manage this Philly tradition? Read our FAQ for traditions hosts</a>
+          </div>
+        </div>
+
         {/* Reviews */}
         <section className="max-w-4xl mx-auto py-10 px-4">
           <h2 className="text-3xl sm:text-4xl font-[Barrio] text-gray-800 mb-8">Reviews</h2>

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -32,8 +32,18 @@ const Footer = () => {
           <p className="text-xs text-gray-500">&copy; {year} Our Philly. All rights reserved.</p>
         </div>
 
+        {/* Help nav */}
+        <div>
+          <h3 className="text-lg font-semibold text-white mb-3">Help</h3>
+          <ul className="space-y-2">
+            <li>
+              <a href="/traditions-faq" className="text-sm text-gray-400 hover:text-white">Traditions Hosts FAQ</a>
+            </li>
+          </ul>
+        </div>
+
         {/* empty spacer to align heart */}
-        <div className="col-span-1 md:col-span-2" />
+        <div className="col-span-1 md:col-span-1" />
       </div>
     </footer>
   );

--- a/src/TraditionsFAQ.jsx
+++ b/src/TraditionsFAQ.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import UpcomingTraditionsScroller from './UpcomingTraditionsScroller';
+
+export default function TraditionsFAQ() {
+  const heartUrl = 'https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images/OurPhilly-CityHeart-1.png';
+  return (
+    <div className="min-h-screen bg-neutral-50 flex flex-col">
+      <Helmet>
+        <title>Traditions Hosts FAQ | Our Philly</title>
+        <meta name="description" content="Quick FAQ for organizers of Philly’s annual traditions—photo reviews, Add to Plans, site placement, and support." />
+      </Helmet>
+      <Navbar />
+      <main className="flex-grow">
+        <section className="pt-24 pb-16 px-4 max-w-3xl mx-auto text-center">
+          <img src={heartUrl} alt="Our Philly heart logo" width="120" height="120" className="mx-auto mb-6" />
+          <h1 className="text-4xl sm:text-5xl font-[Barrio] text-indigo-900 mb-4">Traditions Hosts FAQ</h1>
+          <p className="text-lg text-gray-700 mb-12">For organizers of Philly’s annual traditions (e.g., Broad Street Run, Danny Rumph Classic).</p>
+          <div className="space-y-4 text-left">
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">What is a “Tradition” page?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">A special page for any event that happens every year in Philadelphia. It has a custom layout, a photo-review gallery, and <strong>Description</strong> + <strong>What to Expect</strong> sections written by Our Philly.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">How do photo reviews work?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Attendees post photos after your event; approved images appear in a scrolling gallery near the top.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">My page looks empty—how do I improve it?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Ask past attendees to add photo reviews from prior years to seed the gallery.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">What happens when someone taps “Add to Plans”?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Your event auto-reappears in that user’s Plans next year when the tradition returns.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">Where do Traditions appear on the site?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">They’re prioritized: at the top of the homepage, in homepage search results, and again toward the bottom—plus other featured spots.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">Is there any cost?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">No.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">I’m unhappy with my page or need edits/support—how do I reach you?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Email <a href="mailto:bill@ourphilly.org" className="text-indigo-700 underline">bill@ourphilly.org</a> or DM us on Instagram <a href="https://www.instagram.com/ourphillydotorg/" className="text-indigo-700 underline" target="_blank" rel="noopener noreferrer">@ourphillydotorg</a>.</p>
+            </details>
+          </div>
+        </section>
+        <section className="bg-neutral-100 py-16 px-4">
+          <h2 className="text-3xl font-[Barrio] text-indigo-900 text-center mb-8">Sample Upcoming Traditions</h2>
+          <div className="max-w-screen-xl mx-auto">
+            <UpcomingTraditionsScroller />
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -46,6 +46,7 @@ import GroupEventDetailPage from './GroupEventDetailPage.jsx';
 import ScrollToTop from './ScrollToTop'
 import TagPage from './TagPage.jsx'
 import ContactPage from './ContactPage.jsx'
+import TraditionsFAQ from './TraditionsFAQ.jsx'
 import RecurringPage from './RecurringEventPage.jsx'
 
 
@@ -111,6 +112,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/groups/:slug/events/:eventId" element={<GroupEventDetailPage />} />
           <Route path="/tags/:slug" element={<TagPage />} />
           <Route path="/contact" element={<ContactPage />} />
+          <Route path="/traditions-faq" element={<TraditionsFAQ />} />
           <Route path="/series/:slug/:date" element={<RecurringPage />} />
 
 


### PR DESCRIPTION
## Summary
- add `/traditions-faq` page with FAQ accordion and upcoming traditions scroller
- show CTA linking to FAQ above reviews on event pages
- link FAQ in footer and sitemap
- ensure FAQ accordion arrow and question appear on same line

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run generate-sitemap` *(fails: Missing SUPABASE_URL or SUPABASE_ANON_KEY/SUPABASE_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68968316b264832cbe7779531dcb207d