### PR TITLE
Add pages for video carousel tags

### DIFF
--- a/src/PlansVideoIndex.jsx
+++ b/src/PlansVideoIndex.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Navbar from './Navbar';
+import { Link } from 'react-router-dom';
+
+export default function PlansVideoIndex() {
+  const links = [
+    { to: '/plans-video-arts', label: 'Arts' },
+    { to: '/plans-video-food', label: 'Nomnomslurp' },
+    { to: '/plans-video-fitness', label: 'Fitness' },
+    { to: '/plans-video-music', label: 'Music' }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar />
+      <div className="max-w-md mx-auto p-4 grid grid-cols-2 gap-4 mt-4">
+        {links.map(link => (
+          <Link
+            key={link.to}
+            to={link.to}
+            className="block p-8 bg-white rounded-lg shadow text-center text-lg font-semibold hover:bg-gray-100"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -36,6 +36,7 @@ import AdminActivity from './AdminActivity.jsx';
 import AdminComments from './AdminComments.jsx';
 import SocialVideoCarousel from './SocialVideoCarousel.jsx';
 import PlansVideoCarousel from './PlansVideoCarousel.jsx';
+import PlansVideoIndex from './PlansVideoIndex.jsx';
 import AdminVideoPromo from './AdminVideoPromo.jsx';
 import BigBoardEventPage  from './BigBoardEventPage';
 import BigBoardCarousel from './BigBoardCarousel.jsx';
@@ -108,6 +109,10 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/social-video-food" element={<SocialVideoCarousel tag="nomnomslurp" />} />
           <Route path="/social-video-fitness" element={<SocialVideoCarousel tag="fitness" />} />
           <Route path="/plans-video-arts" element={<PlansVideoCarousel tag="arts" />} />
+          <Route path="/plans-video-food" element={<PlansVideoCarousel tag="nomnomslurp" />} />
+          <Route path="/plans-video-fitness" element={<PlansVideoCarousel tag="fitness" />} />
+          <Route path="/plans-video-music" element={<PlansVideoCarousel tag="music" />} />
+          <Route path="/plans-video" element={<PlansVideoIndex />} />
           <Route path="/big-board/:slug"  element={<BigBoardEventPage />} />
           <Route path="/board-carousel" element={<BigBoardCarousel />} />
           <Route path="/:venue" element={<VenuePage />} />


### PR DESCRIPTION
## Summary
- Add tag-specific routes to plans video carousel for food, fitness, and music
- Create index page linking to arts, food, fitness, and music video carousels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext'; lint config not runnable)*

------
https://chatgpt.com/codex/tasks/task_e_689f2887c4ec832ca0205e96de222687