### PR TITLE
Show relative date on Plans Video cards

### DIFF
--- a/src/PlansVideoCarousel.jsx
+++ b/src/PlansVideoCarousel.jsx
@@ -21,11 +21,20 @@ const parseLocalYMD = str => {
 
 const formatDate = date => {
   if (!date) return ''
-  return 'This ' + date.toLocaleDateString('en-US', {
-    weekday: 'long',
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const diffDays = Math.round((date - today) / (1000 * 60 * 60 * 24))
+  const monthDay = date.toLocaleDateString('en-US', {
     month: 'long',
-    day: 'numeric'
+    day: 'numeric',
   })
+  if (diffDays === 0) return `Today, ${monthDay}`
+  if (diffDays === 1) return `Tomorrow, ${monthDay}`
+  const weekday = date.toLocaleDateString('en-US', { weekday: 'long' })
+  const weekDiff = Math.floor(diffDays / 7)
+  if (weekDiff === 0) return `This ${weekday}, ${monthDay}`
+  if (weekDiff === 1) return `Next ${weekday}, ${monthDay}`
+  return `${weekday}, ${monthDay}`
 }
 
 export default function PlansVideoCarousel({
@@ -343,7 +352,8 @@ export default function PlansVideoCarousel({
                       </div>
                     )}
                     <div className="min-h-0 flex-1 overflow-y-auto p-4 text-center">
-                      <h3 className="font-bold text-xl mb-4">{evt.name}</h3>
+                      <h3 className="font-bold text-xl">{evt.name}</h3>
+                      <p className="text-gray-700 mb-4">{formatDate(evt.start)}</p>
                     </div>
                     <div className="shrink-0 border-t p-3 bg-white">
                       <button


### PR DESCRIPTION
## Summary
- display relative date under each Plans Video card title
- format dates as Today/Tomorrow/This Weekday/Next Weekday with month and day

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Invalid option '--ext')
- `npx eslint .` (fails: 150 errors, 2 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a4cca5c040832cadeb83f747fff347