### PR TITLE
Add weekend plans video page

### DIFF
--- a/src/PlansVideoIndex.jsx
+++ b/src/PlansVideoIndex.jsx
@@ -20,6 +20,7 @@ export default function PlansVideoIndex() {
   }, []);
 
   const links = [
+    { to: '/plans-video/weekend-plans', label: 'This Weekend' },
     { to: '/plans-video-arts', label: 'Arts' },
     { to: '/plans-video-food', label: 'Nomnomslurp' },
     { to: '/plans-video-fitness', label: 'Fitness' },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -118,6 +118,10 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           />
           <Route path="/plans-video-peco" element={<PlansVideoCarousel tag="peco-multicultural" />} />
           <Route path="/plans-video-markets" element={<PlansVideoCarousel tag="markets" />} />
+          <Route
+            path="/plans-video/weekend-plans"
+            element={<PlansVideoCarousel weekend headline="Events This Weekend in Philly" limit={30} />}
+          />
           <Route path="/plans-video" element={<PlansVideoIndex />} />
           <Route path="/big-board/:slug"  element={<BigBoardEventPage />} />
           <Route path="/board-carousel" element={<BigBoardCarousel />} />


### PR DESCRIPTION
## Summary
- show carousel of up to 30 events for current/upcoming weekend across all tables
- link weekend page from plans video index
- route `/plans-video/weekend-plans` with weekend headline

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_68a4d3b351c4832cac3a739fcedfd4ab