### PR TITLE
Limit fitness groups to five and hide Health & Fitness tag

### DIFF
--- a/src/PlansVideoCarousel.jsx
+++ b/src/PlansVideoCarousel.jsx
@@ -143,11 +143,21 @@ export default function PlansVideoCarousel({
         .from('groups')
         .select('id, slug, Name, Type')
       if (!error) {
-        const fitnessTags = ['climbing','cycling','running','health & fitness','sports leagues','outdoors & adventure','yoga']
-        const filtered = (data || []).filter(g => {
-          const types = (g.Type || '').toLowerCase()
-          return fitnessTags.some(t => types.includes(t))
-        })
+        const fitnessTags = ['climbing','cycling','running','sports leagues','outdoors & adventure','yoga']
+        const filtered = (data || [])
+          .filter(g => {
+            const types = (g.Type || '').toLowerCase()
+            return fitnessTags.some(t => types.includes(t))
+          })
+          .map(g => ({
+            ...g,
+            Type: (g.Type || '')
+              .split(',')
+              .map(t => t.trim())
+              .filter(t => t.toLowerCase() !== 'health & fitness')
+              .join(', '),
+          }))
+          .slice(0, 5)
         setGroups(filtered)
       }
     })()
@@ -654,7 +664,7 @@ export default function PlansVideoCarousel({
       let gIdx = 0
       const sampleGroups = () => {
         const shuffled = [...groups].sort(() => Math.random() - 0.5)
-        return shuffled.slice(0,7)
+        return shuffled.slice(0,5)
       }
       for (let i = 0; i < events.length; i++) {
         if (i > 0 && i % 4 === 0) {


### PR DESCRIPTION
## Summary
- Filter fitness groups to exclude "Health & Fitness" tag and limit to five results.
- Show up to five random fitness groups per slide in the plans video carousel.

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_68bed78434e4832c8a81d236cc1da8e8