### PR TITLE
fix: show total event count across pages

### DIFF
--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -969,7 +969,8 @@ useEffect(() => {
 
   const allPagedEvents = sortedEvents.slice((page - 1) * EVENTS_PER_PAGE, page * EVENTS_PER_PAGE);
 
-  const fullCount = allPagedEvents.length;
+  // Use the total number of events across all pages for the header count
+  const fullCount = totalCount;
   let toShow = allPagedEvents;
 if (selectedOption === 'today' && !showAllToday) {
   toShow = allPagedEvents.slice(0, 4);


### PR DESCRIPTION
## Summary
- show total number of events across all pages in header text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68bdc112bdbc832c836eedccadcd75cc