### PR TITLE
Add Traditions, PECO, and Markets plans video pages

### DIFF
--- a/src/PlansVideoCarousel.jsx
+++ b/src/PlansVideoCarousel.jsx
@@ -28,7 +28,11 @@ const formatDate = date => {
   })
 }
 
-export default function PlansVideoCarousel({ tag = 'arts' }) {
+export default function PlansVideoCarousel({
+  tag = 'arts',
+  onlyEvents = false,
+  headline,
+}) {
   const [events, setEvents] = useState([])
   const [loading, setLoading] = useState(true)
   const containerRef = useRef(null)
@@ -91,11 +95,15 @@ export default function PlansVideoCarousel({ tag = 'arts' }) {
         const tagId = tagRow?.id
         if (!tagId) { setEvents([]); setLoading(false); return }
 
+        const allowedTypes = onlyEvents
+          ? ['events']
+          : ['events', 'big_board_events', 'all_events', 'group_events']
+
         const { data: taggings } = await supabase
           .from('taggings')
           .select('taggable_id, taggable_type')
           .eq('tag_id', tagId)
-          .in('taggable_type', ['events','big_board_events','all_events','group_events'])
+          .in('taggable_type', allowedTypes)
 
         const idsByType = { events: [], big_board_events: [], all_events: [], group_events: [] }
         ;(taggings || []).forEach(t => {
@@ -103,25 +111,25 @@ export default function PlansVideoCarousel({ tag = 'arts' }) {
         })
 
         const [eRes, bbRes, aeRes, geRes] = await Promise.all([
-          idsByType.events.length
+          allowedTypes.includes('events') && idsByType.events.length
             ? supabase
                 .from('events')
                 .select('id, slug, "E Name", Dates, "End Date", "E Image", "E Description"')
                 .in('id', idsByType.events)
             : { data: [] },
-          idsByType.big_board_events.length
+          allowedTypes.includes('big_board_events') && idsByType.big_board_events.length
             ? supabase
                 .from('big_board_events')
                 .select('id, title, slug, start_date, end_date, description, big_board_posts!big_board_posts_event_id_fkey(image_url)')
                 .in('id', idsByType.big_board_events)
             : { data: [] },
-          idsByType.all_events.length
+          allowedTypes.includes('all_events') && idsByType.all_events.length
             ? supabase
                 .from('all_events')
                 .select('id, slug, name, start_date, image, description, venue_id(slug)')
                 .in('id', idsByType.all_events)
             : { data: [] },
-          idsByType.group_events.length
+          allowedTypes.includes('group_events') && idsByType.group_events.length
             ? supabase
                 .from('group_events')
                 .select('id, title, slug, description, start_date, end_date, image_url, group_id')
@@ -142,65 +150,77 @@ export default function PlansVideoCarousel({ tag = 'arts' }) {
         }
 
         const merged = []
-        ;(eRes.data || []).forEach(e => {
-          const start = parseDate(e.Dates)
-          const end = e['End Date'] ? parseDate(e['End Date']) : start
-          merged.push({
-            key: `ev-${e.id}`,
-            slug: `/events/${e.slug}`,
-            name: e['E Name'],
-            start, end,
-            image: e['E Image'] || '',
-            description: e['E Description'] || ''
-          })
-        })
-        ;(bbRes.data || []).forEach(ev => {
-          const start = parseLocalYMD(ev.start_date)
-          const end = ev.end_date ? parseLocalYMD(ev.end_date) : start
-          const key = ev.big_board_posts?.[0]?.image_url
-          const image = key
-            ? supabase.storage.from('big-board').getPublicUrl(key).data.publicUrl
-            : ''
-          merged.push({
-            key: `bb-${ev.id}`,
-            slug: `/big-board/${ev.slug}`,
-            name: ev.title,
-            start, end,
-            image,
-            description: ev.description || ''
-          })
-        })
-        ;(aeRes.data || []).forEach(ev => {
-          const start = parseLocalYMD(ev.start_date)
-          const venueSlug = ev.venue_id?.slug
-          merged.push({
-            key: `ae-${ev.id}`,
-            slug: venueSlug ? `/${venueSlug}/${ev.slug}` : `/${ev.slug}`,
-            name: ev.name,
-            start,
-            end: start,
-            image: ev.image || '',
-            description: ev.description || ''
-          })
-        })
-        ;(geRes.data || []).forEach(ev => {
-          const start = parseLocalYMD(ev.start_date)
-          const end = ev.end_date ? parseLocalYMD(ev.end_date) : start
-          let image = ''
-          if (ev.image_url?.startsWith('http')) image = ev.image_url
-          else if (ev.image_url) image = supabase.storage.from('big-board').getPublicUrl(ev.image_url).data.publicUrl
-          const groupSlug = groupMap[ev.group_id]
-          if (groupSlug) {
+        if (allowedTypes.includes('events')) {
+          ;(eRes.data || []).forEach(e => {
+            const start = parseDate(e.Dates)
+            const end = e['End Date'] ? parseDate(e['End Date']) : start
             merged.push({
-              key: `ge-${ev.id}`,
-              slug: `/groups/${groupSlug}/events/${ev.slug}`,
+              key: `ev-${e.id}`,
+              slug: `/events/${e.slug}`,
+              name: e['E Name'],
+              start,
+              end,
+              image: e['E Image'] || '',
+              description: e['E Description'] || ''
+            })
+          })
+        }
+        if (allowedTypes.includes('big_board_events')) {
+          ;(bbRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const end = ev.end_date ? parseLocalYMD(ev.end_date) : start
+            const key = ev.big_board_posts?.[0]?.image_url
+            const image = key
+              ? supabase.storage.from('big-board').getPublicUrl(key).data.publicUrl
+              : ''
+            merged.push({
+              key: `bb-${ev.id}`,
+              slug: `/big-board/${ev.slug}`,
               name: ev.title,
-              start, end,
+              start,
+              end,
               image,
               description: ev.description || ''
             })
-          }
-        })
+          })
+        }
+        if (allowedTypes.includes('all_events')) {
+          ;(aeRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const venueSlug = ev.venue_id?.slug
+            merged.push({
+              key: `ae-${ev.id}`,
+              slug: venueSlug ? `/${venueSlug}/${ev.slug}` : `/${ev.slug}`,
+              name: ev.name,
+              start,
+              end: start,
+              image: ev.image || '',
+              description: ev.description || ''
+            })
+          })
+        }
+        if (allowedTypes.includes('group_events')) {
+          ;(geRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const end = ev.end_date ? parseLocalYMD(ev.end_date) : start
+            let image = ''
+            if (ev.image_url?.startsWith('http')) image = ev.image_url
+            else if (ev.image_url)
+              image = supabase.storage.from('big-board').getPublicUrl(ev.image_url).data.publicUrl
+            const groupSlug = groupMap[ev.group_id]
+            if (groupSlug) {
+              merged.push({
+                key: `ge-${ev.id}`,
+                slug: `/groups/${groupSlug}/events/${ev.slug}`,
+                name: ev.title,
+                start,
+                end,
+                image,
+                description: ev.description || ''
+              })
+            }
+          })
+        }
 
         const today = new Date(); today.setHours(0,0,0,0)
         const upcoming = merged
@@ -261,7 +281,7 @@ export default function PlansVideoCarousel({ tag = 'arts' }) {
           className="bg-[#ba3d36] text-white py-3 text-center font-[Barrio] text-lg z-10"
           style={{ marginTop: navHeight }}
         >
-          Upcoming #{tag} events in Philly
+          {headline || `Upcoming #${tag} events in Philly`}
         </div>
 
         <div

--- a/src/PlansVideoIndex.jsx
+++ b/src/PlansVideoIndex.jsx
@@ -23,7 +23,10 @@ export default function PlansVideoIndex() {
     { to: '/plans-video-arts', label: 'Arts' },
     { to: '/plans-video-food', label: 'Nomnomslurp' },
     { to: '/plans-video-fitness', label: 'Fitness' },
-    { to: '/plans-video-music', label: 'Music' }
+    { to: '/plans-video-music', label: 'Music' },
+    { to: '/plans-video-traditions', label: 'Traditions' },
+    { to: '/plans-video-peco', label: 'PECO Multicultural' },
+    { to: '/plans-video-markets', label: 'Markets' },
   ];
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -112,6 +112,12 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/plans-video-food" element={<PlansVideoCarousel tag="nomnomslurp" />} />
           <Route path="/plans-video-fitness" element={<PlansVideoCarousel tag="fitness" />} />
           <Route path="/plans-video-music" element={<PlansVideoCarousel tag="music" />} />
+          <Route
+            path="/plans-video-traditions"
+            element={<PlansVideoCarousel tag="traditions" onlyEvents headline="Upcoming Philly Traditions" />}
+          />
+          <Route path="/plans-video-peco" element={<PlansVideoCarousel tag="peco-multicultural" />} />
+          <Route path="/plans-video-markets" element={<PlansVideoCarousel tag="markets" />} />
           <Route path="/plans-video" element={<PlansVideoIndex />} />
           <Route path="/big-board/:slug"  element={<BigBoardEventPage />} />
           <Route path="/board-carousel" element={<BigBoardCarousel />} />


### PR DESCRIPTION
## Summary
- support custom headlines and event sources in `PlansVideoCarousel`
- add plans video pages for traditions, PECO Multicultural, and markets tags
- expand `/plans-video` index with new links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_689f622e4324832cae7fac397350715d