### PR TITLE
Refactor event action buttons for clarity

### DIFF
--- a/src/BigBoardEventPage.jsx
+++ b/src/BigBoardEventPage.jsx
@@ -14,6 +14,14 @@ import SubmitEventSection from './SubmitEventSection';
 import useEventFavorite from './utils/useEventFavorite';
 import { isTagActive } from './utils/tagUtils';
 const CommentsSection = lazy(() => import('./CommentsSection'));
+import {
+  CalendarCheck,
+  CalendarPlus,
+  ExternalLink,
+  Pencil,
+  Share2,
+  Trash2,
+} from 'lucide-react';
 
 export default function BigBoardEventPage() {
   const { slug } = useParams();
@@ -122,6 +130,18 @@ export default function BigBoardEventPage() {
       copyLinkFallback(url);
     }
   }
+
+  const gcalLink = event ? (() => {
+    const start = event.start_date?.replace(/-/g, '') || '';
+    const end = (event.end_date || event.start_date || '').replace(/-/g, '');
+    const url = window.location.href;
+    return (
+      'https://www.google.com/calendar/render?action=TEMPLATE' +
+      `&text=${encodeURIComponent(event.title)}` +
+      `&dates=${start}/${end}` +
+      `&details=${encodeURIComponent('Details: ' + url)}`
+    );
+  })() : '#';
 
   // Fetch main event (including lat/lng)
   useEffect(() => {
@@ -733,107 +753,76 @@ export default function BigBoardEventPage() {
                       <p className="text-gray-700">{event.description}</p>
                     </div>
                   )}
-                  <div className="mb-6">
+                  <div className="space-y-4">
                     <button
                       onClick={handleFavorite}
                       disabled={favLoading}
-                      className={`w-full border border-indigo-600 rounded-md py-3 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+                      className={`w-full flex items-center justify-center gap-2 rounded-md py-3 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 border border-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
                     >
+                      <CalendarCheck className="w-5 h-5" />
                       {isFavorite ? 'In the Plans' : 'Add to Plans'}
                     </button>
-                  </div>
-                  {event.link && (
-                    <div className="mb-6">
+
+                    {event.link && (
                       <a
                         href={event.link}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className={`
-                          block w-full
-                          px-6 py-3
-                          rounded-md
-                          text-center
-                          bg-indigo-600 text-white
-                          text-base font-medium
-                          shadow-sm
-                          hover:bg-indigo-700
-                          focus:outline-none focus:ring-2 focus:ring-indigo-500
-                          active:scale-95
-                          transition duration-150 ease-in-out
-                          mb-4
-                        `}
+                        className="w-full flex items-center justify-center gap-2 rounded-md py-3 font-semibold border border-indigo-600 text-indigo-600 hover:bg-indigo-50"
                       >
-                        Event Page
+                        <ExternalLink className="w-5 h-5" />
+                        Visit Site
+                      </a>
+                    )}
+
+                    <div className="flex items-center justify-center gap-6 pt-2">
+                      <button
+                        onClick={handleShare}
+                        className="flex items-center gap-2 text-indigo-600 hover:underline"
+                      >
+                        <Share2 className="w-5 h-5" />
+                        Share
+                      </button>
+                      <a
+                        href={gcalLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-2 text-indigo-600 hover:underline"
+                      >
+                        <CalendarPlus className="w-5 h-5" />
+                        Google Calendar
                       </a>
                     </div>
-                  )}
 
-                  <div className="mt-6 flex flex-col space-y-4">
-                    <button
-                      onClick={handleShare}
-                      className={`
-                        w-full
-                        px-6 py-3
-                        rounded-md
-                        bg-green-600 text-white
-                        text-base font-medium
-                        shadow-sm
-                        hover:bg-green-700
-                        focus:outline-none focus:ring-2 focus:ring-green-500
-                        active:scale-95
-                        transition duration-150 ease-in-out
-                      `}
-                    >
-                      Share
-                    </button>
                     {event.owner_id === user?.id && (
-                      <>
+                      <div className="flex gap-3 pt-2">
                         <button
                           onClick={startEditing}
-                          className={`
-                            w-full
-                            px-6 py-3
-                            rounded-md
-                            bg-indigo-600 text-white
-                            text-base font-medium
-                            shadow-sm
-                            hover:bg-indigo-700
-                            focus:outline-none focus:ring-2 focus:ring-indigo-500
-                            active:scale-95
-                            transition duration-150 ease-in-out
-                          `}
+                          className="flex-1 flex items-center justify-center gap-2 rounded-md py-2 bg-indigo-100 text-indigo-700 hover:bg-indigo-200"
                         >
+                          <Pencil className="w-4 h-4" />
                           Edit
                         </button>
                         <button
                           onClick={handleDelete}
-                          className={`
-                            w-full
-                            px-6 py-3
-                            rounded-md
-                            bg-red-600 text-white
-                            text-base font-medium
-                            shadow-sm
-                            hover:bg-red-700
-                            focus:outline-none focus:ring-2 focus:ring-red-500
-                            active:scale-95
-                            transition duration-150 ease-in-out
-                          `}
+                          className="flex-1 flex items-center justify-center gap-2 rounded-md py-2 bg-red-100 text-red-700 hover:bg-red-200"
                         >
+                          <Trash2 className="w-4 h-4" />
                           Delete
                         </button>
-                      </>
+                      </div>
                     )}
+
                     <Link
                       to="/"
-                      className="w-full text-center text-indigo-600 hover:underline font-medium"
+                      className="block text-center text-indigo-600 hover:underline font-medium"
                     >
                       ← Back to Events
                     </Link>
                   </div>
-                </>
-              )}
-            </div>
+                  </>
+                )}
+              </div>
 
             {/* Right: full image */}
             <div>

