### PR TITLE
Fix PlansVideoCarousel card height

### DIFF
--- a/src/PlansVideoCarousel.jsx
+++ b/src/PlansVideoCarousel.jsx
@@ -245,7 +245,7 @@ export default function PlansVideoCarousel({ tag = 'arts' }) {
                   style={{ minWidth: '100%' }}
                 >
                   <div
-                    className={`w-11/12 max-w-md h-full mx-auto rounded-xl overflow-hidden flex flex-col transition-all duration-500 ${
+                    className={`w-11/12 max-w-md max-h-[calc(100vh-5rem)] mx-auto rounded-xl overflow-hidden flex flex-col transition-all duration-500 ${
                       idx === current && added
                         ? 'border-4 border-indigo-600'
                         : 'border border-transparent'


### PR DESCRIPTION
## Summary
- ensure PlansVideoCarousel cards stay within the viewport by capping height at `calc(100vh - 5rem)`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_689f1cdcda30832c8eaabf494c6629b9