### PR TITLE
Fix plans card sizing and export

### DIFF
--- a/src/UpcomingPlansCard.jsx
+++ b/src/UpcomingPlansCard.jsx
@@ -5,6 +5,7 @@ import { RRule } from 'rrule';
 import { FaTwitter, FaFacebook, FaInstagram, FaTiktok } from 'react-icons/fa';
 
 const logoUrl = 'https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images//logoo.png';
+const MAX_EVENTS = 10;
 
 function parseEventsDateRange(startStr, explicitEnd) {
   if (!startStr) return { start: null, end: null };
@@ -201,7 +202,7 @@ export default function UpcomingPlansCard() {
         })
         .filter(ev => ev._date && ev._end && ev._end >= today)
         .sort((a, b) => a._date - b._date)
-        .slice(0, 10)
+        .slice(0, MAX_EVENTS)
         .map(({ _date, _end, ...rest }) => rest);
 
       setEvents(upcoming);
@@ -251,20 +252,22 @@ export default function UpcomingPlansCard() {
 
   const handleShare = async network => {
     void network;
-    // Export only the inner square card so the resulting image is 1080×1080
     const card = document.getElementById('plans-card');
     if (!card) return;
     try {
       const { toBlob } = await import('https://esm.sh/html-to-image');
       const cleanup = await embedImages(card);
+      const originalOverflow = card.style.overflow;
+      card.style.overflow = 'hidden';
+      card.scrollTop = 0;
+      const scale = 1080 / card.offsetWidth;
       const blob = await toBlob(card, {
-        pixelRatio: 2,
-        width: 1080,
-        height: 1080,
+        pixelRatio: scale,
         cacheBust: true,
         // Exclude elements (like the close and share buttons) marked with data-no-export
         filter: node => !(node instanceof HTMLElement && node.dataset.noExport !== undefined),
       });
+      card.style.overflow = originalOverflow;
       cleanup();
       if (!blob) throw new Error('image generation failed');
       const file = new File([blob], 'plans.png', { type: 'image/png' });
@@ -293,76 +296,70 @@ export default function UpcomingPlansCard() {
 
   return (
     <div className="min-h-screen bg-white flex flex-col items-center justify-center py-8">
-      <div className="mb-4 flex justify-center" data-no-export>
-        <button
-          onClick={() => navigate(-1)}
-          className="text-gray-500 hover:text-gray-700 text-sm"
-        >
-          Go Back
-        </button>
-      </div>
+      <button
+        onClick={() => navigate(-1)}
+        className="mb-4 px-6 py-2 text-lg font-semibold bg-blue-600 text-white rounded"
+        data-no-export
+      >
+        Go Back
+      </button>
       <div className="relative">
-        <button
-          onClick={() => navigate(-1)}
-          className="absolute -top-4 -right-4 text-gray-500 hover:text-gray-700"
-          aria-label="Close"
-          data-no-export
-        >
-          ×
-        </button>
         <div
           id="plans-card-wrapper"
           className="relative bg-white w-[540px] max-w-full aspect-[9/16] flex items-center justify-center"
         >
           <div
             id="plans-card"
-            className="relative bg-white w-full aspect-square rounded-lg shadow flex flex-col px-8 pt-6 pb-0 overflow-hidden"
+            className="relative bg-white w-full aspect-square rounded-lg shadow flex flex-col px-8 pt-6 pb-0 overflow-y-auto"
           >
-          <header className="flex items-center gap-2 mb-3">
-            <img src={logoUrl} alt="Our Philly" className="h-8" crossOrigin="anonymous" />
-            <span className="text-[10px] text-gray-600">Make your Philly plans at ourphilly.org</span>
-          </header>
-        <div className="flex flex-col items-center mb-2">
-          <span className="text-sm font-semibold">{profile.username || profile.slug}</span>
-        </div>
-        {events.length === 0 ? (
-          <div className="flex-1 flex items-center justify-center text-gray-500 text-sm">No upcoming events saved.</div>
-        ) : (
-          <>
-            <div className="text-center text-xs uppercase tracking-wide text-gray-500 border-b pb-1 mb-2">
-              Upcoming plans
+            <header className="flex items-center gap-2 mb-3">
+              <img src={logoUrl} alt="Our Philly" className="h-8" crossOrigin="anonymous" />
+              <span className="text-[10px] text-gray-600">Make your Philly plans at ourphilly.org</span>
+            </header>
+            <div className="flex flex-col items-center mb-2">
+              <span className="text-sm font-semibold">{profile.username || profile.slug}</span>
             </div>
-            <ul className="flex-1 divide-y text-xs">
-              {events.map(ev => (
-                <li key={`${ev.source_table}-${ev.id}`} className="py-1 truncate">
-                  {ev.title} - {ev.displayDate}
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
-        <img
-          src="https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images/meet-gritty-formatted.png"
-          alt="Mascot"
-          className="w-16 self-start mt-2 block"
-          crossOrigin="anonymous"
-        />
-        <div className="flex justify-center gap-4 mt-4 pb-4" data-no-export>
-          <button onClick={() => handleShare('twitter')} aria-label="Share to Twitter">
-            <FaTwitter className="text-sky-500" />
-          </button>
-          <button onClick={() => handleShare('facebook')} aria-label="Share to Facebook">
-            <FaFacebook className="text-blue-600" />
-          </button>
-          <button onClick={() => handleShare('instagram')} aria-label="Share to Instagram Stories">
-            <FaInstagram className="text-pink-500" />
-          </button>
-          <button onClick={() => handleShare('tiktok')} aria-label="Share to TikTok">
-            <FaTiktok className="text-black" />
-          </button>
-        </div>
+            {events.length === 0 ? (
+              <div className="flex-1 flex items-center justify-center text-gray-500 text-sm">No upcoming events saved.</div>
+            ) : (
+              <>
+                <div className="text-center text-xs uppercase tracking-wide text-gray-500 border-b pb-1 mb-2">
+                  Upcoming plans
+                </div>
+                <ul className="divide-y">
+                  {events.map(ev => (
+                    <li key={`${ev.source_table}-${ev.id}`} className="py-2">
+                      <div className="text-base font-medium leading-snug break-words">
+                        {ev.title}
+                      </div>
+                      <div className="text-sm text-gray-500">{ev.displayDate}</div>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+            <img
+              src="https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images/meet-gritty-formatted.png"
+              alt="Mascot"
+              className="w-16 mt-auto self-start"
+              crossOrigin="anonymous"
+            />
           </div>
         </div>
+      </div>
+      <div className="flex justify-center gap-4 mt-4" data-no-export>
+        <button onClick={() => handleShare('twitter')} aria-label="Share to Twitter">
+          <FaTwitter className="text-sky-500" />
+        </button>
+        <button onClick={() => handleShare('facebook')} aria-label="Share to Facebook">
+          <FaFacebook className="text-blue-600" />
+        </button>
+        <button onClick={() => handleShare('instagram')} aria-label="Share to Instagram Stories">
+          <FaInstagram className="text-pink-500" />
+        </button>
+        <button onClick={() => handleShare('tiktok')} aria-label="Share to TikTok">
+          <FaTiktok className="text-black" />
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Allow scrolling through saved events on the plans card page
- Export a full 1080×1080 image without scrollbars and keep the mascot pinned at the bottom

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npx eslint -c eslint.config.js src/UpcomingPlansCard.jsx` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_689a1c313874832c88e06acb7d53af13