### PR TITLE
Integrate Philadelphia sports games into events

### DIFF
--- a/src/EventsPageHero.jsx
+++ b/src/EventsPageHero.jsx
@@ -105,7 +105,7 @@ export default function EventsPageHero() {
         let allGames = []
         for (const slug of teamSlugs) {
           const res  = await fetch(
-            `https://api.seatgeek.com/2/events?performers.slug=${slug}&per_page=20&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
+            `https://api.seatgeek.com/2/events?performers.slug=${slug}&venue.city=Philadelphia&per_page=20&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
           )
           const json = await res.json()
           allGames.push(...(json.events || []))
@@ -115,16 +115,16 @@ export default function EventsPageHero() {
           .filter(e => {
             const d = new Date(e.datetime_local)
             d.setHours(0,0,0,0)
-            return d.getTime() === today.getTime()
+            return d.getTime() === today.getTime() && e.venue?.city === 'Philadelphia'
           })
           .map(e => {
-            const local = e.performers.find(p => p.name.startsWith('Philadelphia '))
-            const opp   = e.performers.find(p => p !== local)
+            const local = e.performers.find(p => p.home_team) || e.performers.find(p => p.name.startsWith('Philadelphia '))
+            const opp   = e.performers.find(p => p.id !== local?.id)
             const team     = local?.name.replace(/^Philadelphia\s+/, '')  || ''
             const opponent = opp?.name.replace(/^Philadelphia\s+/, '')  || ''
             const hour = new Date(e.datetime_local)
               .toLocaleTimeString('en-US',{ hour: 'numeric', minute: 'numeric', hour12: true })
-            return `${team} at ${opponent} at ${hour}`
+            return `${opponent} at ${team} at ${hour}`
           })
         setSportsSummary(gamesToday.join(', '))
       } catch (err) {

--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -280,36 +280,47 @@ const [sportsEvents, setSportsEvents]     = useState([]);    // filtered by date
 
 useEffect(() => {
   (async () => {
-    const teamSlugs = [
-      'philadelphia-phillies',
-      'philadelphia-76ers',
-      'philadelphia-eagles',
-      'philadelphia-flyers',
-      'philadelphia-union',
-    ];
-    let all = [];
-    for (const slug of teamSlugs) {
-      const res  = await fetch(
-        `https://api.seatgeek.com/2/events?performers.slug=${slug}&per_page=50&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
-      );
-      const json = await res.json();
-      all.push(...(json.events || []));
-    }
-    // normalize into your shape
-    const mapped = all.map(e => {
-      const dt   = new Date(e.datetime_local);
-      const home = e.performers.find(p => p.home_team) || e.performers[0];
-      const away = e.performers.find(p => !p.home_team) || home;
-      return {
-        id:         `sg-${e.id}`,
-        title,
-        start_date: dt.toISOString().slice(0,10),
-        imageUrl:   local.image || other.image,
-        href:       e.url,
-        isSports:   true,
+    try {
+      const teamSlugs = [
+        'philadelphia-phillies',
+        'philadelphia-76ers',
+        'philadelphia-eagles',
+        'philadelphia-flyers',
+        'philadelphia-union',
+      ];
+      let all = [];
+      for (const slug of teamSlugs) {
+        const res = await fetch(
+          `https://api.seatgeek.com/2/events?performers.slug=${slug}&venue.city=Philadelphia&per_page=50&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
+        );
+        const json = await res.json();
+        all.push(...(json.events || []));
       }
-    });
-    setSportsEventsRaw(mapped);
+      const mapped = all.map(e => {
+        const dt = new Date(e.datetime_local);
+        const performers = e.performers || [];
+        const home = performers.find(p => p.home_team) || performers[0] || {};
+        const away = performers.find(p => p.id !== home.id) || {};
+        const title =
+          e.short_title ||
+          `${(home.name || '').replace(/^Philadelphia\s+/,'')} vs ${(away.name || '').replace(/^Philadelphia\s+/,'')}`;
+        return {
+          id: `sg-${e.id}`,
+          title,
+          start_date: dt.toISOString().slice(0,10),
+          start_time: dt.toTimeString().slice(0,5),
+          imageUrl: home.image || away.image || '',
+          href: `/sports/${e.id}`,
+          external_url: e.url,
+          isSports: true,
+          latitude: e.venue?.location?.lat,
+          longitude: e.venue?.location?.lon,
+        };
+      });
+      setSportsEventsRaw(mapped);
+    } catch (err) {
+      console.error('Error fetching sports events', err);
+    }
   })();
 }, []);
 
