### PR TITLE
Ensure plans card exports as 1080x1080 square

### DIFF
--- a/src/UpcomingPlansCard.jsx
+++ b/src/UpcomingPlansCard.jsx
@@ -251,13 +251,16 @@ export default function UpcomingPlansCard() {
 
   const handleShare = async network => {
     void network;
-    const card = document.getElementById('plans-card-wrapper');
+    // Export only the inner square card so the resulting image is 1080×1080
+    const card = document.getElementById('plans-card');
     if (!card) return;
     try {
       const { toBlob } = await import('https://esm.sh/html-to-image');
       const cleanup = await embedImages(card);
       const blob = await toBlob(card, {
         pixelRatio: 2,
+        width: 1080,
+        height: 1080,
         cacheBust: true,
         // Exclude elements (like the close and share buttons) marked with data-no-export
         filter: node => !(node instanceof HTMLElement && node.dataset.noExport !== undefined),
@@ -309,11 +312,12 @@ export default function UpcomingPlansCard() {
         </button>
         <div
           id="plans-card-wrapper"
-          className="relative bg-white w-[540px] max-w-full aspect-[9/16] flex items-center justify-center"
+          className="relative bg-white flex items-center justify-center"
+          style={{ width: 'min(540px, 100vw, 100vh)', height: 'min(540px, 100vw, 100vh)' }}
         >
           <div
             id="plans-card"
-            className="relative bg-white w-full aspect-square rounded-lg shadow flex flex-col px-8 pt-6 pb-0 overflow-hidden"
+            className="relative bg-white w-full h-full rounded-lg shadow flex flex-col px-8 pt-6 pb-0 overflow-hidden"
           >
           <header className="flex items-center gap-2 mb-3">
             <img src={logoUrl} alt="Our Philly" className="h-8" crossOrigin="anonymous" />


### PR DESCRIPTION
## Summary
- Capture the inner plans card during sharing
- Export with explicit 1080x1080 dimensions for square image output
- Scale plans card wrapper to the smaller of 540px, viewport width, or viewport height so the entire card is visible on any screen size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6899f5879b80832c8a58c98cdf837174