### PR TITLE
Add traditions gallery plans video page

### DIFF
--- a/src/PlansVideoIndex.jsx
+++ b/src/PlansVideoIndex.jsx
@@ -28,6 +28,7 @@ export default function PlansVideoIndex() {
     { to: '/plans-video-fitness', label: 'Fitness' },
     { to: '/plans-video-music', label: 'Music' },
     { to: '/plans-video-birds', label: 'Birds' },
+    { to: '/plans-video/traditions-gallery', label: 'Traditions gAllery' },
     { to: '/plans-video/traditions-video', label: 'Traditions Video' },
     { to: '/plans-video-oktoberfest', label: 'Oktoberfest' },
     { to: '/plans-video-peco', label: 'PECO Multicultural' },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -119,6 +119,10 @@ ReactDOM.createRoot(document.getElementById('root')).render(
           <Route path="/plans-video-music" element={<PlansVideoCarousel tag="music" />} />
           <Route path="/plans-video-oktoberfest" element={<PlansVideoCarousel tag="oktoberfest" />} />
           <Route path="/plans-video/traditions-video" element={<TraditionsVideo />} />
+          <Route
+            path="/plans-video/traditions-gallery"
+            element={<PlansVideoCarousel onlyEvents headline="Traditions gAllery" limit={30} />}
+          />
           <Route path="/plans-video-peco" element={<PlansVideoCarousel tag="peco-multicultural" />} />
           <Route path="/plans-video-markets" element={<PlansVideoCarousel tag="markets" />} />
           <Route


### PR DESCRIPTION
## Summary
- add a Plans Video route for the Traditions gAllery that reuses the carousel and limits the feed to the `events` table
- expose the new page from the plans-video index menu

## Testing
- npm run lint *(fails: Invalid option '--ext' with eslint.config.js)*
- npx eslint . *(fails: repository-wide lint issues pre-exist)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2641c12c832caf418f89c426fc7e