### PR TITLE
Add Groups FAQ page for group owners

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -25,6 +25,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://ourphilly.org/groups-faq</loc>
+    <lastmod>2025-06-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://ourphilly.org/music-hall-at-world-cafe-live/the-quincy-jones-experience</loc>
     <lastmod>2025-06-17</lastmod>
     <changefreq>weekly</changefreq>

--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -39,6 +39,9 @@ const Footer = () => {
             <li>
               <a href="/traditions-faq" className="text-sm text-gray-400 hover:text-white">Traditions Hosts FAQ</a>
             </li>
+            <li>
+              <a href="/groups-faq" className="text-sm text-gray-400 hover:text-white">Groups FAQ</a>
+            </li>
           </ul>
         </div>
 

--- a/src/GroupDetailPage.jsx
+++ b/src/GroupDetailPage.jsx
@@ -284,6 +284,11 @@ export default function GroupDetailPage() {
               </button>
             )}
           </div>
+          <div className="mt-2">
+            <a href="/groups-faq" className="text-sm text-indigo-700 underline">
+              Read our Groups FAQ
+            </a>
+          </div>
 
           {/* ── Add Event Form or Prompt ─────────────────────────────────── */}
           {user ? (

--- a/src/GroupsFAQ.jsx
+++ b/src/GroupsFAQ.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import PopularGroups from './PopularGroups.jsx';
+
+export default function GroupsFAQ() {
+  const heartUrl = 'https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images/OurPhilly-CityHeart-1.png';
+  return (
+    <div className="min-h-screen bg-neutral-50 flex flex-col">
+      <Helmet>
+        <title>Groups FAQ | Our Philly</title>
+        <meta name="description" content="Brief FAQ for Philly group owners—how to submit, claim pages, post events, and increase visibility on Our Philly." />
+      </Helmet>
+      <Navbar />
+      <main className="flex-grow">
+        <section className="pt-32 pb-16 px-4 max-w-3xl mx-auto text-center">
+          <img src={heartUrl} alt="Our Philly heart logo" width="120" height="120" className="mx-auto mb-6" />
+          <h1 className="text-4xl sm:text-5xl font-[Barrio] text-indigo-900 mb-4">Groups FAQ</h1>
+          <p className="text-lg text-gray-700 mb-12">For clubs, associations, neighborhood networks—any group in Philadelphia.</p>
+          <div className="space-y-4 text-left">
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">What is a “Group” on Our Philly?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Any club, association, or neighborhood network in Philadelphia. Submit your group and we’ll list it.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">How do I add my group?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Use the <a href="/groups" className="text-indigo-700 underline">Add Your Group</a> button on the Groups page. We’ll publish your page after a quick review.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">How do I claim my group page?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">On your group page, click <strong>Claim Group</strong>. We’ll verify ownership and make you the page owner.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">What can page owners do?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Create events on behalf of the group. Your group's events will appear in the homepage search results (group events appear first), on relevant tag pages (e.g., #family), and on your group page.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">How do people find my group?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Visitors browse the Groups page search or use Quick Match to pick tags/areas and get a tailored list.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">Does it cost anything?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">No.</p>
+            </details>
+            <details className="bg-white rounded-lg shadow p-4">
+              <summary className="cursor-pointer">
+                <h2 className="inline text-xl font-semibold text-gray-800">Need help or edits?</h2>
+              </summary>
+              <p className="mt-2 text-gray-700 leading-relaxed">Email <a href="mailto:bill@ourphilly.org" className="text-indigo-700 underline">bill@ourphilly.org</a> or DM <a href="https://www.instagram.com/ourphillydotorg/" className="text-indigo-700 underline" target="_blank" rel="noopener noreferrer">@ourphillydotorg</a> on Instagram.</p>
+            </details>
+          </div>
+          <p className="mt-12 text-gray-700">
+            Need more support? Email <a href="mailto:bill@ourphilly.org" className="text-indigo-700 underline">bill@ourphilly.org</a> or DM us on Instagram <a href="https://www.instagram.com/ourphillydotorg/" className="text-indigo-700 underline" target="_blank" rel="noopener noreferrer">@ourphillydotorg</a>.
+          </p>
+        </section>
+        <PopularGroups />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/GroupsPage.jsx
+++ b/src/GroupsPage.jsx
@@ -89,6 +89,12 @@ export default function GroupsPage() {
         <div className="pt-32">
           <GroupProgressBar />
 
+          <div className="bg-indigo-100 text-center py-3 mt-4">
+            <a href="/groups-faq" className="text-indigo-700 underline text-lg">
+              Read our Groups FAQ
+            </a>
+          </div>
+
           {/* Match Wizard Promo Section */}
           <div className="bg-indigo-50 border-b border-indigo-100">
             <div className="max-w-screen-xl mx-auto px-4 py-8">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -47,6 +47,7 @@ import ScrollToTop from './ScrollToTop'
 import TagPage from './TagPage.jsx'
 import ContactPage from './ContactPage.jsx'
 import TraditionsFAQ from './TraditionsFAQ.jsx'
+import GroupsFAQ from './GroupsFAQ.jsx'
 import RecurringPage from './RecurringEventPage.jsx'
 
 
@@ -113,6 +114,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/tags/:slug" element={<TagPage />} />
           <Route path="/contact" element={<ContactPage />} />
           <Route path="/traditions-faq" element={<TraditionsFAQ />} />
+          <Route path="/groups-faq" element={<GroupsFAQ />} />
           <Route path="/series/:slug/:date" element={<RecurringPage />} />
 
 


### PR DESCRIPTION
## Summary
- refine Groups FAQ content to reference "Add Your Group" and consolidate owner capabilities with event visibility
- add a centered notification bar on the groups index and simplify group detail page notice text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: 'console' is not defined and other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7a7f644832cbaceada527bb39ad