### PR TITLE
Ensure plans card exports as 1080x1080 square

### DIFF
--- a/src/UpcomingPlansCard.jsx
+++ b/src/UpcomingPlansCard.jsx
@@ -251,13 +251,16 @@ export default function UpcomingPlansCard() {
 
   const handleShare = async network => {
     void network;
-    const card = document.getElementById('plans-card-wrapper');
+    // Export only the inner square card so the resulting image is 1080×1080
+    const card = document.getElementById('plans-card');
     if (!card) return;
     try {
       const { toBlob } = await import('https://esm.sh/html-to-image');
       const cleanup = await embedImages(card);
       const blob = await toBlob(card, {
         pixelRatio: 2,
+        width: 1080,
+        height: 1080,
         cacheBust: true,
         // Exclude elements (like the close and share buttons) marked with data-no-export
         filter: node => !(node instanceof HTMLElement && node.dataset.noExport !== undefined),


### PR DESCRIPTION
## Summary
- Capture the inner plans card during sharing
- Export with explicit 1080x1080 dimensions for square image output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6899f5879b80832c8a58c98cdf837174