### PR TITLE
Remove navigation from admin video promo and show more events

### DIFF
--- a/src/AdminVideoPromo.jsx
+++ b/src/AdminVideoPromo.jsx
@@ -1,6 +1,5 @@
 // src/AdminVideoPromo.jsx
 import React, { useEffect, useState, useContext } from 'react';
-import Navbar from './Navbar';
 import { supabase } from './supabaseClient';
 import { AuthContext } from './AuthProvider';
 
@@ -81,7 +80,7 @@ export default function AdminVideoPromo() {
         };
       })
       .filter(ev => ev.date && ev.date >= today)
-      .slice(0, 7);
+      .slice(0, 11);
     setEvents(upcoming);
   }
 
@@ -92,8 +91,6 @@ export default function AdminVideoPromo() {
   return (
     <>
       <div className="relative min-h-screen text-white">
-        <div className="fixed top-0 w-full h-1 bg-white z-50" />
-        <Navbar style={{ top: '4px' }} />
         <video
           className="absolute inset-0 w-full h-full object-cover"
           src="https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images//13687405-hd_1080_1920_30fps.mp4"
@@ -103,7 +100,7 @@ export default function AdminVideoPromo() {
           playsInline
         />
         <div className="absolute inset-0 bg-black/50" />
-        <div className="relative z-10 pt-36 max-w-2xl mx-auto px-4">
+        <div className="relative z-10 max-w-2xl mx-auto px-4 pt-6 pb-6">
           <h1 className="text-center text-4xl font-[Barrio] mb-1">Upcoming Philly Traditions</h1>
           <p className="text-center text-xs mb-4">Make your Philly plans at ourphilly.org</p>
           {events.map(ev => (


### PR DESCRIPTION
## Summary
- hide navigation and tag menu from admin video promo page for a cleaner display
- expand upcoming events shown from 7 to 11
- replace margins with paddings above title and event list to avoid white space

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: 155 errors, e.g. `console` is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c59233ec34832c8d5c817cc5e92152