### PR TITLE
Refine social video and promo layout

### DIFF
--- a/src/AdminVideoPromo.jsx
+++ b/src/AdminVideoPromo.jsx
@@ -59,7 +59,7 @@ export default function AdminVideoPromo() {
   async function loadEvents() {
     const { data, error } = await supabase
       .from('events')
-      .select('id, "E Name", Dates, "E Image"')
+      .select('id, "E Name", Dates, "E Image", "E Description"')
       .order('Dates', { ascending: true });
     if (error) {
       console.error(error);
@@ -76,10 +76,12 @@ export default function AdminVideoPromo() {
           image: e['E Image'],
           date,
           displayDate: formatDisplayDate(date, time),
+          captionDate: formatDisplayDate(date, null),
+          description: e['E Description'],
         };
       })
       .filter(ev => ev.date && ev.date >= today)
-      .slice(0, 7);
+      .slice(0, 10);
     setEvents(upcoming);
   }
 
@@ -88,39 +90,52 @@ export default function AdminVideoPromo() {
   }
 
   return (
-    <div className="relative min-h-screen text-white">
-      <Navbar />
-      <video
-        className="absolute inset-0 w-full h-full object-cover"
-        src="https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images//13687405-hd_1080_1920_30fps.mp4"
-        autoPlay
-        loop
-        muted
-        playsInline
-      />
-      <div className="absolute inset-0 bg-black/50" />
-      <div className="relative z-10 pt-24 max-w-2xl mx-auto px-4">
-        <h1 className="text-center text-4xl font-[Barrio] mb-4">UPCOMING PHILLY TRADITIONS</h1>
-        {events.map(ev => (
-          <div
-            key={ev.id}
-            className="flex w-full items-center justify-center gap-3 py-2 border-b border-white/30 last:border-none"
-          >
-            {ev.image && (
-              <img
-                src={ev.image}
-                alt=""
-                className="w-20 h-12 object-cover rounded"
-              />
-            )}
-            <div className="text-left">
-              <div className="text-lg font-semibold text-gray-100">{ev.name}</div>
-              <div className="text-sm text-gray-300">{ev.displayDate}</div>
+    <>
+      <div className="relative min-h-screen text-white">
+        <Navbar />
+        <video
+          className="absolute inset-0 w-full h-full object-cover"
+          src="https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images//13687405-hd_1080_1920_30fps.mp4"
+          autoPlay
+          loop
+          muted
+          playsInline
+        />
+        <div className="absolute inset-0 bg-black/50" />
+        <div className="relative z-10 pt-36 max-w-2xl mx-auto px-4">
+          <h1 className="text-center text-4xl font-[Barrio] mb-1">Next 10 Philly Traditions</h1>
+          <p className="text-center text-xs mb-4">Make your Philly plans at ourphilly.org</p>
+          {events.map(ev => (
+            <div
+              key={ev.id}
+              className="flex w-full items-center justify-start gap-2 py-1 border-b border-white/30 last:border-none"
+            >
+              {ev.image && (
+                <img
+                  src={ev.image}
+                  alt=""
+                  className="w-16 h-10 object-cover rounded"
+                />
+              )}
+              <div className="text-left">
+                <div className="text-sm font-semibold text-gray-100">{ev.name}</div>
+                <div className="text-xs text-gray-300">{ev.displayDate}</div>
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
-    </div>
+      <div className="bg-white">
+        <div className="h-24" />
+        <div className="px-4 pb-24 text-sm text-gray-800">
+          {events.map(ev => (
+            <p key={ev.id} className="mb-2">
+              {`${ev.name} - ${ev.captionDate} - ${ev.description}`}
+            </p>
+          ))}
+        </div>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- make social-video tag pills more transparent and show only events from events table
- adjust admin video promo layout: start content below nav, smaller left-aligned items, add caption area beneath video
- extend video promo to show up to ten traditions, with repositioned headline and subheadline

## Testing
- `npm test` *(fails: Missing script: "test"*)
- `npm run lint` *(fails: Invalid option '--ext'*)
- `npx eslint .` *(fails: Parsing errors in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_689bad3e90d4832cb785325010405486