### PR TITLE
Streamline sharing on traditions pages

### DIFF
--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -513,6 +513,14 @@ export default function EventDetailPage() {
                 {isFavorite ? 'In the Plans' : 'Add to Plans'}
               </button>
             </div>
+            <div className="mb-6">
+              <button
+                onClick={handleShare}
+                className="w-full border border-gray-300 rounded-md py-3 font-semibold text-gray-700 hover:bg-gray-100"
+              >
+                Tell Somebody
+              </button>
+            </div>
           </div>
           <div>
             {event['E Image'] && (


### PR DESCRIPTION
## Summary
- Remove dedicated Traditions Card page and routing
- Keep prominent "Tell Somebody" button on event details for sharing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68990602ba7c832cbd75f1c15413b7cc