### PR TITLE
Adjust social video card height and tighten seasonal tag window

### DIFF
--- a/src/SocialVideoCarousel.jsx
+++ b/src/SocialVideoCarousel.jsx
@@ -224,7 +224,7 @@ export default function SocialVideoCarousel({ tag }) {
         Subscribe to #tags for your daily digest
       </div>
 
-      <div className="h-[calc(80vh+80px)] min-h-[400px] overflow-hidden relative z-10">
+      <div className="h-[calc(100vh-8rem)] flex-1 overflow-hidden relative z-10 pb-16">
         {loading ? (
           <p className="text-center py-20">Loading…</p>
         ) : (

--- a/src/utils/tagUtils.js
+++ b/src/utils/tagUtils.js
@@ -14,15 +14,10 @@ export function isTagActive(tag) {
       const opts = RRule.parseString(tag.rrule);
       if (tag.season_start) opts.dtstart = parseLocalYMD(tag.season_start);
       const rule = new RRule(opts);
-      const searchStart = new Date(today);
-      searchStart.setDate(searchStart.getDate() - 8);
-      const next = rule.after(searchStart, true);
+      const next = rule.after(today, true);
       if (!next) return false;
-      const start = new Date(next);
-      start.setDate(start.getDate() - 7);
-      const end = new Date(next);
-      end.setDate(end.getDate() + 1);
-      return today >= start && today < end;
+      const diff = Math.floor((next - today) / (1000 * 60 * 60 * 24));
+      return diff >= 0 && diff <= 7;
     } catch {
       return false;
     }


### PR DESCRIPTION
## Summary
- ensure social video carousel fits between nav and bottom bar on mobile
- show seasonal tags only within 7 days of next recurrence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: Parsing errors and no-undef across repo)*

------
https://chatgpt.com/codex/tasks/task_e_689f19894148832ca3410b5b531238fc