### PR TITLE
Add onboarding flow and preview route

### DIFF
--- a/src/CultureModal.jsx
+++ b/src/CultureModal.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from './supabaseClient';
+
+export default function CultureModal({ initial = [], onSave, onClose }) {
+  const [tags, setTags] = useState([]);
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState(new Set(initial));
+
+  useEffect(() => {
+    supabase
+      .from('culture_tags')
+      .select('id,name,emoji')
+      .order('name', { ascending: true })
+      .then(({ data }) => setTags(data || []));
+  }, []);
+
+  const toggle = id => {
+    setSelected(prev => {
+      const s = new Set(prev);
+      s.has(id) ? s.delete(id) : s.add(id);
+      return s;
+    });
+  };
+
+  const handleSave = () => {
+    onSave(Array.from(selected));
+  };
+
+  const filtered = tags.filter(t =>
+    t.name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+      <div className="bg-white rounded-lg p-4 max-h-[80vh] overflow-y-auto w-80 space-y-3">
+        <div className="flex justify-between items-center">
+          <h2 className="font-semibold">Select Cultures</h2>
+          <button onClick={onClose} className="text-xl">×</button>
+        </div>
+        <input
+          className="w-full border p-1"
+          placeholder="Search"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <div className="space-y-1">
+          {filtered.map(t => (
+            <label key={t.id} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={selected.has(t.id)}
+                onChange={() => toggle(t.id)}
+              />
+              <span>{t.emoji} {t.name}</span>
+            </label>
+          ))}
+        </div>
+        <button
+          onClick={handleSave}
+          className="mt-2 bg-indigo-600 text-white px-4 py-1 rounded"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/OnboardingFlow.jsx
+++ b/src/OnboardingFlow.jsx
@@ -1,0 +1,235 @@
+import React, { useEffect, useState, useContext, useRef } from 'react';
+import { supabase } from './supabaseClient';
+import ProgressBar from './ProgressBar.jsx';
+import SavedEventCard from './SavedEventCard.jsx';
+import CultureModal from './CultureModal.jsx';
+import { AuthContext } from './AuthProvider';
+import useProfile from './utils/useProfile';
+import useProfileTags from './utils/useProfileTags';
+import imageCompression from 'browser-image-compression';
+import { Link } from 'react-router-dom';
+
+export default function OnboardingFlow({ onComplete = () => {}, demo = false }) {
+  const total = 4;
+  const [step, setStep] = useState(1);
+
+  const next = () => setStep(s => Math.min(total, s + 1));
+  const back = () => setStep(s => Math.max(1, s - 1));
+  const skip = () => next();
+
+  // Step 1: upcoming events
+  const [events, setEvents] = useState([]);
+  useEffect(() => {
+    if (step !== 1) return;
+    (async () => {
+      const today = new Date().toISOString().split('T')[0];
+      const { data } = await supabase
+        .from('all_events')
+        .select('id,slug,name,start_date,image,venue_id(slug,name)')
+        .gte('start_date', today)
+        .order('start_date')
+        .limit(10);
+      setEvents(data || []);
+    })();
+  }, [step]);
+
+  // Step 2: tags
+  const [tags, setTags] = useState([]);
+  const [tagSel, setTagSel] = useState(new Set());
+  useEffect(() => {
+    if (step !== 2) return;
+    supabase
+      .from('tags')
+      .select('id,name')
+      .order('name')
+      .then(({ data }) => setTags(data || []));
+  }, [step]);
+  const toggleTag = id => {
+    setTagSel(prev => {
+      const n = new Set(prev);
+      n.has(id) ? n.delete(id) : n.add(id);
+      return n;
+    });
+  };
+
+  // Step 3: profile
+  const { user } = useContext(AuthContext);
+  const { profile, updateProfile } = useProfile();
+  const { tags: existingCultures, saveTags } = useProfileTags('culture');
+  const [username, setUsername] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [cultures, setCultures] = useState([]);
+  const [showCultures, setShowCultures] = useState(false);
+  const fileRef = useRef(null);
+
+  useEffect(() => {
+    if (step === 3 && profile) {
+      setUsername(profile.username || profile.slug || '');
+      setImageUrl(profile.image_url || '');
+      setCultures((existingCultures || []).map(t => t.id));
+    }
+  }, [step, profile, existingCultures]);
+
+  const handleFile = async e => {
+    if (!user) return;
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const compressed = await imageCompression(file, { maxWidthOrHeight: 512 });
+    const name = `${user.id}-${Date.now()}.jpg`;
+    const { error: uploadError } = await supabase.storage
+      .from('profile-images')
+      .upload(name, compressed, { upsert: true });
+    if (!uploadError) {
+      const { data } = supabase.storage
+        .from('profile-images')
+        .getPublicUrl(name);
+      setImageUrl(data.publicUrl);
+    }
+  };
+
+  const saveProfile = async () => {
+    if (demo) return;
+    await updateProfile({ username, image_url: imageUrl });
+    await saveTags(cultures);
+  };
+
+  // Step 2 save subscriptions
+  const saveTagsStep = async () => {
+    if (demo || !user) return;
+    const rows = Array.from(tagSel).map(tag_id => ({ user_id: user.id, tag_id }));
+    await supabase.from('user_subscriptions').delete().eq('user_id', user.id);
+    if (rows.length) {
+      await supabase.from('user_subscriptions').insert(rows);
+    }
+  };
+
+  const finish = async () => {
+    await saveProfile();
+    await saveTagsStep();
+    onComplete();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto p-6 flex flex-col gap-4">
+        {step === 1 && (
+          <div className="space-y-4">
+            <h2 className="text-2xl font-bold">Add some events to your plans</h2>
+            <div className="flex gap-4 overflow-x-auto pb-2">
+              {events.map(ev => (
+                <div key={ev.id} className="w-64 flex-shrink-0">
+                  <SavedEventCard event={{
+                    id: ev.id,
+                    slug: ev.slug,
+                    title: ev.name,
+                    image: ev.image,
+                    imageUrl: ev.image,
+                    start_date: ev.start_date,
+                    venues: ev.venue_id,
+                    source_table: 'all_events',
+                  }} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {step === 2 && (
+          <div className="space-y-4">
+            <h2 className="text-2xl font-bold">Pick tags for your daily email</h2>
+            <div className="grid grid-cols-2 gap-2">
+              {tags.map(t => (
+                <label key={t.id} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={tagSel.has(t.id)}
+                    onChange={() => toggleTag(t.id)}
+                  />
+                  <span>#{t.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+        {step === 3 && (
+          <div className="space-y-4">
+            <h2 className="text-2xl font-bold">Customize your profile</h2>
+            <div className="flex flex-col items-center gap-4">
+              <div className="relative">
+                {imageUrl ? (
+                  <img src={imageUrl} alt="avatar" className="w-24 h-24 rounded-full object-cover" />
+                ) : (
+                  <div className="w-24 h-24 rounded-full bg-gray-300" />
+                )}
+                <input type="file" ref={fileRef} className="hidden" onChange={handleFile} />
+                <button
+                  className="absolute bottom-0 right-0 bg-black/60 text-white text-xs px-2 py-1 rounded"
+                  onClick={() => fileRef.current?.click()}
+                >
+                  Change
+                </button>
+              </div>
+              <input
+                className="border px-3 py-1 rounded w-full max-w-xs"
+                value={username}
+                onChange={e => setUsername(e.target.value)}
+                placeholder="Username"
+              />
+              <button
+                onClick={() => setShowCultures(true)}
+                className="underline"
+              >
+                {cultures.length ? `${cultures.length} cultures selected` : 'Select cultures'}
+              </button>
+            </div>
+            {showCultures && (
+              <CultureModal
+                initial={cultures}
+                onSave={ids => {
+                  setCultures(ids);
+                  setShowCultures(false);
+                }}
+                onClose={() => setShowCultures(false)}
+              />
+            )}
+          </div>
+        )}
+        {step === 4 && (
+          <div className="space-y-4 text-center">
+            <h2 className="text-2xl font-bold">Welcome to Our Philly!</h2>
+            <p>Explore groups or try our quick match tool to find your crew in the city.</p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <Link to="/groups" className="bg-indigo-600 text-white px-4 py-2 rounded">
+                Go to Groups
+              </Link>
+              <Link to="/groups?match=1" className="border border-indigo-600 text-indigo-600 px-4 py-2 rounded">
+                Try Group Match
+              </Link>
+            </div>
+          </div>
+        )}
+
+        <ProgressBar current={step} total={total} />
+
+        <div className="flex justify-between pt-2">
+          {step > 1 ? (
+            <button onClick={back} className="text-sm underline">Back</button>
+          ) : <span />}
+          {step < total ? (
+            <div className="space-x-2">
+              <button onClick={skip} className="text-sm underline">Skip</button>
+              <button onClick={async () => {
+                if (step === 2) await saveTagsStep();
+                if (step === 3) await saveProfile();
+                next();
+              }} className="bg-indigo-600 text-white px-4 py-1 rounded">
+                Next
+              </button>
+            </div>
+          ) : (
+            <button onClick={finish} className="bg-indigo-600 text-white px-4 py-1 rounded">Finish</button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ProgressBar.jsx
+++ b/src/ProgressBar.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function ProgressBar({ current = 1, total = 4 }) {
+  const pct = Math.min(100, Math.max(0, (current / total) * 100));
+  return (
+    <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+      <div
+        className="h-full bg-indigo-600 transition-all duration-300"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,6 +14,7 @@ import LoginPage from './LoginPage.jsx'
 import SignUpPage from './SignUpPage.jsx'
 import ProfilePage from './ProfilePage.jsx';
 import PublicProfilePage from './PublicProfilePage.jsx';
+import OnboardingFlow from './OnboardingFlow.jsx';
 import { AuthProvider } from './AuthProvider.jsx'
 import MomentsExplorer from './MomentsExplorer.jsx' 
 import EventDetailPage from './EventDetailPage.jsx'
@@ -85,6 +86,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignUpPage />} />
           <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/onboarding-preview" element={<OnboardingFlow demo />} />
           <Route path="/u/:slug" element={<PublicProfilePage />} />
           <Route path="/moments" element={<MomentsExplorer />} />
           <Route path="/moments/:id" element={<MomentsExplorer />} />


### PR DESCRIPTION
## Summary
- add multi-step `OnboardingFlow` modal with events, tag subscription, profile setup, and orientation steps
- integrate onboarding in `ProfilePage` using `onboarding_complete` flag and optional `?onboard=1` param
- provide `/onboarding-preview` route and reusable `ProgressBar`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Invalid option '--ext' using eslint.config.js)


------
https://chatgpt.com/codex/tasks/task_e_68a718a7e5c0832cb5f65fb8ce46e47c