### PR TITLE
feat: add community notices and big board page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ import RecentActivity from './RecentActivity';
 import BigBoardEventsGrid from './BigBoardEventsGrid';
 import CityHolidayAlert from './CityHolidayAlert';
 import MoreEventsBanner from './MoreEventsBanner';
+import CommunityNotices from './CommunityNotices';
 
 
 
@@ -127,11 +128,12 @@ function App() {
      
       
       <div className="overflow-x-hidden  min-h-screen flex flex-col bg-white-100 pt-20 relative">
-        <Navbar /> 
-        <CityHolidayAlert />
+      <Navbar />
+      <CityHolidayAlert />
+      <CommunityNotices />
 
 
-          
+
 <div className="relative flex flex-col md:flex-row items-center justify-center mt-12 mb-1">
   {/* we need a positioning context for the line + mascot */}
   <div className="relative inline-block text-center">
@@ -143,7 +145,7 @@ function App() {
           <div className="mt-4 border-b border-gray-200 pb-4">
             <nav className="inline-flex items-center text-sm uppercase font-bold text-indigo-600">
               {/* Big Board */}
-              <Link to="/board" className="flex items-center space-x-1 hover:underline">
+              <Link to="/big-board" className="flex items-center space-x-1 hover:underline">
                 <span role="img" aria-label="bulletin board">📌</span>
                 <span>Big Board</span>
                 <span className="bg-yellow-400 text-white text-[10px] font-bold px-1 rounded">NEW</span>

--- a/src/CommunityNotices.jsx
+++ b/src/CommunityNotices.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from './supabaseClient';
+
+export default function CommunityNotices() {
+  const [notices, setNotices] = useState([]);
+
+  useEffect(() => {
+    supabase
+      .from('community_bulletin_latest')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(3)
+      .then(({ data }) => setNotices(data || []));
+  }, []);
+
+  if (!notices.length) return null;
+
+  return (
+    <section className="max-w-3xl mx-auto mt-8 px-4">
+      <h2 className="text-2xl font-bold mb-4">Community Notices</h2>
+      <div className="space-y-4">
+        {notices.map(n => (
+          <div key={n.id} className="bg-white rounded-lg shadow p-4">
+            <Link to={`/groups/${n.group_slug}`} className="font-semibold text-indigo-600">
+              {n.group_name}
+            </Link>
+            <p className="mt-2">{n.content}</p>
+          </div>
+        ))}
+      </div>
+      <div className="text-right mt-4">
+        <Link to="/big-board" className="text-indigo-600 underline">
+          See more notices →
+        </Link>
+      </div>
+    </section>
+  );
+}
+

--- a/src/CommunityNoticesPage.jsx
+++ b/src/CommunityNoticesPage.jsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import { supabase } from './supabaseClient';
+
+export default function BigBoard() {
+  const [notices, setNotices] = useState([]);
+
+  useEffect(() => {
+    supabase
+      .from('community_bulletin_latest')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .then(({ data }) => setNotices(data || []));
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-amber-50 to-white">
+      <Helmet>
+        <title>Big Board | Our Philly</title>
+      </Helmet>
+      <Navbar />
+      <div className="max-w-2xl mx-auto px-4 pt-32 pb-16">
+        <h1 className="text-5xl font-[Barrio] text-center text-indigo-900">Big Board</h1>
+        <p className="text-center text-lg text-indigo-700 mt-2 mb-10">
+          A friendly neighborhood bulletin.{' '}
+          <Link to="/groups" className="underline font-semibold">
+            Visit a group page
+          </Link>{' '}
+          to leave your own notice.
+        </p>
+        <div className="space-y-4">
+          {notices.map(n => (
+            <div key={n.id} className="bg-white rounded-xl shadow p-5 border-l-4 border-indigo-500">
+              <div className="text-xs text-gray-500">{new Date(n.created_at).toLocaleDateString()}</div>
+              <Link
+                to={`/groups/${n.group_slug}`}
+                className="block text-lg font-semibold text-indigo-700"
+              >
+                {n.group_name}
+              </Link>
+              <p className="mt-1 text-gray-700">{n.content}</p>
+              <a
+                href={n.proof_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-indigo-600 text-sm underline mt-2 inline-block"
+              >
+                Proof
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/GroupDetailPage.jsx
+++ b/src/GroupDetailPage.jsx
@@ -11,6 +11,7 @@ import { getMyFavorites, addFavorite, removeFavorite } from './utils/favorites'
 import OutletsList from './OutletsList'
 import Voicemail from './Voicemail'
 import Footer from './Footer'
+import GroupNoticesSection from './GroupNoticesSection'
 
 export default function GroupDetailPage() {
   const { slug } = useParams()
@@ -350,6 +351,8 @@ export default function GroupDetailPage() {
           )}
         </div>
       </div>
+
+      <GroupNoticesSection groupId={group.id} />
 
       {/* ── Events Grid ──────────────────────────────────────────────────── */}
 <section className="mt-12 max-w-screen-xl mx-auto px-4">

--- a/src/GroupNoticesSection.jsx
+++ b/src/GroupNoticesSection.jsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from './supabaseClient';
+import { AuthContext } from './AuthProvider';
+
+export default function GroupNoticesSection({ groupId }) {
+  const { user } = useContext(AuthContext);
+  const [notices, setNotices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [content, setContent] = useState('');
+  const [proofUrl, setProofUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!groupId) return;
+    fetchNotices();
+  }, [groupId]);
+
+  async function fetchNotices() {
+    setLoading(true);
+    const { data } = await supabase
+      .from('group_notices')
+      .select('*')
+      .eq('group_id', groupId)
+      .eq('status', 'active')
+      .order('created_at', { ascending: false });
+    setNotices(data || []);
+    setLoading(false);
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!user) return;
+    const text = content.trim();
+    const url = proofUrl.trim();
+    if (!text || !url) return;
+    setSubmitting(true);
+    await supabase.from('group_notices').insert({
+      group_id: groupId,
+      user_id: user.id,
+      content: text,
+      proof_url: url,
+    });
+    setContent('');
+    setProofUrl('');
+    await fetchNotices();
+    setSubmitting(false);
+  }
+
+  async function handleDelete(id) {
+    await supabase.from('group_notices').delete().eq('id', id);
+    setNotices(n => n.filter(x => x.id !== id));
+  }
+
+  return (
+    <section className="max-w-screen-xl mx-auto mt-12 px-4">
+      <h2 className="text-2xl font-bold mb-4">Community Notices</h2>
+      {loading ? (
+        <p>Loading…</p>
+      ) : notices.length === 0 ? (
+        <p className="text-gray-500">No notices yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {notices.map(n => (
+            <div key={n.id} className="bg-white rounded-lg shadow p-4">
+              <p className="text-lg">{n.content}</p>
+              <a
+                href={n.proof_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-indigo-600 text-sm block mt-2"
+              >
+                Proof
+              </a>
+              <div className="text-xs text-gray-500 mt-2 flex justify-between">
+                <span>{new Date(n.created_at).toLocaleString()}</span>
+                {user?.id === n.user_id && (
+                  <button
+                    onClick={() => handleDelete(n.id)}
+                    className="text-red-500"
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {user ? (
+        <form onSubmit={handleSubmit} className="mt-6 space-y-2">
+          <textarea
+            value={content}
+            onChange={e => setContent(e.target.value)}
+            rows={3}
+            placeholder="Add a notice…"
+            className="w-full border rounded-lg p-2"
+          />
+          <input
+            type="url"
+            value={proofUrl}
+            onChange={e => setProofUrl(e.target.value)}
+            placeholder="Link to proof"
+            className="w-full border rounded-lg p-2"
+          />
+          <button
+            type="submit"
+            disabled={submitting}
+            className="bg-indigo-600 text-white px-4 py-2 rounded"
+          >
+            {submitting ? 'Posting…' : 'Post Notice'}
+          </button>
+        </form>
+      ) : (
+        <p className="mt-4 text-sm text-gray-600">
+          <Link to="/login" className="text-indigo-600 underline">
+            Log in
+          </Link>{' '}
+          to post a notice.
+        </p>
+      )}
+    </section>
+  );
+}
+

--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -30,6 +30,7 @@ import useEventFavorite from './utils/useEventFavorite.js'
 import { AuthContext } from './AuthProvider'
 import { FaStar } from 'react-icons/fa';
 import FallingPills from './FallingPills';
+import CommunityNotices from './CommunityNotices';
 
 
 
@@ -1303,6 +1304,7 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
       
             {/* ─── Recent Activity ─── */}
             <RecentActivity />
+            <CommunityNotices />
             <DigIntoPhillySection />
             <HeroLanding fullWidth />
             <TaggedEventScroller

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -38,6 +38,7 @@ import SocialVideoCarousel from './SocialVideoCarousel.jsx';
 import AdminVideoPromo from './AdminVideoPromo.jsx';
 import BigBoardEventPage  from './BigBoardEventPage';
 import BigBoardCarousel from './BigBoardCarousel.jsx';
+import BigBoard from './CommunityNoticesPage.jsx';
 import MainEvents from './MainEvents.jsx';
 import VenuePage from './VenuePage';
 import MainEventsDetail from './MainEventsDetail.jsx';
@@ -96,6 +97,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/privacy" element={<PrivacyPage />} />
           <Route path="/outlets/:slug" element={<OutletDetailPage />} />
           <Route path="/board" element={<BigBoardPage />} />
+          <Route path="/big-board" element={<BigBoard />} />
           <Route path="/admin/users" element={<AdminUsers />} />
           <Route path="/admin/reviews" element={<AdminReviews />} />
           <Route path="/admin/updates" element={<AdminGroupUpdates />} />


### PR DESCRIPTION
## Summary
- redesign the Big Board notices page with a friendly call to share updates and sleeker styling
- show latest community notices on the home page above the Dig Into Philly section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint src/CommunityNotices.jsx src/CommunityNoticesPage.jsx src/MainEvents.jsx` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_689cb40865a8832ca9cd93213c297e40