### PR TITLE
Fix plans card sizing and export

### DIFF
--- a/src/UpcomingPlansCard.jsx
+++ b/src/UpcomingPlansCard.jsx
@@ -5,6 +5,7 @@ import { RRule } from 'rrule';
 import { FaTwitter, FaFacebook, FaInstagram, FaTiktok } from 'react-icons/fa';
 
 const logoUrl = 'https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images//logoo.png';
+const MAX_EVENTS = 10;
 
 function parseEventsDateRange(startStr, explicitEnd) {
   if (!startStr) return { start: null, end: null };
@@ -47,6 +48,17 @@ export default function UpcomingPlansCard() {
   const [profile, setProfile] = useState(null);
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [cardSize, setCardSize] = useState(() =>
+    Math.min(window.innerWidth, window.innerHeight - 120)
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setCardSize(Math.min(window.innerWidth, window.innerHeight - 120));
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   useEffect(() => {
     if (!slug) return;
@@ -201,7 +213,7 @@ export default function UpcomingPlansCard() {
         })
         .filter(ev => ev._date && ev._end && ev._end >= today)
         .sort((a, b) => a._date - b._date)
-        .slice(0, 10)
+        .slice(0, MAX_EVENTS)
         .map(({ _date, _end, ...rest }) => rest);
 
       setEvents(upcoming);
@@ -257,10 +269,10 @@ export default function UpcomingPlansCard() {
     try {
       const { toBlob } = await import('https://esm.sh/html-to-image');
       const cleanup = await embedImages(card);
+      const width = card.getBoundingClientRect().width;
+      const scale = 1080 / width;
       const blob = await toBlob(card, {
-        pixelRatio: 2,
-        width: 1080,
-        height: 1080,
+        pixelRatio: scale,
         cacheBust: true,
         // Exclude elements (like the close and share buttons) marked with data-no-export
         filter: node => !(node instanceof HTMLElement && node.dataset.noExport !== undefined),
@@ -292,50 +304,46 @@ export default function UpcomingPlansCard() {
   }
 
   return (
-    <div className="min-h-screen bg-white flex flex-col items-center justify-center py-8">
-      <div className="mb-4 flex justify-center" data-no-export>
-        <button
-          onClick={() => navigate(-1)}
-          className="text-gray-500 hover:text-gray-700 text-sm"
-        >
-          Go Back
-        </button>
-      </div>
-      <div className="relative">
-        <button
-          onClick={() => navigate(-1)}
-          className="absolute -top-4 -right-4 text-gray-500 hover:text-gray-700"
-          aria-label="Close"
-          data-no-export
-        >
-          ×
-        </button>
+    <div className="min-h-screen bg-white flex flex-col items-center justify-center p-4">
+      <button
+        onClick={() => navigate(-1)}
+        className="mb-4 px-6 py-2 text-lg font-semibold bg-blue-600 text-white rounded"
+        data-no-export
+      >
+        Go Back
+      </button>
+      <div
+        id="plans-card-wrapper"
+        className="flex items-center justify-center"
+        style={{ width: cardSize, height: cardSize }}
+      >
         <div
-          id="plans-card-wrapper"
-          className="relative bg-white w-[540px] max-w-full aspect-[9/16] flex items-center justify-center"
+          id="plans-card"
+          className="relative bg-white w-full h-full rounded-lg shadow flex flex-col px-8 pt-6 pb-4 overflow-hidden"
         >
-          <div
-            id="plans-card"
-            className="relative bg-white w-full aspect-square rounded-lg shadow flex flex-col px-8 pt-6 pb-0 overflow-hidden"
-          >
-          <header className="flex items-center gap-2 mb-3">
+          <header className="flex items-center gap-2 mb-4">
             <img src={logoUrl} alt="Our Philly" className="h-8" crossOrigin="anonymous" />
-            <span className="text-[10px] text-gray-600">Make your Philly plans at ourphilly.org</span>
+            <span className="text-xs text-gray-600">Make your Philly plans at ourphilly.org</span>
           </header>
-        <div className="flex flex-col items-center mb-2">
-          <span className="text-sm font-semibold">{profile.username || profile.slug}</span>
+        <div className="flex flex-col items-center mb-4">
+          <span className="text-base font-semibold">{profile.username || profile.slug}</span>
         </div>
         {events.length === 0 ? (
           <div className="flex-1 flex items-center justify-center text-gray-500 text-sm">No upcoming events saved.</div>
         ) : (
           <>
-            <div className="text-center text-xs uppercase tracking-wide text-gray-500 border-b pb-1 mb-2">
+            <div className="text-center text-sm uppercase tracking-wide text-gray-500 border-b pb-2 mb-4">
               Upcoming plans
             </div>
-            <ul className="flex-1 divide-y text-xs">
+            <ul className="divide-y">
               {events.map(ev => (
-                <li key={`${ev.source_table}-${ev.id}`} className="py-1 truncate">
-                  {ev.title} - {ev.displayDate}
+                <li key={`${ev.source_table}-${ev.id}`} className="py-2">
+                  <div className="text-base font-medium leading-snug break-words">
+                    {ev.title}
+                  </div>
+                  <div className="text-sm text-gray-500">
+                    {ev.displayDate}
+                  </div>
                 </li>
               ))}
             </ul>
@@ -347,22 +355,21 @@ export default function UpcomingPlansCard() {
           className="w-16 self-start mt-2 block"
           crossOrigin="anonymous"
         />
-        <div className="flex justify-center gap-4 mt-4 pb-4" data-no-export>
-          <button onClick={() => handleShare('twitter')} aria-label="Share to Twitter">
-            <FaTwitter className="text-sky-500" />
-          </button>
-          <button onClick={() => handleShare('facebook')} aria-label="Share to Facebook">
-            <FaFacebook className="text-blue-600" />
-          </button>
-          <button onClick={() => handleShare('instagram')} aria-label="Share to Instagram Stories">
-            <FaInstagram className="text-pink-500" />
-          </button>
-          <button onClick={() => handleShare('tiktok')} aria-label="Share to TikTok">
-            <FaTiktok className="text-black" />
-          </button>
         </div>
-          </div>
-        </div>
+      </div>
+      <div className="flex justify-center gap-4 mt-4" data-no-export>
+        <button onClick={() => handleShare('twitter')} aria-label="Share to Twitter">
+          <FaTwitter className="text-sky-500" />
+        </button>
+        <button onClick={() => handleShare('facebook')} aria-label="Share to Facebook">
+          <FaFacebook className="text-blue-600" />
+        </button>
+        <button onClick={() => handleShare('instagram')} aria-label="Share to Instagram Stories">
+          <FaInstagram className="text-pink-500" />
+        </button>
+        <button onClick={() => handleShare('tiktok')} aria-label="Share to TikTok">
+          <FaTiktok className="text-black" />
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Show at most 10 upcoming events so card height stays predictable
- Enlarge typography and spacing, allowing titles to wrap over two lines and dates on their own line to reduce blank space
- (previous commits) Ensure upcoming plans card fits on screen and exports clean square images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npx eslint src/UpcomingPlansCard.jsx` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_689a1c313874832c88e06acb7d53af13