### PR TITLE
Add Traditions, PECO, and Markets plans video pages

### DIFF
--- a/src/PlansVideoIndex.jsx
+++ b/src/PlansVideoIndex.jsx
@@ -23,7 +23,10 @@ export default function PlansVideoIndex() {
     { to: '/plans-video-arts', label: 'Arts' },
     { to: '/plans-video-food', label: 'Nomnomslurp' },
     { to: '/plans-video-fitness', label: 'Fitness' },
-    { to: '/plans-video-music', label: 'Music' }
+    { to: '/plans-video-music', label: 'Music' },
+    { to: '/plans-video-traditions', label: 'Traditions' },
+    { to: '/plans-video-peco', label: 'PECO Multicultural' },
+    { to: '/plans-video-markets', label: 'Markets' },
   ];
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -112,6 +112,12 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/plans-video-food" element={<PlansVideoCarousel tag="nomnomslurp" />} />
           <Route path="/plans-video-fitness" element={<PlansVideoCarousel tag="fitness" />} />
           <Route path="/plans-video-music" element={<PlansVideoCarousel tag="music" />} />
+          <Route
+            path="/plans-video-traditions"
+            element={<PlansVideoCarousel onlyEvents headline="Upcoming Philly Traditions" />}
+          />
+          <Route path="/plans-video-peco" element={<PlansVideoCarousel tag="peco-multicultural" />} />
+          <Route path="/plans-video-markets" element={<PlansVideoCarousel tag="markets" />} />
           <Route path="/plans-video" element={<PlansVideoIndex />} />
           <Route path="/big-board/:slug"  element={<BigBoardEventPage />} />
           <Route path="/board-carousel" element={<BigBoardCarousel />} />


### PR DESCRIPTION
## Summary
- support custom headlines and event sources in `PlansVideoCarousel`
- add plans video pages for traditions, PECO Multicultural, and markets tags
- expand `/plans-video` index with new links
- load all events when the carousel has no tag so traditions cards appear

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_689f622e4324832cae7fac397350715d