### PR TITLE
Prompt login before posting events

### DIFF
--- a/src/FloatingAddButton.jsx
+++ b/src/FloatingAddButton.jsx
@@ -1,13 +1,26 @@
 // src/FloatingAddButton.jsx
-import React from 'react'
+import React, { useContext, useState } from 'react'
 import { PlusIcon } from '@heroicons/react/24/solid'
+import { AuthContext } from './AuthProvider'
+import LoginPromptModal from './LoginPromptModal'
 
 export default function FloatingAddButton({ onClick }) {
+  const { user } = useContext(AuthContext)
+  const [showLogin, setShowLogin] = useState(false)
+
+  const handleClick = () => {
+    if (user) {
+      onClick()
+    } else {
+      setShowLogin(true)
+    }
+  }
+
   return (
     <>
       {/* Desktop: circular floating button */}
       <button
-        onClick={onClick}
+        onClick={handleClick}
         className="
           hidden md:block
           fixed bottom-6 right-6 z-50
@@ -22,7 +35,7 @@ export default function FloatingAddButton({ onClick }) {
 
       {/* Mobile: full-width sticky bar */}
       <button
-        onClick={onClick}
+        onClick={handleClick}
         className="
           md:hidden
           fixed bottom-0 left-0 right-0 z-50
@@ -36,6 +49,8 @@ export default function FloatingAddButton({ onClick }) {
         <PlusIcon className="h-6 w-6" />
         <span className="font-semibold">Post Event</span>
       </button>
+
+      {showLogin && <LoginPromptModal onClose={() => setShowLogin(false)} />}
     </>
   )
 }

--- a/src/LoginPromptModal.jsx
+++ b/src/LoginPromptModal.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function LoginPromptModal({ onClose }) {
+  return (
+    <div className="fixed inset-0 z-50 bg-black/30 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="bg-white rounded-xl w-full max-w-sm shadow-xl p-6 text-center relative">
+        <h2 className="text-2xl font-bold mb-4">Log In Required</h2>
+        <p className="mb-6">Please log in to post events.</p>
+        <div className="flex justify-center space-x-4">
+          <Link
+            to="/login"
+            onClick={onClose}
+            className="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+          >
+            Log In
+          </Link>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 border rounded hover:bg-gray-100"
+          >
+            Cancel
+          </button>
+        </div>
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-3 text-gray-400 hover:text-black text-xl"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -7,6 +7,7 @@ import PostFlyerModal from './PostFlyerModal';
 import { AuthContext } from './AuthProvider';
 import { supabase } from './supabaseClient';
 import NavTagMenu from './NavTagMenu';
+import LoginPromptModal from './LoginPromptModal';
 
 export default function Navbar({ style }) {
   const { user } = useContext(AuthContext);
@@ -16,6 +17,7 @@ export default function Navbar({ style }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [showSubmitModal, setShowSubmitModal] = useState(false);
   const [showPostModal, setShowPostModal] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
@@ -28,6 +30,11 @@ export default function Navbar({ style }) {
   };
 
   const openPostModal = () => {
+    if (!user) {
+      setShowLoginModal(true);
+      setMenuOpen(false);
+      return;
+    }
     setShowPostModal(true);
     setMenuOpen(false);
   };
@@ -177,6 +184,7 @@ export default function Navbar({ style }) {
       {/* Modals */}
       {showSubmitModal && <SubmitGroupModal onClose={() => setShowSubmitModal(false)} />}
       {showPostModal && <PostFlyerModal isOpen={showPostModal} onClose={() => setShowPostModal(false)} />}
+      {showLoginModal && <LoginPromptModal onClose={() => setShowLoginModal(false)} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable login prompt modal
- show modal if logged-out users click Post Event in nav or the floating add button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: 157 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a748ee9890832c8a8177b292b0d9f5