### PR TITLE
Refine footer tagline and link alignment

### DIFF
--- a/src/Footer.jsx
+++ b/src/Footer.jsx
@@ -8,33 +8,27 @@ const Footer = () => {
 
   return (
     <footer className="relative bg-gray-900 text-gray-300 pt-64 pb-12 px-6 overflow-visible">
-      {/* clipping window: only top half of heart shows */}
-      <div className="absolute bottom-0 right-0 h-64 w-[600px]  pointer-events-none">
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 pointer-events-none">
         <img
           src={heartUrl}
           alt="Heart"
-          className="absolute bottom-0 right-0 w-3/4 h-auto opacity-100"
+          className="w-20 sm:w-24 h-auto -translate-y-1/2"
         />
       </div>
 
       <div className="max-w-screen-xl mx-auto grid grid-cols-1 md:grid-cols-4 gap-10 relative z-10">
         {/* Brand / Copyright */}
         <div className="col-span-1 md:col-span-2">
-        <img
-              src="https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/sign/group-images/logoo.png?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJncm91cC1pbWFnZXMvbG9nb28ucG5nIiwiaWF0IjoxNzQ1NzYzMzA5LCJleHAiOjMzMjgxNzYzMzA5fQ.5BrTLfgwYzwT3UnYsqOkaJKLTP4pDVME_T-l7fyllc0"
-              alt="Our Philly Logo"
-              className="h-20 w-auto"
-            />
-          <p className="text-sm text-gray-400 mb-4">
-            Making community more accessible in the city.
+          <p className="text-4xl sm:text-6xl md:text-7xl font-[Barrio] text-white leading-tight mb-6">
+            Our Philly: The most comprehensive events calendar in Philadelphia.
           </p>
 
           <p className="text-xs text-gray-500">&copy; {year} Our Philly. All rights reserved.</p>
         </div>
 
         {/* Help nav */}
-        <div>
-          <h3 className="text-lg font-semibold text-white mb-3">Help</h3>
+        <div className="md:text-right md:justify-self-end">
+          <h3 className="text-lg font-semibold text-white mb-3">more</h3>
           <ul className="space-y-2">
             <li>
               <a href="/traditions-faq" className="text-sm text-gray-400 hover:text-white">Traditions Hosts FAQ</a>


### PR DESCRIPTION
## Summary
- shrink the footer heart graphic further so it gently overlaps the section above
- remove the Our Philly wordmark image, restyle the tagline with the Barrio font, and enlarge the typography
- right-align the footer "more" links to replace the previous Help column heading

## Testing
- npm run lint *(fails: Invalid option '--ext' when using eslint.config.js)*
- npx eslint . *(fails: repository has existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc10065928832cbb802623bfd52f2e