### PR TITLE
Remove Coming Soon text from tagged event scrollers

### DIFF
--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -701,17 +701,14 @@ export default function EventDetailPage() {
         <TaggedEventScroller
           tags={['nomnomslurp']}
           fullWidth
-          header={(
-            <>
-              <Link
-                to="/tags/nomnomslurp"
-                className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
-              >
-                #NomNomSlurp
-              </Link>
-              <span className="ml-4 text-xl">Upcoming</span>
-            </>
-          )}
+          header={
+            <Link
+              to="/tags/nomnomslurp"
+              className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
+            >
+              #NomNomSlurp
+            </Link>
+          }
         />
 
         <hr className="my-8 border-gray-200" />

--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -1235,47 +1235,38 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
             <TaggedEventScroller
               tags={['birds']}
               fullWidth
-              header={(
-                <>
-                  <Link
-                    to="/tags/birds"
-                    className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#FFD700] bg-[#FFD700] text-[#004C55] rounded-full"
-                  >
-                    #Birds
-                  </Link>
-                  <span className="ml-4 text-3xl sm:text-5xl font-[Barrio] text-[#004C55]">Coming Soon</span>
-                </>
-              )}
+              header={
+                <Link
+                  to="/tags/birds"
+                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#FFD700] bg-[#FFD700] text-[#004C55] rounded-full"
+                >
+                  #Birds
+                </Link>
+              }
             />
             <TaggedEventScroller
               tags={['arts']}
               fullWidth
-              header={(
-                <>
-                  <Link
-                    to="/tags/arts"
-                    className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
-                  >
-                    #Arts
-                  </Link>
-                  <span className="ml-4 text-3xl sm:text-5xl font-[Barrio] text-[#004C55]">Coming Soon</span>
-                </>
-              )}
+              header={
+                <Link
+                  to="/tags/arts"
+                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
+                >
+                  #Arts
+                </Link>
+              }
             />
             <TaggedEventScroller
               tags={['nomnomslurp']}
               fullWidth
-              header={(
-                <>
-                  <Link
-                    to="/tags/nomnomslurp"
-                    className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
-                  >
-                    #NomNomSlurp
-                  </Link>
-                  <span className="ml-4 text-3xl sm:text-5xl font-[Barrio] text-[#004C55]">Coming Soon</span>
-                </>
-              )}
+              header={
+                <Link
+                  to="/tags/nomnomslurp"
+                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
+                >
+                  #NomNomSlurp
+                </Link>
+              }
             />
             <RecurringEventsScroller windowStart={startOfWeek} windowEnd={endOfWeek} eventType="open_mic" header="Karaoke, Bingo, Open Mics Coming Up..." />
 

--- a/src/MainEventsDetail.jsx
+++ b/src/MainEventsDetail.jsx
@@ -702,17 +702,14 @@ export default function MainEventsDetail() {
             <TaggedEventScroller
               tags={['music']}
               fullWidth
-              header={(
-                <>
-                  <Link
-                    to="/tags/music"
-                    className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
-                  >
-                    #Music
-                  </Link>
-                  <span className="ml-4 text-xl">Coming Soon</span>
-                </>
-              )}
+              header={
+                <Link
+                  to="/tags/music"
+                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
+                >
+                  #Music
+                </Link>
+              }
             />
           {sameDayEvents.length > 0 && (
             <section className="max-w-4xl mx-auto mt-12 px-4">


### PR DESCRIPTION
## Summary
- Drop hardcoded "Coming Soon"/"Upcoming" labels from TaggedEventScroller headers
- Leave only the tag link so seasonal badges can appear beside it

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: Parsing errors and undefined variables)*

------
https://chatgpt.com/codex/tasks/task_e_6898911df780832cb77c049abc80c197