--- a/src/EventDetailPage.jsx
+++ b/src/EventDetailPage.jsx
@@ -16,6 +16,7 @@ import TaggedEventScroller from './TaggedEventsScroller';
 import SubmitEventSection from './SubmitEventSection';
 import useEventFavorite from './utils/useEventFavorite';
 import ReviewPhotoGrid from './ReviewPhotoGrid';
+import { CalendarCheck, CalendarPlus, ExternalLink, Share2 } from 'lucide-react';
 
 export default function EventDetailPage() {
   const { slug } = useParams();
@@ -349,6 +350,18 @@ export default function EventDetailPage() {
     ? getFriendlyDate(event.Dates)
     : `${sd.toLocaleDateString('en-US',{ month:'long', day:'numeric' })} — ${ed.toLocaleDateString('en-US',{ month:'long', day:'numeric' })}`;
 
+  const gcalLink = (() => {
+    const start = (event.Dates || '').replace(/-/g, '');
+    const end = (event['End Date'] || event.Dates || '').replace(/-/g, '');
+    const url = window.location.href;
+    return (
+      'https://www.google.com/calendar/render?action=TEMPLATE' +
+      `&text=${encodeURIComponent(event['E Name'])}` +
+      `&dates=${start}/${end}` +
+      `&details=${encodeURIComponent('Details: ' + url)}`
+    );
+  })();
+
   return (
     <div className="flex flex-col min-h-screen bg-white">
       <Helmet>
@@ -407,30 +420,44 @@ export default function EventDetailPage() {
               {displayDate}
               {event.time && ` — ${event.time}`}
             </p>
-            <div className="flex justify-center gap-4 mb-6">
+            <div className="flex flex-col items-center gap-4 mb-6">
+              <button
+                onClick={toggleFav}
+                disabled={toggling}
+                className={`flex items-center gap-2 px-4 py-2 rounded font-semibold border border-indigo-400 ${isFavorite ? 'bg-white text-indigo-600' : 'bg-indigo-600 text-white hover:bg-indigo-700'}`}
+              >
+                <CalendarCheck className="w-5 h-5" />
+                {isFavorite ? 'In the Plans' : 'Add to Plans'}
+              </button>
               {event['E Link'] && (
                 <a
                   href={event['E Link']}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded"
+                  className="flex items-center gap-2 bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded"
                 >
+                  <ExternalLink className="w-5 h-5" />
                   Visit Site
                 </a>
               )}
-              <button
-                onClick={toggleFav}
-                disabled={toggling}
-                className={`border border-indigo-600 px-4 py-2 rounded font-semibold transition-colors ${isFavorite ? 'bg-white text-indigo-600' : 'bg-indigo-600 text-white hover:bg-indigo-700'}`}
-              >
-                {isFavorite ? 'In the Plans' : 'Add to Plans'}
-              </button>
-              <button
-                onClick={handleShare}
-                className="bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded"
-              >
-                Share
-              </button>
+              <div className="flex gap-4">
+                <button
+                  onClick={handleShare}
+                  className="flex items-center gap-2 bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded"
+                >
+                  <Share2 className="w-5 h-5" />
+                  Share
+                </button>
+                <a
+                  href={gcalLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded"
+                >
+                  <CalendarPlus className="w-5 h-5" />
+                  Google Calendar
+                </a>
+              </div>
             </div>
             {eventTags.length > 0 && (
               <div className="flex flex-wrap justify-center gap-3 mt-4">
@@ -508,8 +535,9 @@ export default function EventDetailPage() {
               <button
                 onClick={toggleFav}
                 disabled={toggling}
-                className={`w-full border border-indigo-600 rounded-md py-3 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+                className={`w-full flex items-center justify-center gap-2 rounded-md py-3 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 border border-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
               >
+                <CalendarCheck className="w-5 h-5" />
                 {isFavorite ? 'In the Plans' : 'Add to Plans'}
               </button>
             </div>

--- a/src/MainEventsDetail.jsx
+++ b/src/MainEventsDetail.jsx
@@ -14,6 +14,14 @@ import TaggedEventScroller from './TaggedEventsScroller';
 import useEventFavorite from './utils/useEventFavorite';
 import CommentsSection from './CommentsSection';
 import ReviewPhotoGrid from './ReviewPhotoGrid';
+import {
+  CalendarCheck,
+  CalendarPlus,
+  ExternalLink,
+  Pencil,
+  Share2,
+  Trash2,
+} from 'lucide-react';
 
 // parse "YYYY-MM-DD" into local Date
 function parseLocalYMD(str) {
@@ -594,48 +602,66 @@ export default function MainEventsDetail() {
                       <p className="text-gray-700 leading-relaxed">{event.description}</p>
                     </div>
                   )}
-                  <div className="mb-6">
+                  <div className="space-y-4">
                     <button
                       onClick={handleFavorite}
                       disabled={toggling}
-                      className={`w-full border border-indigo-600 rounded-md py-3 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+                      className={`w-full flex items-center justify-center gap-2 rounded-md py-3 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 border border-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
                     >
+                      <CalendarCheck className="w-5 h-5" />
                       {isFavorite ? 'In the Plans' : 'Add to Plans'}
                     </button>
-                  </div>
 
-                  <button
-                    onClick={handleShare}
-                    className="w-full bg-green-600 text-white py-3 rounded-lg shadow hover:bg-green-700 transition mb-4"
-                  >
-                    Share
-                  </button>
-
-                  <a
-                    href={gcalLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block w-full bg-indigo-600 text-white py-3 rounded-lg shadow hover:bg-indigo-700 transition mb-4 text-center"
-                  >
-                    Add to Google Calendar
-                  </a>
-
-                  {isAdmin && (
-                    <div className="space-y-3">
-                      <button
-                        onClick={() => setIsEditing(true)}
-                        className="w-full bg-indigo-600 text-white py-3 rounded-lg hover:bg-indigo-700 transition"
+                    {event.link && (
+                      <a
+                        href={event.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="w-full flex items-center justify-center gap-2 rounded-md py-3 font-semibold border border-indigo-600 text-indigo-600 hover:bg-indigo-50"
                       >
-                        Edit Event
-                      </button>
+                        <ExternalLink className="w-5 h-5" />
+                        Visit Site
+                      </a>
+                    )}
+
+                    <div className="flex items-center justify-center gap-6 pt-2">
                       <button
-                        onClick={handleDelete}
-                        className="w-full bg-red-600 text-white py-3 rounded-lg hover:bg-red-700 transition"
+                        onClick={handleShare}
+                        className="flex items-center gap-2 text-indigo-600 hover:underline"
                       >
-                        Delete Event
+                        <Share2 className="w-5 h-5" />
+                        Share
                       </button>
+                      <a
+                        href={gcalLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-2 text-indigo-600 hover:underline"
+                      >
+                        <CalendarPlus className="w-5 h-5" />
+                        Google Calendar
+                      </a>
                     </div>
-                  )}
+
+                    {isAdmin && (
+                      <div className="flex gap-3 pt-2">
+                        <button
+                          onClick={() => setIsEditing(true)}
+                          className="flex-1 flex items-center justify-center gap-2 rounded-md py-2 bg-indigo-100 text-indigo-700 hover:bg-indigo-200"
+                        >
+                          <Pencil className="w-4 h-4" />
+                          Edit
+                        </button>
+                        <button
+                          onClick={handleDelete}
+                          className="flex-1 flex items-center justify-center gap-2 rounded-md py-2 bg-red-100 text-red-700 hover:bg-red-200"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                          Delete
+                        </button>
+                      </div>
+                    )}
+                  </div>
                 </>
               )}
             </div>

--- a/src/RecurringEventPage.jsx
+++ b/src/RecurringEventPage.jsx
@@ -12,6 +12,7 @@ import FloatingAddButton from './FloatingAddButton';
 import SubmitEventSection from './SubmitEventSection';
 import useEventFavorite from './utils/useEventFavorite';
 import CommentsSection from './CommentsSection';
+import { CalendarCheck, CalendarPlus, ExternalLink, Share2 } from 'lucide-react';
 
 export default function RecurringEventPage() {
   const { slug, date } = useParams();
@@ -103,6 +104,19 @@ export default function RecurringEventPage() {
     if (navigator.share) navigator.share({ title, url }).catch(console.error);
     else copyLinkFallback(url);
   }
+
+  const gcalLink = (() => {
+    const next = date || occurrences[0]?.toISOString().slice(0,10);
+    if (!series || !next) return '#';
+    const start = next.replace(/-/g, '');
+    const url = window.location.href;
+    return (
+      'https://www.google.com/calendar/render?action=TEMPLATE' +
+      `&text=${encodeURIComponent(series.name)}` +
+      `&dates=${start}/${start}` +
+      `&details=${encodeURIComponent('Details: ' + url)}`
+    );
+  })();
 
   // Fetch series + tags
   useEffect(() => {
@@ -374,34 +388,48 @@ export default function RecurringEventPage() {
                   <p className="text-gray-700">{series.description}</p>
                 </div>
               )}
-              <div className="mb-6">
-                <button
-                  onClick={handleFavorite}
-                  disabled={favLoading}
-                  className={`w-full border border-indigo-600 rounded-md py-3 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
-                >
-                  {isFavorite ? 'In the Plans' : 'Add to Plans'}
-                </button>
+                <div className="space-y-4">
+                  <button
+                    onClick={handleFavorite}
+                    disabled={favLoading}
+                    className={`w-full flex items-center justify-center gap-2 rounded-md py-3 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 border border-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+                  >
+                    <CalendarCheck className="w-5 h-5" />
+                    {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                  </button>
+
+                  {series.link && (
+                    <a
+                      href={series.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="w-full flex items-center justify-center gap-2 rounded-md py-3 font-semibold border border-indigo-600 text-indigo-600 hover:bg-indigo-50"
+                    >
+                      <ExternalLink className="w-5 h-5" />
+                      Visit Site
+                    </a>
+                  )}
+
+                  <div className="flex items-center justify-center gap-6 pt-2">
+                    <button
+                      onClick={handleShare}
+                      className="flex items-center gap-2 text-indigo-600 hover:underline"
+                    >
+                      <Share2 className="w-5 h-5" />
+                      Share
+                    </button>
+                    <a
+                      href={gcalLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-2 text-indigo-600 hover:underline"
+                    >
+                      <CalendarPlus className="w-5 h-5" />
+                      Google Calendar
+                    </a>
+                  </div>
+                </div>
               </div>
-
-              {series.link && (
-                <a
-                  href={series.link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block w-full bg-indigo-600 text-white text-center py-3 rounded-lg shadow hover:bg-indigo-700 transition"
-                >
-                  Visit Site
-                </a>
-              )}
-
-              <button
-                onClick={handleShare}
-                className="block w-full bg-green-600 text-white text-center py-3 rounded-lg shadow hover:bg-green-700 mt-4 transition"
-              >
-                Share
-              </button>
-          </div>
 
           {/* Right side: capped-height image */}
           <div>


### PR DESCRIPTION
## Summary
- add icon-driven action buttons on event pages
- highlight "Add to Plans" and "Visit Site" across event views
- include Google Calendar and share options consistently
- close unbalanced markup in RecurringEventPage to fix Vercel build error

## Testing
- `npm run build`
- `npm test` (fails: Missing script: "test")
- `npx eslint .` (fails: 1947 errors)


------
https://chatgpt.com/codex/tasks/task_e_68bb1250cc6c832c96d4377be2289851