### PR TITLE
Add social gallery grid component

### DIFF
--- a/src/SocialGalleryGrid.jsx
+++ b/src/SocialGalleryGrid.jsx
@@ -1,0 +1,83 @@
+// src/SocialGalleryGrid.jsx
+import React, { useEffect, useState } from 'react'
+import { supabase } from './supabaseClient'
+import Navbar from './Navbar'
+
+export default function SocialGalleryGrid({ limit = 60 }) {
+  const [events, setEvents] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchEvents = async () => {
+    setLoading(true)
+    try {
+      const { data, error } = await supabase
+        .from('all_events')
+        .select('id, name, image')
+        .not('image', 'is', null)
+        .limit(100)
+      if (error) throw error
+      const shuffled = data.sort(() => 0.5 - Math.random())
+      setEvents(shuffled.slice(0, limit))
+    } catch (e) {
+      console.error('Error fetching events:', e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchEvents()
+  }, [limit])
+
+  useEffect(() => {
+    if (events.length > 0) {
+      window.scrollTo({ top: 0, behavior: 'auto' })
+      const interval = setInterval(() => {
+        const scrolled = window.innerHeight + window.scrollY
+        const height = document.body.offsetHeight
+        if (scrolled >= height) {
+          clearInterval(interval)
+        } else {
+          window.scrollBy({ top: 2, behavior: 'smooth' })
+        }
+      }, 30)
+      return () => clearInterval(interval)
+    }
+  }, [events])
+
+  return (
+    <div className="w-screen overflow-x-hidden">
+      <Navbar />
+      <div className="h-20" />
+      {loading ? (
+        <p className="text-center">Loading...</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-0">
+            {events.map(evt => (
+              <div key={evt.id} className="relative">
+                <img
+                  src={evt.image || 'https://via.placeholder.com/300'}
+                  alt={evt.name}
+                  className="w-full aspect-square object-cover"
+                />
+                <div className="absolute inset-0 bg-black/40" />
+                {evt.name && (
+                  <div className="absolute bottom-0 w-full bg-black/60 text-white text-3xl font-[Barrio] text-center p-2">
+                    {evt.name}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+          <button
+            onClick={fetchEvents}
+            className="w-full h-12 bg-blue-500 text-white"
+          >
+            Refresh
+          </button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -41,6 +41,7 @@ import PlansVideoIndex from './PlansVideoIndex.jsx';
 import AdminVideoPromo from './AdminVideoPromo.jsx';
 import BigBoardEventPage  from './BigBoardEventPage';
 import BigBoardCarousel from './BigBoardCarousel.jsx';
+import SocialGalleryGrid from './SocialGalleryGrid.jsx';
 import MainEvents from './MainEvents.jsx';
 import VenuePage from './VenuePage';
 import MainEventsDetail from './MainEventsDetail.jsx';
@@ -135,6 +136,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/plans-video" element={<PlansVideoIndex />} />
           <Route path="/big-board/:slug"  element={<BigBoardEventPage />} />
           <Route path="/board-carousel" element={<BigBoardCarousel />} />
+          <Route path="/social-gallery" element={<SocialGalleryGrid />} />
           <Route path="/:venue" element={<VenuePage />} />
           <Route path="/:venue/:slug" element={<MainEventsDetail />} />
           <Route path="/groups/:slug/events/:eventId" element={<GroupEventDetailPage />} />


### PR DESCRIPTION
## Summary
- show 60 events in a responsive grid with dark overlays and smaller Barrio titles
- slow automatic scrolling for more gradual browsing

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `curl -I http://localhost:4174/social-gallery`
- `npx -y playwright install chromium` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bca65d9158832c8f941952bcd1c732