### PR TITLE
Insert fitness group rows into PlansVideoCarousel

### DIFF
--- a/src/PlansVideoCarousel.jsx
+++ b/src/PlansVideoCarousel.jsx
@@ -1,5 +1,6 @@
 // src/PlansVideoCarousel.jsx
 import React, { useEffect, useState, useRef } from 'react'
+import { Link } from 'react-router-dom'
 import { supabase } from './supabaseClient'
 import Navbar from './Navbar'
 
@@ -52,6 +53,8 @@ export default function PlansVideoCarousel({
   const [added, setAdded] = useState(false)
   const [pillConfigs, setPillConfigs] = useState([])
   const [navHeight, setNavHeight] = useState(0)
+  const [groups, setGroups] = useState([])
+  const [slides, setSlides] = useState([])
 
   const colors = [
     '#22C55E', // green
@@ -95,6 +98,23 @@ export default function PlansVideoCarousel({
       window.removeEventListener('resize', updateHeight)
     }
   }, [])
+
+  useEffect(() => {
+    if (tag !== 'fitness') { setGroups([]); return }
+    ;(async () => {
+      const { data, error } = await supabase
+        .from('groups')
+        .select('id, slug, Name, Type')
+      if (!error) {
+        const fitnessTags = ['climbing','cycling','running','health & fitness','sports leagues','outdoors & adventure','yoga']
+        const filtered = (data || []).filter(g => {
+          const types = (g.Type || '').toLowerCase()
+          return fitnessTags.some(t => types.includes(t))
+        })
+        setGroups(filtered)
+      }
+    })()
+  }, [tag])
 
   useEffect(() => {
     ;(async () => {
@@ -313,28 +333,103 @@ export default function PlansVideoCarousel({
         }
 
         if (!tag) {
-          const { data } = await supabase
-            .from('events')
-            .select('id, slug, "E Name", Dates, "End Date", "E Image", "E Description"')
-          const todayDate = new Date(); todayDate.setHours(0,0,0,0)
+          const [eRes, bbRes, aeRes, geRes] = await Promise.all([
+            supabase
+              .from('events')
+              .select('id, slug, "E Name", Dates, "End Date", "E Image", "E Description"'),
+            supabase
+              .from('big_board_events')
+              .select('id, title, slug, start_date, end_date, description, big_board_posts!big_board_posts_event_id_fkey(image_url)'),
+            supabase
+              .from('all_events')
+              .select('id, slug, name, start_date, image, description, venue_id(slug)'),
+            supabase
+              .from('group_events')
+              .select('id, title, slug, description, start_date, end_date, image_url, group_id'),
+          ])
+
+          let groupMap = {}
+          if (geRes.data?.length) {
+            const groupIds = [...new Set(geRes.data.map(ev => ev.group_id))]
+            if (groupIds.length) {
+              const { data: groupsData } = await supabase
+                .from('groups')
+                .select('id, slug')
+                .in('id', groupIds)
+              groupsData?.forEach(g => { groupMap[g.id] = g.slug })
+            }
+          }
+
           const merged = []
-          ;(data || []).forEach(e => {
+          ;(eRes.data || []).forEach(e => {
             const start = parseDate(e.Dates)
             const end = e['End Date'] ? parseDate(e['End Date']) : start
-            if (start && start >= todayDate) {
+            merged.push({
+              key: `ev-${e.id}`,
+              slug: `/events/${e.slug}`,
+              name: e['E Name'],
+              start,
+              end,
+              image: e['E Image'] || '',
+              description: e['E Description'] || ''
+            })
+          })
+          ;(bbRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const end = ev.end_date ? parseLocalYMD(ev.end_date) : start
+            const key = ev.big_board_posts?.[0]?.image_url
+            const image = key
+              ? supabase.storage.from('big-board').getPublicUrl(key).data.publicUrl
+              : ''
+            merged.push({
+              key: `bb-${ev.id}`,
+              slug: `/big-board/${ev.slug}`,
+              name: ev.title,
+              start,
+              end,
+              image,
+              description: ev.description || ''
+            })
+          })
+          ;(aeRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const venueSlug = ev.venue_id?.slug
+            merged.push({
+              key: `ae-${ev.id}`,
+              slug: venueSlug ? `/${venueSlug}/${ev.slug}` : `/${ev.slug}`,
+              name: ev.name,
+              start,
+              end: start,
+              image: ev.image || '',
+              description: ev.description || ''
+            })
+          })
+          ;(geRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const end = ev.end_date ? parseLocalYMD(ev.end_date) : start
+            let image = ''
+            if (ev.image_url?.startsWith('http')) image = ev.image_url
+            else if (ev.image_url)
+              image = supabase.storage.from('big-board').getPublicUrl(ev.image_url).data.publicUrl
+            const groupSlug = groupMap[ev.group_id]
+            if (groupSlug) {
               merged.push({
-                key: `ev-${e.id}`,
-                slug: `/events/${e.slug}`,
-                name: e['E Name'],
+                key: `ge-${ev.id}`,
+                slug: `/groups/${groupSlug}/events/${ev.slug}`,
+                name: ev.title,
                 start,
                 end,
-                image: e['E Image'] || '',
-                description: e['E Description'] || ''
+                image,
+                description: ev.description || ''
               })
             }
           })
-          merged.sort((a,b) => a.start - b.start)
-          setEvents(merged.slice(0,limit))
+
+          const todayDate = new Date(); todayDate.setHours(0,0,0,0)
+          const upcoming = merged
+            .filter(ev => ev.start && ev.start >= todayDate)
+            .sort((a, b) => a.start - b.start)
+          setEvents(upcoming.slice(0, limit))
           setLoading(false)
           return
         }
@@ -489,17 +584,45 @@ export default function PlansVideoCarousel({
     }, [tag, onlyEvents, weekend, limit])
 
   useEffect(() => {
-    if (!events.length) return
+    if (!events.length) { setSlides([]); return }
+    if (tag === 'fitness' && groups.length) {
+      const combined = []
+      let gIdx = 0
+      const sampleGroups = () => {
+        const shuffled = [...groups].sort(() => Math.random() - 0.5)
+        return shuffled.slice(0,7)
+      }
+      for (let i = 0; i < events.length; i++) {
+        if (i > 0 && i % 4 === 0) {
+          const sample = sampleGroups()
+          if (sample.length) {
+            combined.push({ type: 'groups', key: `g-${gIdx++}`, groups: sample })
+          }
+        }
+        combined.push({ type: 'event', ...events[i] })
+      }
+      setSlides(combined)
+    } else {
+      setSlides(events.map(ev => ({ type: 'event', ...ev })))
+    }
+  }, [events, groups, tag])
+
+  useEffect(() => {
+    setCurrent(0)
+  }, [slides.length])
+
+  useEffect(() => {
+    if (!slides.length) return
     setAdded(false)
     const borderTimer = setTimeout(() => setAdded(true), 1000)
     const slideTimer = setTimeout(() => {
-      setCurrent(c => (c + 1) % events.length)
+      setCurrent(c => (c + 1) % slides.length)
     }, 2000)
     return () => {
       clearTimeout(borderTimer)
       clearTimeout(slideTimer)
     }
-  }, [current, events])
+  }, [current, slides])
 
   useEffect(() => {
     const el = containerRef.current
@@ -544,46 +667,68 @@ export default function PlansVideoCarousel({
             <p className="text-center py-20">Loading…</p>
           ) : (
             <div ref={containerRef} className="flex w-full h-full overflow-hidden">
-              {events.map((evt, idx) => (
-                <div
-                  key={evt.key}
-                  className="flex-shrink-0 w-full h-full flex items-center justify-center p-4"
-                  style={{ minWidth: '100%' }}
-                >
+              {slides.map((slide, idx) => (
+                slide.type === 'event' ? (
                   <div
-                    className={`plans-carousel-card w-11/12 max-w-md mx-auto flex flex-col overflow-hidden rounded-xl bg-white transition-all duration-500 ${
-                      idx === current && added
-                        ? 'border-4 border-indigo-600'
-                        : 'border border-transparent'
-                    }`}
-                    style={{ maxHeight: 'calc(100dvh - var(--bottom-bar, 5rem) - env(safe-area-inset-bottom))' }}
+                    key={slide.key}
+                    className="flex-shrink-0 w-full h-full flex items-center justify-center p-4"
+                    style={{ minWidth: '100%' }}
                   >
-                    {evt.image && (
-                      <div className="shrink-0 relative w-full aspect-video">
-                        <img
-                          src={evt.image}
-                          alt={evt.name}
-                          className="absolute inset-0 h-full w-full object-cover"
-                        />
+                    <div
+                      className={`plans-carousel-card w-11/12 max-w-md mx-auto flex flex-col overflow-hidden rounded-xl bg-white transition-all duration-500 ${
+                        idx === current && added
+                          ? 'border-4 border-indigo-600'
+                          : 'border border-transparent'
+                      }`}
+                      style={{ maxHeight: 'calc(100dvh - var(--bottom-bar, 5rem) - env(safe-area-inset-bottom))' }}
+                    >
+                      {slide.image && (
+                        <div className="shrink-0 relative w-full aspect-video">
+                          <img
+                            src={slide.image}
+                            alt={slide.name}
+                            className="absolute inset-0 h-full w-full object-cover"
+                          />
+                        </div>
+                      )}
+                      <div className="min-h-0 flex-1 overflow-y-auto p-4 text-center">
+                        <h3 className="font-bold text-xl">{slide.name}</h3>
+                        <p className="text-gray-700 mb-4">{formatDate(slide.start)}</p>
                       </div>
-                    )}
-                    <div className="min-h-0 flex-1 overflow-y-auto p-4 text-center">
-                      <h3 className="font-bold text-xl">{evt.name}</h3>
-                      <p className="text-gray-700 mb-4">{formatDate(evt.start)}</p>
-                    </div>
-                    <div className="shrink-0 border-t p-3 bg-white">
-                      <button
-                        className={`w-full border rounded-md py-2 font-semibold transition-colors ${
-                          idx === current && added
-                            ? 'bg-indigo-600 text-white border-indigo-600'
-                            : 'bg-white text-indigo-600 border-indigo-600'
-                        }`}
-                      >
-                        {idx === current && added ? 'In the Plans' : 'Add to Plans'}
-                      </button>
+                      <div className="shrink-0 border-t p-3 bg-white">
+                        <button
+                          className={`w-full border rounded-md py-2 font-semibold transition-colors ${
+                            idx === current && added
+                              ? 'bg-indigo-600 text-white border-indigo-600'
+                              : 'bg-white text-indigo-600 border-indigo-600'
+                          }`}
+                        >
+                          {idx === current && added ? 'In the Plans' : 'Add to Plans'}
+                        </button>
+                      </div>
                     </div>
                   </div>
-                </div>
+                ) : (
+                  <div
+                    key={slide.key}
+                    className="flex-shrink-0 w-full h-full flex items-center justify-center p-4"
+                    style={{ minWidth: '100%' }}
+                  >
+                    <div className="w-11/12 max-w-md mx-auto bg-white rounded-xl overflow-hidden border">
+                      <p className="px-4 py-2 font-semibold">#fitness groups in the city</p>
+                      {slide.groups.map(g => (
+                        <Link
+                          key={g.id}
+                          to={`/groups/${g.slug}`}
+                          className="block px-4 py-3 border-t first:border-t-0"
+                        >
+                          <p className="font-semibold">{g.Name}</p>
+                          <p className="text-xs text-gray-600">{g.Type}</p>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                )
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
- revert headline to standard event message
- show seven fitness groups per interleaved slide with header
- fetch events from all tables when no tag

## Testing
- `npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68be0acf65b0832c9e053482b8f04f1e