### PR TITLE
Fallback Supabase auth storage for mobile browsers

### DIFF
--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -3,4 +3,22 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = 'https://qdartpzrxmftmaftfdbd.supabase.co';
 const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFkYXJ0cHpyeG1mdG1hZnRmZGJkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDMxMDc3OTgsImV4cCI6MjA1ODY4Mzc5OH0.maFYGLz62w4n-BVERIvbxhIewzjPkkqJgXAn61FmIA8';
 
-export const supabase = createClient(supabaseUrl, supabaseKey);
+let storage;
+let persistSession = false;
+try {
+  if (typeof globalThis.localStorage !== 'undefined') {
+    storage = globalThis.localStorage;
+    persistSession = true;
+  }
+} catch {
+  // In some mobile browsers (e.g., Safari private mode) localStorage
+  // is unavailable or throws. Fall back to in-memory storage so Supabase
+  // still works and events load.
+}
+
+export const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: {
+    storage,
+    persistSession,
+  },
+});


### PR DESCRIPTION
## Summary
- handle missing `localStorage` when creating the Supabase client to avoid runtime errors on mobile browsers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint src/supabaseClient.js`
- `npm run build` *(fails: Browserslist: caniuse-lite is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a6f76610832ca0e097d1d4afff4c