@@ -780,7 +791,7 @@ useEffect(() => {
 
 
   // Pagination
-  const totalCount = events.length + bigBoardEvents.length + traditionEvents.length + groupEvents.length;;
+  const totalCount = events.length + bigBoardEvents.length + traditionEvents.length + groupEvents.length + sportsEvents.length;;
   const pageCount = Math.ceil(totalCount / EVENTS_PER_PAGE);
 
   const allFilteredEvents = [
@@ -795,8 +806,8 @@ useEffect(() => {
   // Big Board first, then Traditions, then All Events
 const allPagedEvents = [
     ...bigBoardEvents,
-    ...traditionEvents,
     ...sportsEvents,
+    ...traditionEvents,
     ...recurringOccs,
     ...groupEvents,
     ...events
@@ -839,6 +850,8 @@ if (selectedOption === 'today' && !showAllToday) {
       } else if (evt.isRecurring) {
         table = 'recurring_events';
         id = id.split('::')[0];
+      } else if (evt.isSports) {
+        table = 'sports';
       } else {
         table = 'all_events';
       }
@@ -846,18 +859,20 @@ if (selectedOption === 'today' && !showAllToday) {
       acc[table].push(id);
       return acc;
     }, {});
-  
+
     Promise.all(
-      Object.entries(idsByType).map(([taggable_type, ids]) =>
-        supabase
-          .from('taggings')
-          .select('tags(name,slug),taggable_id')      // <– returns `tags` field
-          .eq('taggable_type', taggable_type)
-          .in('taggable_id', ids)
-      )
+      Object.entries(idsByType)
+        .filter(([type]) => type !== 'sports')
+        .map(([taggable_type, ids]) =>
+          supabase
+            .from('taggings')
+            .select('tags(name,slug),taggable_id')      // <– returns `tags` field
+            .eq('taggable_type', taggable_type)
+            .in('taggable_id', ids)
+        )
     ).then(results => {
       const map = {};
-  
+
       results.forEach(res => {
         if (res.error) {
           console.error('taggings fetch failed:', res.error);
@@ -868,10 +883,18 @@ if (selectedOption === 'today' && !showAllToday) {
           map[taggable_id].push(tags);
         });
       });
-  
+
+      const sportsTag = allTags.find(t => t.slug === 'sports');
+      if (sportsTag) {
+        (idsByType.sports || []).forEach(id => {
+          map[id] = map[id] || [];
+          map[id].push(sportsTag);
+        });
+      }
+
       setTagMap(map);
     });
-  }, [allPagedEvents]);
+  }, [allPagedEvents, allTags]);
   
   
   
@@ -1111,11 +1134,8 @@ if (loading) {
 
           const bubbleTime = evt.start_time ? ` ${formatTime(evt.start_time)}` : '';
 
-          const isExternal = evt.isSports;
-          const Wrapper    = isExternal ? 'a' : Link;
-          const linkProps = isExternal
-          ? { href: evt.href, target: '_blank', rel: 'noopener noreferrer' }
-          : evt.isGroupEvent
+          const Wrapper = Link;
+          const linkProps = evt.isGroupEvent
             ? { to: evt.href }
             : evt.isRecurring
               ? { to: `/series/${evt.slug}/${evt.start_date}` }
@@ -1123,9 +1143,11 @@ if (loading) {
                 ? { to: `/events/${evt.slug}` }
                 : evt.isBigBoard
                   ? { to: `/big-board/${evt.slug}` }
-                  : evt.venues?.slug && evt.slug
-                    ? { to: `/${evt.venues.slug}/${evt.slug}` }
-                    : { to: '/' };
+                  : evt.isSports
+                    ? { to: evt.href }
+                    : evt.venues?.slug && evt.slug
+                      ? { to: `/${evt.venues.slug}/${evt.slug}` }
+                      : { to: '/' };
 
 
           const tagKey = evt.isRecurring ? String(evt.id).split('::')[0] : evt.id;
@@ -1148,7 +1170,9 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
                       ? 'group_events'
                       : evt.isRecurring
                         ? 'recurring_events'
-                        : 'all_events'
+                        : evt.isSports
+                          ? 'sports'
+                          : 'all_events'
               }
             >
             {({ isFavorite, toggleFavorite, loading }) => (

--- a/src/SportsEventPage.jsx
+++ b/src/SportsEventPage.jsx
@@ -1,0 +1,91 @@
+// src/SportsEventPage.jsx
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+
+export default function SportsEventPage() {
+  const { id } = useParams();
+  const [event, setEvent] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch(
+          `https://api.seatgeek.com/2/events/${id}?client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
+        );
+        const data = await res.json();
+        const ev = data.events?.[0] || data.event || null;
+        setEvent(ev);
+      } catch (err) {
+        console.error('Error loading game', err);
+        setEvent(null);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-white">
+        <Navbar />
+        <div className="pt-32 text-center">Loading...</div>
+        <Footer />
+      </div>
+    );
+  }
+
+  if (!event) {
+    return (
+      <div className="min-h-screen bg-white">
+        <Navbar />
+        <div className="pt-32 text-center">Event not found.</div>
+        <Footer />
+      </div>
+    );
+  }
+
+  const dt = new Date(event.datetime_local);
+  const performers = event.performers || [];
+  const home = performers.find(p => p.home_team) || performers.find(p => p.name.startsWith('Philadelphia')) || performers[0] || {};
+  const away = performers.find(p => p.id !== home.id) || {};
+  const image = home.image || away.image || '';
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Navbar />
+      <main className="max-w-screen-xl mx-auto pt-24 px-4">
+        <h1 className="text-4xl font-bold text-gray-800 mb-4">{event.short_title}</h1>
+        <div className="flex flex-wrap gap-2 mb-6">
+          <Link to="/tags/sports" className="bg-green-100 text-green-800 px-3 py-1 rounded-full text-sm font-semibold">#sports</Link>
+        </div>
+        {image && (
+          <img src={image} alt={event.short_title} className="w-full max-h-96 object-cover rounded-lg mb-6" />
+        )}
+        <p className="text-gray-700 mb-2">
+          📅 {dt.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
+        </p>
+        <p className="text-gray-700 mb-2">
+          ⏰ {dt.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric' })}
+        </p>
+        <p className="text-gray-700 mb-4">
+          📍 {event.venue?.name}, {event.venue?.city}
+        </p>
+        {event.stats?.lowest_price && (
+          <p className="text-yellow-700 mb-6">Tickets from ${event.stats.lowest_price}</p>
+        )}
+        <a
+          href={event.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block bg-indigo-600 text-white px-6 py-3 rounded-md font-semibold"
+        >
+          Get Tickets
+        </a>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/SportsEventsGrid.jsx
+++ b/src/SportsEventsGrid.jsx
@@ -1,5 +1,6 @@
 // src/SportsEventsGrid.jsx
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 const teamSlugs = [
   'philadelphia-phillies',
@@ -19,13 +20,14 @@ export default function SportsEventsGrid() {
         let allEvents = [];
         for (const slug of teamSlugs) {
           const res = await fetch(
-            `https://api.seatgeek.com/2/events?performers.slug=${slug}&per_page=20&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
+            `https://api.seatgeek.com/2/events?performers.slug=${slug}&venue.city=Philadelphia&per_page=20&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
           );
           const data = await res.json();
           allEvents.push(...(data.events || []));
         }
-        allEvents.sort((a, b) => new Date(a.datetime_local) - new Date(b.datetime_local));
-        setEvents(allEvents);
+        const homeGames = allEvents.filter(e => e.venue?.city === 'Philadelphia');
+        homeGames.sort((a, b) => new Date(a.datetime_local) - new Date(b.datetime_local));
+        setEvents(homeGames);
       } catch (err) {
         console.error('Error fetching events:', err);
       } finally {
@@ -80,11 +82,9 @@ export default function SportsEventsGrid() {
                 'bg-gray-500';
 
               return (
-                <a
+                <Link
                   key={evt.id}
-                  href={evt.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  to={`/sports/${evt.id}`}
                   className="relative min-w-[360px] max-w-[360px] bg-white rounded-2xl shadow-lg hover:shadow-xl transition-transform hover:scale-105 overflow-hidden flex flex-col"
                 >
                   <div className="relative">
@@ -125,7 +125,7 @@ export default function SportsEventsGrid() {
                       📍 {evt.venue?.name}, {evt.venue?.city}
                     </p>
                   </div>
-                </a>
+                </Link>
               );
             })}
           </div>

--- a/src/SportsPage.jsx
+++ b/src/SportsPage.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import Navbar from './Navbar';
 import { Helmet } from 'react-helmet';
 import FilteredGroupSection from './FilteredGroupSection';
+import { Link } from 'react-router-dom';
 
 
 const teamSlugs = [
@@ -27,14 +28,15 @@ const SportsPage = () => {
 
         for (const slug of teamSlugs) {
           const res = await fetch(
-            `https://api.seatgeek.com/2/events?performers.slug=${slug}&per_page=20&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
+            `https://api.seatgeek.com/2/events?performers.slug=${slug}&venue.city=Philadelphia&per_page=20&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
           );
           const data = await res.json();
           allEvents.push(...(data.events || []));
         }
 
-        allEvents.sort((a, b) => new Date(a.datetime_local) - new Date(b.datetime_local));
-        setEvents(allEvents);
+        const homeGames = allEvents.filter(e => e.venue?.city === 'Philadelphia');
+        homeGames.sort((a, b) => new Date(a.datetime_local) - new Date(b.datetime_local));
+        setEvents(homeGames);
       } catch (error) {
         console.error('Error fetching events:', error);
       } finally {
@@ -116,11 +118,9 @@ const SportsPage = () => {
                   const weekday = eventDate.toLocaleDateString('en-US', { weekday: 'short' }).toUpperCase();
 
                   return (
-                    <a
+                    <Link
                       key={event.id}
-                      href={event.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      to={`/sports/${event.id}`}
                       className="bg-white rounded-2xl shadow hover:shadow-xl transition-transform hover:scale-105 overflow-hidden flex flex-col"
                     >
                       <div className="relative">
@@ -150,7 +150,7 @@ const SportsPage = () => {
                           📍 {event.venue?.name}, {event.venue?.city}
                         </p>
                       </div>
-                    </a>
+                    </Link>
                   );
                 })}
               </div>

--- a/src/SportsTonightSidebar.jsx
+++ b/src/SportsTonightSidebar.jsx
@@ -1,5 +1,6 @@
 // src/SportsTonightSidebar.jsx
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 const teamSlugs = [
   'philadelphia-phillies',
@@ -19,7 +20,7 @@ export default function SportsTonightSidebar() {
         let allEvents = [];
         for (const slug of teamSlugs) {
           const res = await fetch(
-            `https://api.seatgeek.com/2/events?performers.slug=${slug}&per_page=10&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
+            `https://api.seatgeek.com/2/events?performers.slug=${slug}&venue.city=Philadelphia&per_page=10&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
           );
           const data = await res.json();
           allEvents.push(...(data.events || []));
@@ -29,7 +30,7 @@ export default function SportsTonightSidebar() {
         const tonight = allEvents.filter(evt => {
           const d = new Date(evt.datetime_local);
           d.setHours(0, 0, 0, 0);
-          return d.getTime() === today.getTime();
+          return d.getTime() === today.getTime() && evt.venue?.city === 'Philadelphia';
         });
         tonight.sort((a, b) => new Date(a.datetime_local) - new Date(b.datetime_local));
         setGames(tonight);
@@ -65,11 +66,9 @@ export default function SportsTonightSidebar() {
             const venueName  = evt.venue?.name || '';
 
             return (
-              <a
+              <Link
                 key={evt.id}
-                href={evt.url}
-                target="_blank"
-                rel="noopener noreferrer"
+                to={`/sports/${evt.id}`}
                 className="flex items-center gap-1 hover:bg-gray-50 px-2 py-1 rounded transition text-sm"
               >
                 <img
@@ -80,11 +79,11 @@ export default function SportsTonightSidebar() {
                 <span className="font-semibold text-[#28313e]">{localName}</span>
                 <span className="text-gray-500">vs</span>
                 <span className="font-semibold text-[#28313e]">{visitorName}</span>
-                
+
                 <span className="ml-2 text-gray-600 whitespace-nowrap">
                   {gameTime} @ {venueName}
                 </span>
-              </a>
+              </Link>
             );
           })}
         </div>

--- a/src/TaggedEventsScroller.jsx
+++ b/src/TaggedEventsScroller.jsx
@@ -262,6 +262,41 @@ export default function TaggedEventsScroller({
           });
         });
 
+        // SeatGeek sports events when #sports is requested
+        if (tags.includes('sports')) {
+          try {
+            const teamSlugs = [
+              'philadelphia-phillies',
+              'philadelphia-76ers',
+              'philadelphia-eagles',
+              'philadelphia-flyers',
+              'philadelphia-union',
+            ];
+            let sgEvents = [];
+            for (const slug of teamSlugs) {
+              const res = await fetch(
+                `https://api.seatgeek.com/2/events?performers.slug=${slug}&venue.city=Philadelphia&per_page=20&sort=datetime_local.asc&client_id=${import.meta.env.VITE_SEATGEEK_CLIENT_ID}`
+              );
+              const json = await res.json();
+              sgEvents.push(...(json.events || []));
+            }
+            sgEvents.forEach(e => {
+              const start = new Date(e.datetime_local);
+              merged.push({
+                id: `sg-${e.id}`,
+                source_table: 'sports',
+                title: e.short_title,
+                imageUrl: e.performers?.[0]?.image || '',
+                start,
+                end: start,
+                href: `/sports/${e.id}`,
+              });
+            });
+          } catch (err) {
+            console.error('Error loading sports events', err);
+          }
+        }
+
         // 7) filter + sort + limit
         const today = new Date(); today.setHours(0, 0, 0, 0);
         const upcoming = merged

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -50,6 +50,7 @@ import ContactPage from './ContactPage.jsx'
 import TraditionsFAQ from './TraditionsFAQ.jsx'
 import GroupsFAQ from './GroupsFAQ.jsx'
 import RecurringPage from './RecurringEventPage.jsx'
+import SportsEventPage from './SportsEventPage.jsx'
 
 
 
@@ -72,6 +73,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/:view" element={<MainEvents />} />
           <Route path="/old" element={<App />} />
           <Route path="/sports" element={<SportsPage />} />
+          <Route path="/sports/:id" element={<SportsEventPage />} />
           <Route path="/trivia" element={<TriviaNights />} />
           <Route path="/voicemail" element={<VoicemailPage />} />
           <Route path="/groups" element={<GroupsPage />} />


### PR DESCRIPTION
## Summary
- Attach `#sports` tag to SeatGeek events in main search results
- Load SeatGeek events on the `#sports` tag page alongside database-tagged events
- Fix sports event page to fetch the correct SeatGeek event data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_68a51a388ffc832c969196931212021b