### PR TITLE
Insert fitness group rows into PlansVideoCarousel

### DIFF
--- a/src/PlansVideoCarousel.jsx
+++ b/src/PlansVideoCarousel.jsx
@@ -1,7 +1,9 @@
 // src/PlansVideoCarousel.jsx
 import React, { useEffect, useState, useRef } from 'react'
+import { Link } from 'react-router-dom'
 import { supabase } from './supabaseClient'
 import Navbar from './Navbar'
+import { RRule } from 'rrule'
 
 const parseDate = datesStr => {
   if (!datesStr) return null
@@ -17,6 +19,42 @@ const parseLocalYMD = str => {
   const [y, m, d] = str.split('-').map(Number)
   const dt = new Date(y, m - 1, d)
   return isNaN(dt) ? null : dt
+}
+
+const expandRecurring = (rows, windowStart = null, windowEnd = null) => {
+  const out = []
+  const today0 = new Date()
+  today0.setHours(0, 0, 0, 0)
+  ;(rows || []).forEach(r => {
+    if (!r.rrule || !r.start_date) return
+    const opts = RRule.parseString(r.rrule)
+    const startTime = r.start_time || '00:00:00'
+    const dtstart = new Date(`${r.start_date}T${startTime}`)
+    if (isNaN(dtstart)) return
+    opts.dtstart = dtstart
+    if (r.end_date) opts.until = new Date(`${r.end_date}T23:59:59`)
+    const rule = new RRule(opts)
+    let dates = []
+    if (windowStart && windowEnd) {
+      dates = rule.between(windowStart, windowEnd, true)
+    } else {
+      const next = rule.after(today0, true)
+      if (next) dates = [next]
+    }
+    dates.forEach(d => {
+      const dateStr = d.toISOString().slice(0, 10)
+      out.push({
+        key: `re-${r.id}-${dateStr}`,
+        slug: `/series/${r.slug}/${dateStr}`,
+        name: r.name,
+        start: d,
+        end: d,
+        image: r.image_url || '',
+        description: r.description || ''
+      })
+    })
+  })
+  return out
 }
 
 const formatDate = date => {
@@ -52,6 +90,8 @@ export default function PlansVideoCarousel({
   const [added, setAdded] = useState(false)
   const [pillConfigs, setPillConfigs] = useState([])
   const [navHeight, setNavHeight] = useState(0)
+  const [groups, setGroups] = useState([])
+  const [slides, setSlides] = useState([])
 
   const colors = [
     '#22C55E', // green
@@ -97,6 +137,23 @@ export default function PlansVideoCarousel({
   }, [])
 
   useEffect(() => {
+    if (tag !== 'fitness') { setGroups([]); return }
+    ;(async () => {
+      const { data, error } = await supabase
+        .from('groups')
+        .select('id, slug, Name, Type')
+      if (!error) {
+        const fitnessTags = ['climbing','cycling','running','health & fitness','sports leagues','outdoors & adventure','yoga']
+        const filtered = (data || []).filter(g => {
+          const types = (g.Type || '').toLowerCase()
+          return fitnessTags.some(t => types.includes(t))
+        })
+        setGroups(filtered)
+      }
+    })()
+  }, [tag])
+
+  useEffect(() => {
     ;(async () => {
       try {
         if (weekend) {
@@ -108,7 +165,7 @@ export default function PlansVideoCarousel({
           else friday.setDate(todayDate.getDate() + (5 - day))
           const sunday = new Date(friday); sunday.setDate(friday.getDate() + 2)
 
-          const [eRes, bbRes, aeRes, geRes] = await Promise.all([
+          const [eRes, bbRes, aeRes, geRes, reRes] = await Promise.all([
             supabase
               .from('events')
               .select('id, slug, "E Name", Dates, "End Date", "E Image", "E Description"'),
@@ -121,6 +178,10 @@ export default function PlansVideoCarousel({
             supabase
               .from('group_events')
               .select('id, title, slug, description, start_date, end_date, image_url, group_id'),
+            supabase
+              .from('recurring_events')
+              .select('id, name, slug, description, image_url, start_date, end_date, start_time, rrule')
+              .eq('is_active', true),
           ])
 
           let groupMap = {}
@@ -199,6 +260,8 @@ export default function PlansVideoCarousel({
               })
             }
           })
+
+          merged.push(...expandRecurring(reRes.data || [], friday, sunday))
 
           const weekendEvents = merged
             .filter(ev => ev.start && ev.start >= friday && ev.start <= sunday)
@@ -212,7 +275,7 @@ export default function PlansVideoCarousel({
           const todayDate = new Date(); todayDate.setHours(0,0,0,0)
           const tomorrow = new Date(todayDate); tomorrow.setDate(todayDate.getDate() + 1)
 
-          const [eRes, bbRes, aeRes, geRes] = await Promise.all([
+          const [eRes, bbRes, aeRes, geRes, reRes] = await Promise.all([
             supabase
               .from('events')
               .select('id, slug, "E Name", Dates, "End Date", "E Image", "E Description"'),
@@ -225,6 +288,10 @@ export default function PlansVideoCarousel({
             supabase
               .from('group_events')
               .select('id, title, slug, description, start_date, end_date, image_url, group_id'),
+            supabase
+              .from('recurring_events')
+              .select('id, name, slug, description, image_url, start_date, end_date, start_time, rrule')
+              .eq('is_active', true),
           ])
 
           let groupMap = {}
@@ -304,6 +371,8 @@ export default function PlansVideoCarousel({
             }
           })
 
+          merged.push(...expandRecurring(reRes.data || [], todayDate, tomorrow))
+
           const todayEvents = merged
             .filter(ev => ev.start && ev.start >= todayDate && ev.start < tomorrow)
             .sort((a, b) => a.start - b.start)
@@ -313,28 +382,109 @@ export default function PlansVideoCarousel({
         }
 
         if (!tag) {
-          const { data } = await supabase
-            .from('events')
-            .select('id, slug, "E Name", Dates, "End Date", "E Image", "E Description"')
-          const todayDate = new Date(); todayDate.setHours(0,0,0,0)
+          const [eRes, bbRes, aeRes, geRes, reRes] = await Promise.all([
+            supabase
+              .from('events')
+              .select('id, slug, "E Name", Dates, "End Date", "E Image", "E Description"'),
+            supabase
+              .from('big_board_events')
+              .select('id, title, slug, start_date, end_date, description, big_board_posts!big_board_posts_event_id_fkey(image_url)'),
+            supabase
+              .from('all_events')
+              .select('id, slug, name, start_date, image, description, venue_id(slug)'),
+            supabase
+              .from('group_events')
+              .select('id, title, slug, description, start_date, end_date, image_url, group_id'),
+            supabase
+              .from('recurring_events')
+              .select('id, name, slug, description, image_url, start_date, end_date, start_time, rrule')
+              .eq('is_active', true),
+          ])
+
+          let groupMap = {}
+          if (geRes.data?.length) {
+            const groupIds = [...new Set(geRes.data.map(ev => ev.group_id))]
+            if (groupIds.length) {
+              const { data: groupsData } = await supabase
+                .from('groups')
+                .select('id, slug')
+                .in('id', groupIds)
+              groupsData?.forEach(g => { groupMap[g.id] = g.slug })
+            }
+          }
+
           const merged = []
-          ;(data || []).forEach(e => {
+          ;(eRes.data || []).forEach(e => {
             const start = parseDate(e.Dates)
             const end = e['End Date'] ? parseDate(e['End Date']) : start
-            if (start && start >= todayDate) {
+            merged.push({
+              key: `ev-${e.id}`,
+              slug: `/events/${e.slug}`,
+              name: e['E Name'],
+              start,
+              end,
+              image: e['E Image'] || '',
+              description: e['E Description'] || ''
+            })
+          })
+          ;(bbRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const end = ev.end_date ? parseLocalYMD(ev.end_date) : start
+            const key = ev.big_board_posts?.[0]?.image_url
+            const image = key
+              ? supabase.storage.from('big-board').getPublicUrl(key).data.publicUrl
+              : ''
+            merged.push({
+              key: `bb-${ev.id}`,
+              slug: `/big-board/${ev.slug}`,
+              name: ev.title,
+              start,
+              end,
+              image,
+              description: ev.description || ''
+            })
+          })
+          ;(aeRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const venueSlug = ev.venue_id?.slug
+            merged.push({
+              key: `ae-${ev.id}`,
+              slug: venueSlug ? `/${venueSlug}/${ev.slug}` : `/${ev.slug}`,
+              name: ev.name,
+              start,
+              end: start,
+              image: ev.image || '',
+              description: ev.description || ''
+            })
+          })
+          ;(geRes.data || []).forEach(ev => {
+            const start = parseLocalYMD(ev.start_date)
+            const end = ev.end_date ? parseLocalYMD(ev.end_date) : start
+            let image = ''
+            if (ev.image_url?.startsWith('http')) image = ev.image_url
+            else if (ev.image_url)
+              image = supabase.storage.from('big-board').getPublicUrl(ev.image_url).data.publicUrl
+            const groupSlug = groupMap[ev.group_id]
+            if (groupSlug) {
               merged.push({
-                key: `ev-${e.id}`,
-                slug: `/events/${e.slug}`,
-                name: e['E Name'],
+                key: `ge-${ev.id}`,
+                slug: `/groups/${groupSlug}/events/${ev.slug}`,
+                name: ev.title,
                 start,
                 end,
-                image: e['E Image'] || '',
-                description: e['E Description'] || ''
+                image,
+                description: ev.description || ''
               })
             }
           })
-          merged.sort((a,b) => a.start - b.start)
-          setEvents(merged.slice(0,limit))
+
+          merged.push(...expandRecurring(reRes.data || []))
+
+          const todayDate = new Date(); todayDate.setHours(0,0,0,0)
+          const upcoming = merged
+            .filter(ev => ev.start && ev.start >= todayDate)
+            .sort((a, b) => a.start - b.start)
+          setEvents(upcoming.slice(0, limit))
           setLoading(false)
           return
         }
@@ -349,7 +499,7 @@ export default function PlansVideoCarousel({
 
         const allowedTypes = onlyEvents
           ? ['events']
-          : ['events', 'big_board_events', 'all_events', 'group_events']
+          : ['events', 'big_board_events', 'all_events', 'group_events', 'recurring_events']
 
         const { data: taggings } = await supabase
           .from('taggings')
@@ -357,12 +507,12 @@ export default function PlansVideoCarousel({
           .eq('tag_id', tagId)
           .in('taggable_type', allowedTypes)
 
-        const idsByType = { events: [], big_board_events: [], all_events: [], group_events: [] }
+        const idsByType = { events: [], big_board_events: [], all_events: [], group_events: [], recurring_events: [] }
         ;(taggings || []).forEach(t => {
           if (idsByType[t.taggable_type]) idsByType[t.taggable_type].push(t.taggable_id)
         })
 
-        const [eRes, bbRes, aeRes, geRes] = await Promise.all([
+        const [eRes, bbRes, aeRes, geRes, reRes] = await Promise.all([
           allowedTypes.includes('events') && idsByType.events.length
             ? supabase
                 .from('events')
@@ -386,6 +536,12 @@ export default function PlansVideoCarousel({
                 .from('group_events')
                 .select('id, title, slug, description, start_date, end_date, image_url, group_id')
                 .in('id', idsByType.group_events)
+            : { data: [] },
+          allowedTypes.includes('recurring_events') && idsByType.recurring_events.length
+            ? supabase
+                .from('recurring_events')
+                .select('id, name, slug, description, image_url, start_date, end_date, start_time, rrule')
+                .in('id', idsByType.recurring_events)
             : { data: [] },
         ])
 
@@ -473,6 +629,9 @@ export default function PlansVideoCarousel({
             }
           })
         }
+        if (allowedTypes.includes('recurring_events')) {
+          merged.push(...expandRecurring(reRes.data || []))
+        }
 
         const todayDate = new Date(); todayDate.setHours(0,0,0,0)
         const upcoming = merged
@@ -489,17 +648,45 @@ export default function PlansVideoCarousel({
     }, [tag, onlyEvents, weekend, limit])
 
   useEffect(() => {
-    if (!events.length) return
+    if (!events.length) { setSlides([]); return }
+    if (tag === 'fitness' && groups.length) {
+      const combined = []
+      let gIdx = 0
+      const sampleGroups = () => {
+        const shuffled = [...groups].sort(() => Math.random() - 0.5)
+        return shuffled.slice(0,7)
+      }
+      for (let i = 0; i < events.length; i++) {
+        if (i > 0 && i % 4 === 0) {
+          const sample = sampleGroups()
+          if (sample.length) {
+            combined.push({ type: 'groups', key: `g-${gIdx++}`, groups: sample })
+          }
+        }
+        combined.push({ type: 'event', ...events[i] })
+      }
+      setSlides(combined)
+    } else {
+      setSlides(events.map(ev => ({ type: 'event', ...ev })))
+    }
+  }, [events, groups, tag])
+
+  useEffect(() => {
+    setCurrent(0)
+  }, [slides.length])
+
+  useEffect(() => {
+    if (!slides.length) return
     setAdded(false)
     const borderTimer = setTimeout(() => setAdded(true), 1000)
     const slideTimer = setTimeout(() => {
-      setCurrent(c => (c + 1) % events.length)
+      setCurrent(c => (c + 1) % slides.length)
     }, 2000)
     return () => {
       clearTimeout(borderTimer)
       clearTimeout(slideTimer)
     }
-  }, [current, events])
+  }, [current, slides])
 
   useEffect(() => {
     const el = containerRef.current
@@ -544,46 +731,68 @@ export default function PlansVideoCarousel({
             <p className="text-center py-20">Loading…</p>
           ) : (
             <div ref={containerRef} className="flex w-full h-full overflow-hidden">
-              {events.map((evt, idx) => (
-                <div
-                  key={evt.key}
-                  className="flex-shrink-0 w-full h-full flex items-center justify-center p-4"
-                  style={{ minWidth: '100%' }}
-                >
+              {slides.map((slide, idx) => (
+                slide.type === 'event' ? (
                   <div
-                    className={`plans-carousel-card w-11/12 max-w-md mx-auto flex flex-col overflow-hidden rounded-xl bg-white transition-all duration-500 ${
-                      idx === current && added
-                        ? 'border-4 border-indigo-600'
-                        : 'border border-transparent'
-                    }`}
-                    style={{ maxHeight: 'calc(100dvh - var(--bottom-bar, 5rem) - env(safe-area-inset-bottom))' }}
+                    key={slide.key}
+                    className="flex-shrink-0 w-full h-full flex items-center justify-center p-4"
+                    style={{ minWidth: '100%' }}
                   >
-                    {evt.image && (
-                      <div className="shrink-0 relative w-full aspect-video">
-                        <img
-                          src={evt.image}
-                          alt={evt.name}
-                          className="absolute inset-0 h-full w-full object-cover"
-                        />
+                    <div
+                      className={`plans-carousel-card w-11/12 max-w-md mx-auto flex flex-col overflow-hidden rounded-xl bg-white transition-all duration-500 ${
+                        idx === current && added
+                          ? 'border-4 border-indigo-600'
+                          : 'border border-transparent'
+                      }`}
+                      style={{ maxHeight: 'calc(100dvh - var(--bottom-bar, 5rem) - env(safe-area-inset-bottom))' }}
+                    >
+                      {slide.image && (
+                        <div className="shrink-0 relative w-full aspect-video">
+                          <img
+                            src={slide.image}
+                            alt={slide.name}
+                            className="absolute inset-0 h-full w-full object-cover"
+                          />
+                        </div>
+                      )}
+                      <div className="min-h-0 flex-1 overflow-y-auto p-4 text-center">
+                        <h3 className="font-bold text-xl">{slide.name}</h3>
+                        <p className="text-gray-700 mb-4">{formatDate(slide.start)}</p>
                       </div>
-                    )}
-                    <div className="min-h-0 flex-1 overflow-y-auto p-4 text-center">
-                      <h3 className="font-bold text-xl">{evt.name}</h3>
-                      <p className="text-gray-700 mb-4">{formatDate(evt.start)}</p>
-                    </div>
-                    <div className="shrink-0 border-t p-3 bg-white">
-                      <button
-                        className={`w-full border rounded-md py-2 font-semibold transition-colors ${
-                          idx === current && added
-                            ? 'bg-indigo-600 text-white border-indigo-600'
-                            : 'bg-white text-indigo-600 border-indigo-600'
-                        }`}
-                      >
-                        {idx === current && added ? 'In the Plans' : 'Add to Plans'}
-                      </button>
+                      <div className="shrink-0 border-t p-3 bg-white">
+                        <button
+                          className={`w-full border rounded-md py-2 font-semibold transition-colors ${
+                            idx === current && added
+                              ? 'bg-indigo-600 text-white border-indigo-600'
+                              : 'bg-white text-indigo-600 border-indigo-600'
+                          }`}
+                        >
+                          {idx === current && added ? 'In the Plans' : 'Add to Plans'}
+                        </button>
+                      </div>
                     </div>
                   </div>
-                </div>
+                ) : (
+                  <div
+                    key={slide.key}
+                    className="flex-shrink-0 w-full h-full flex items-center justify-center p-4"
+                    style={{ minWidth: '100%' }}
+                  >
+                    <div className="w-11/12 max-w-md mx-auto bg-white rounded-xl overflow-hidden border">
+                      <p className="px-4 py-2 font-semibold">#fitness groups in the city</p>
+                      {slide.groups.map(g => (
+                        <Link
+                          key={g.id}
+                          to={`/groups/${g.slug}`}
+                          className="block px-4 py-3 border-t first:border-t-0"
+                        >
+                          <p className="font-semibold">{g.Name}</p>
+                          <p className="text-xs text-gray-600">{g.Type}</p>
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                )
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
- add recurring event handling to PlansVideoCarousel using RRule
- fetch recurring events alongside other tables for weekend, today, and tagged views
- include recurring events when filtering by tag so fitness pages show recurring classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Invalid option '--ext' with eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68be0acf65b0832c9e053482b8f04f1e