### PR TITLE
Add birds plans video page

### DIFF
--- a/src/PlansVideoIndex.jsx
+++ b/src/PlansVideoIndex.jsx
@@ -26,6 +26,7 @@ export default function PlansVideoIndex() {
     { to: '/plans-video-food', label: 'Nomnomslurp' },
     { to: '/plans-video-fitness', label: 'Fitness' },
     { to: '/plans-video-music', label: 'Music' },
+    { to: '/plans-video-birds', label: 'Birds' },
     { to: '/plans-video-traditions', label: 'Traditions' },
     { to: '/plans-video-peco', label: 'PECO Multicultural' },
     { to: '/plans-video-markets', label: 'Markets' },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -115,6 +115,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/social-video-fitness" element={<SocialVideoCarousel tag="fitness" />} />
           <Route path="/plans-video-arts" element={<PlansVideoCarousel tag="arts" />} />
           <Route path="/plans-video-food" element={<PlansVideoCarousel tag="nomnomslurp" />} />
+          <Route path="/plans-video-birds" element={<PlansVideoCarousel tag="birds" />} />
           <Route path="/plans-video-fitness" element={<PlansVideoCarousel tag="fitness" />} />
           <Route path="/plans-video-music" element={<PlansVideoCarousel tag="music" />} />
           <Route


### PR DESCRIPTION
## Summary
- add `/plans-video-birds` route showing bird-tagged events
- list Birds section on Plans Video index page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint src/main.jsx src/PlansVideoIndex.jsx` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_68b5db206c70832c8884d97d86aee068