### PR TITLE
Limit video promo traditions to seven and add page-specific navbar offset

### DIFF
--- a/src/AdminVideoPromo.jsx
+++ b/src/AdminVideoPromo.jsx
@@ -81,7 +81,7 @@ export default function AdminVideoPromo() {
         };
       })
       .filter(ev => ev.date && ev.date >= today)
-      .slice(0, 10);
+      .slice(0, 7);
     setEvents(upcoming);
   }
 
@@ -92,7 +92,8 @@ export default function AdminVideoPromo() {
   return (
     <>
       <div className="relative min-h-screen text-white">
-        <Navbar />
+        <div className="fixed top-0 w-full h-1 bg-white z-50" />
+        <Navbar style={{ top: '4px' }} />
         <video
           className="absolute inset-0 w-full h-full object-cover"
           src="https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images//13687405-hd_1080_1920_30fps.mp4"
@@ -103,7 +104,7 @@ export default function AdminVideoPromo() {
         />
         <div className="absolute inset-0 bg-black/50" />
         <div className="relative z-10 pt-36 max-w-2xl mx-auto px-4">
-          <h1 className="text-center text-4xl font-[Barrio] mb-1">Next 10 Philly Traditions</h1>
+          <h1 className="text-center text-4xl font-[Barrio] mb-1">Upcoming Philly Traditions</h1>
           <p className="text-center text-xs mb-4">Make your Philly plans at ourphilly.org</p>
           {events.map(ev => (
             <div

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -8,7 +8,7 @@ import { AuthContext } from './AuthProvider';
 import { supabase } from './supabaseClient';
 import NavTagMenu from './NavTagMenu';
 
-export default function Navbar() {
+export default function Navbar({ style }) {
   const { user } = useContext(AuthContext);
   const location = useLocation();
   const navigate = useNavigate();
@@ -41,7 +41,7 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="fixed top-0 w-full bg-white shadow z-50">
+      <nav className="fixed top-0 w-full bg-white shadow z-50" style={style}>
         <div className="max-w-screen-xl mx-auto flex items-center justify-between h-20 px-4">
           {/* Logo */}
           <Link to="/" className="flex-shrink-0">


### PR DESCRIPTION
## Summary
- Show only the next seven traditions on the video promo page
- Rename video promo heading to "Upcoming Philly Traditions"
- Add a small white spacer bar above the navbar and allow Navbar to accept style overrides

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint src/AdminVideoPromo.jsx src/Navbar.jsx` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_689bba8fabf4832c9d41851b715b2ad3