### PR TITLE
Add Traditions Video link under plans-video

### DIFF
--- a/src/PlansVideoIndex.jsx
+++ b/src/PlansVideoIndex.jsx
@@ -28,7 +28,7 @@ export default function PlansVideoIndex() {
     { to: '/plans-video-fitness', label: 'Fitness' },
     { to: '/plans-video-music', label: 'Music' },
     { to: '/plans-video-birds', label: 'Birds' },
-    { to: '/plans-video-traditions', label: 'Traditions' },
+    { to: '/plans-video/traditions-video', label: 'Traditions Video' },
     { to: '/plans-video-oktoberfest', label: 'Oktoberfest' },
     { to: '/plans-video-peco', label: 'PECO Multicultural' },
     { to: '/plans-video-markets', label: 'Markets' },

--- a/src/TraditionsVideo.jsx
+++ b/src/TraditionsVideo.jsx
@@ -1,7 +1,6 @@
-// src/AdminVideoPromo.jsx
-import React, { useEffect, useState, useContext } from 'react';
+// src/TraditionsVideo.jsx
+import React, { useEffect, useState } from 'react';
 import { supabase } from './supabaseClient';
-import { AuthContext } from './AuthProvider';
 
 function parseDateTime(datesStr) {
   if (!datesStr) return { date: null, time: null };
@@ -45,15 +44,12 @@ function formatDisplayDate(date, startTime) {
   return `${prefix}, ${datePart}${timePart ? `, ${timePart}` : ''}`;
 }
 
-export default function AdminVideoPromo() {
-  const { isAdmin } = useContext(AuthContext);
+export default function TraditionsVideo() {
   const [events, setEvents] = useState([]);
 
   useEffect(() => {
-    if (isAdmin) {
-      loadEvents();
-    }
-  }, [isAdmin]);
+    loadEvents();
+  }, []);
 
   async function loadEvents() {
     const { data, error } = await supabase
@@ -82,10 +78,6 @@ export default function AdminVideoPromo() {
       .filter(ev => ev.date && ev.date >= today)
       .slice(0, 10);
     setEvents(upcoming);
-  }
-
-  if (!isAdmin) {
-    return <div className="text-center py-20 text-gray-500">Access denied.</div>;
   }
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -38,7 +38,7 @@ import AdminComments from './AdminComments.jsx';
 import SocialVideoCarousel from './SocialVideoCarousel.jsx';
 import PlansVideoCarousel from './PlansVideoCarousel.jsx';
 import PlansVideoIndex from './PlansVideoIndex.jsx';
-import AdminVideoPromo from './AdminVideoPromo.jsx';
+import TraditionsVideo from './TraditionsVideo.jsx';
 import BigBoardEventPage  from './BigBoardEventPage';
 import BigBoardCarousel from './BigBoardCarousel.jsx';
 import MainEvents from './MainEvents.jsx';
@@ -109,7 +109,6 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/admin/comments" element={<AdminComments />} />
           <Route path="/admin" element={<AdminDashboard />} />
           <Route path="/admin/activity" element={<AdminActivity />} />
-          <Route path="/admin/video-promo" element={<AdminVideoPromo />} />
           <Route path="/social-video-arts" element={<SocialVideoCarousel tag="arts" />} />
           <Route path="/social-video-food" element={<SocialVideoCarousel tag="nomnomslurp" />} />
           <Route path="/social-video-fitness" element={<SocialVideoCarousel tag="fitness" />} />
@@ -119,10 +118,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/plans-video-fitness" element={<PlansVideoCarousel tag="fitness" limit={40} />} />
           <Route path="/plans-video-music" element={<PlansVideoCarousel tag="music" />} />
           <Route path="/plans-video-oktoberfest" element={<PlansVideoCarousel tag="oktoberfest" />} />
-          <Route
-            path="/plans-video-traditions"
-            element={<PlansVideoCarousel onlyEvents headline="Upcoming Philly Traditions" />}
-          />
+          <Route path="/plans-video/traditions-video" element={<TraditionsVideo />} />
           <Route path="/plans-video-peco" element={<PlansVideoCarousel tag="peco-multicultural" />} />
           <Route path="/plans-video-markets" element={<PlansVideoCarousel tag="markets" />} />
           <Route


### PR DESCRIPTION
## Summary
- Move video promo out of admin into a public TraditionsVideo component
- Route `/plans-video/traditions-video` serves the traditions video and is linked from the plans-video index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: 157 problems, 155 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68c5c6aa66e4832cb56ebe09353395ff