### PR TITLE
Update weekend and traditions pages and navigation

### DIFF
--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -1,7 +1,7 @@
 // src/Navbar.jsx
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Menu, X } from 'lucide-react';
+import { ChevronDown, Menu, X } from 'lucide-react';
 import { FaTiktok, FaInstagram } from 'react-icons/fa';
 import SubmitGroupModal from './SubmitGroupModal';
 import PostFlyerModal from './PostFlyerModal';
@@ -16,9 +16,14 @@ export default function Navbar({ style }) {
   const navigate = useNavigate();
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const [guidesOpen, setGuidesOpen] = useState(false);
   const [showSubmitModal, setShowSubmitModal] = useState(false);
   const [showPostModal, setShowPostModal] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
+
+  useEffect(() => {
+    setGuidesOpen(false);
+  }, [location.pathname]);
 
   const handleLogout = async () => {
     await supabase.auth.signOut();
@@ -46,6 +51,10 @@ export default function Navbar({ style }) {
         ? 'text-gray-900 font-semibold'
         : 'text-gray-700'
     }`;
+
+  const exploreActive =
+    location.pathname.startsWith('/this-weekend-in-philadelphia') ||
+    location.pathname.startsWith('/philadelphia-events');
 
   return (
     <>
@@ -84,7 +93,7 @@ export default function Navbar({ style }) {
 
             {/* Primary links */}
             <ul className="flex items-center space-x-6 font-medium">
-              
+
               <li>
                 <button
                   onClick={openPostModal}
@@ -92,6 +101,44 @@ export default function Navbar({ style }) {
                 >
                   Post Event
                 </button>
+              </li>
+
+              <li
+                className="relative"
+                onMouseEnter={() => setGuidesOpen(true)}
+                onMouseLeave={() => setGuidesOpen(false)}
+              >
+                <button
+                  onClick={() => setGuidesOpen(open => !open)}
+                  className={`flex items-center space-x-1 ${
+                    exploreActive ? 'text-gray-900 font-semibold' : 'text-gray-700'
+                  } hover:text-gray-900 transition`}
+                  aria-haspopup="true"
+                  aria-expanded={guidesOpen}
+                >
+                  <span>Events &amp; Guides</span>
+                  <ChevronDown
+                    className={`w-4 h-4 transition-transform ${guidesOpen ? 'rotate-180' : ''}`}
+                  />
+                </button>
+                {guidesOpen && (
+                  <div className="absolute right-0 mt-3 w-64 bg-white border border-gray-200 rounded-xl shadow-lg py-3 z-50">
+                    <Link
+                      to="/this-weekend-in-philadelphia"
+                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-indigo-50 hover:text-indigo-700"
+                      onClick={() => setGuidesOpen(false)}
+                    >
+                      This Weekend in Philadelphia
+                    </Link>
+                    <Link
+                      to="/philadelphia-events/"
+                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-indigo-50 hover:text-indigo-700"
+                      onClick={() => setGuidesOpen(false)}
+                    >
+                      Philly Traditions Calendar
+                    </Link>
+                  </div>
+                )}
               </li>
 
               <li>
@@ -106,7 +153,7 @@ export default function Navbar({ style }) {
               <li>
                 <Link
                   to="/contact"
-                  className={`flex items-center space-x-1 ${linkClass('/groups')}`}
+                  className={`flex items-center space-x-1 ${linkClass('/contact')}`}
                 >
                   <span>Contact</span>
                 </Link>
@@ -187,14 +234,25 @@ export default function Navbar({ style }) {
                 <FaInstagram className="w-5 h-5 text-gray-700 hover:text-gray-900" />
               </a>
             </div>
+            <Link
+              to="/this-weekend-in-philadelphia"
+              className="block"
+              onClick={() => setMenuOpen(false)}
+            >
+              This Weekend in Philly
+            </Link>
+            <Link
+              to="/philadelphia-events/"
+              className="block"
+              onClick={() => setMenuOpen(false)}
+            >
+              Philly Traditions Calendar
+            </Link>
             <Link to="/groups" className="block" onClick={() => setMenuOpen(false)}>
               Claim Your Group
             </Link>
-            <Link
-              to="/contact"
-              className={`flex items-center space-x-1 ${linkClass('/groups')}`}
-            >
-              <span>Contact</span>
+            <Link to="/contact" className="block" onClick={() => setMenuOpen(false)}>
+              Contact
             </Link>
             <Link to="/about" className="block" onClick={() => setMenuOpen(false)}>
               About

--- a/src/PhiladelphiaEventsIndex.jsx
+++ b/src/PhiladelphiaEventsIndex.jsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getZonedDate, PHILLY_TIME_ZONE, indexToMonthSlug } from './utils/dateUtils';
+
+export default function PhiladelphiaEventsIndex() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const now = getZonedDate(new Date(), PHILLY_TIME_ZONE);
+    const slug = indexToMonthSlug(now.getMonth() + 1);
+    const year = now.getFullYear();
+    navigate(`/philadelphia-events-${slug}-${year}/`, { replace: true });
+  }, [navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-white text-gray-600">
+      Redirecting to this month’s events…
+    </div>
+  );
+}
+

--- a/src/ThisMonthInPhiladelphia.jsx
+++ b/src/ThisMonthInPhiladelphia.jsx
@@ -1,0 +1,314 @@
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import { supabase } from './supabaseClient';
+import { AuthContext } from './AuthProvider';
+import useEventFavorite from './utils/useEventFavorite';
+import {
+  PHILLY_TIME_ZONE,
+  monthSlugToIndex,
+  indexToMonthSlug,
+  getMonthWindow,
+  parseMonthDayYear,
+  overlaps,
+  setEndOfDay,
+  formatMonthYear,
+  formatEventDateRange,
+} from './utils/dateUtils';
+
+const DEFAULT_OG_IMAGE = 'https://ourphilly.org/og-image.png';
+const CANONICAL_BASE = 'https://ourphilly.org/philadelphia-events-';
+
+function setMetaTag(name, content) {
+  if (typeof document === 'undefined') return;
+  let tag = document.querySelector(`meta[name="${name}"]`);
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute('name', name);
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', content);
+}
+
+function setPropertyTag(property, content) {
+  if (typeof document === 'undefined') return;
+  let tag = document.querySelector(`meta[property="${property}"]`);
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute('property', property);
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', content);
+}
+
+function setCanonicalLink(url) {
+  if (typeof document === 'undefined') return;
+  let link = document.querySelector('link[rel="canonical"]');
+  if (!link) {
+    link = document.createElement('link');
+    link.setAttribute('rel', 'canonical');
+    document.head.appendChild(link);
+  }
+  link.setAttribute('href', url);
+}
+
+function FavoriteState({ event_id, source_table, children }) {
+  const state = useEventFavorite({ event_id, source_table });
+  return children(state);
+}
+
+const MONTH_VIEW_REGEX = /^philadelphia-events-([a-z-]+)-(\d{4})$/i;
+
+export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverride } = {}) {
+  const params = useParams();
+  const navigate = useNavigate();
+  const { user } = useContext(AuthContext);
+
+  const viewParam = params.view;
+  const viewMatch = useMemo(() => {
+    if (viewParam) {
+      const match = viewParam.match(MONTH_VIEW_REGEX);
+      if (match) {
+        return { monthSlug: match[1].toLowerCase(), year: match[2] };
+      }
+    }
+    return null;
+  }, [viewParam]);
+
+  const monthSlugParam = monthSlugOverride || params.monthSlug || (viewMatch ? viewMatch.monthSlug : null);
+  const yearParam = yearOverride || params.year || (viewMatch ? viewMatch.year : null);
+
+  const normalizedMonthSlug = monthSlugParam ? monthSlugParam.toLowerCase() : null;
+  const monthIndex = normalizedMonthSlug ? monthSlugToIndex(normalizedMonthSlug) : null;
+  const yearNum = yearParam ? Number(yearParam) : NaN;
+  const hasValidParams = Boolean(monthIndex && !Number.isNaN(yearNum));
+
+  useEffect(() => {
+    if (!hasValidParams) {
+      navigate('/philadelphia-events', { replace: true });
+    }
+  }, [hasValidParams, navigate]);
+
+  const monthWindow = useMemo(() => {
+    if (!monthIndex || Number.isNaN(yearNum)) return { start: null, end: null };
+    return getMonthWindow(yearNum, monthIndex, PHILLY_TIME_ZONE);
+  }, [monthIndex, yearNum]);
+
+  const monthStart = monthWindow.start;
+  const monthEnd = monthWindow.end;
+
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!monthIndex || Number.isNaN(yearNum) || !monthStart || !monthEnd) return;
+    setLoading(true);
+    supabase
+      .from('events')
+      .select(`
+        id,
+        "E Name",
+        "E Description",
+        Dates,
+        "End Date",
+        "E Image",
+        slug
+      `)
+      .order('Dates', { ascending: true })
+      .then(({ data, error }) => {
+        if (error) {
+          console.error('Error loading monthly events', error);
+          setEvents([]);
+          setLoading(false);
+          return;
+        }
+        const filtered = (data || [])
+          .map(evt => {
+            const startDate = parseMonthDayYear(evt.Dates, PHILLY_TIME_ZONE);
+            const endDateRaw = parseMonthDayYear(evt['End Date'], PHILLY_TIME_ZONE) || startDate;
+            if (!startDate || !endDateRaw) return null;
+            const endDate = setEndOfDay(new Date(endDateRaw));
+            if (!overlaps(startDate, endDate, monthStart, monthEnd)) return null;
+            return {
+              id: evt.id,
+              title: evt['E Name'],
+              description: evt['E Description'],
+              imageUrl: evt['E Image'] || '',
+              startDate,
+              endDate,
+              slug: evt.slug,
+              source_table: 'events',
+            };
+          })
+          .filter(Boolean)
+          .sort((a, b) => (a.startDate?.getTime() || 0) - (b.startDate?.getTime() || 0));
+        setEvents(filtered);
+        setLoading(false);
+      });
+  }, [monthIndex, yearNum, monthStart, monthEnd]);
+
+  const monthLabel = monthStart ? formatMonthYear(monthStart, PHILLY_TIME_ZONE) : '';
+  const headingLabel = monthLabel || 'Philadelphia';
+  const prevMonthIndex = monthIndex ? (monthIndex === 1 ? 12 : monthIndex - 1) : null;
+  const prevYear = monthIndex === 1 ? yearNum - 1 : yearNum;
+  const nextMonthIndex = monthIndex ? (monthIndex === 12 ? 1 : monthIndex + 1) : null;
+  const nextYear = monthIndex === 12 ? yearNum + 1 : yearNum;
+
+  const prevWindow = prevMonthIndex ? getMonthWindow(prevYear, prevMonthIndex, PHILLY_TIME_ZONE) : null;
+  const nextWindow = nextMonthIndex ? getMonthWindow(nextYear, nextMonthIndex, PHILLY_TIME_ZONE) : null;
+
+  const prevSlug = prevMonthIndex
+    ? `/philadelphia-events-${indexToMonthSlug(prevMonthIndex)}-${prevYear}/`
+    : '/philadelphia-events/';
+  const nextSlug = nextMonthIndex
+    ? `/philadelphia-events-${indexToMonthSlug(nextMonthIndex)}-${nextYear}/`
+    : '/philadelphia-events/';
+
+  const prevLabel = prevWindow ? formatMonthYear(prevWindow.start, PHILLY_TIME_ZONE) : '';
+  const nextLabel = nextWindow ? formatMonthYear(nextWindow.start, PHILLY_TIME_ZONE) : '';
+
+  const firstImage = useMemo(() => {
+    for (const evt of events) {
+      if (evt.imageUrl) return evt.imageUrl;
+    }
+    return null;
+  }, [events]);
+
+  const canonicalUrl = monthIndex && !Number.isNaN(yearNum)
+    ? `${CANONICAL_BASE}${indexToMonthSlug(monthIndex)}-${yearNum}/`
+    : `${CANONICAL_BASE}`;
+
+  useEffect(() => {
+    if (!monthIndex || Number.isNaN(yearNum) || !monthStart) return;
+    const heroImage = firstImage || DEFAULT_OG_IMAGE;
+    const pageTitle = monthLabel ? `Philly Traditions in ${monthLabel}` : 'Philly Traditions in Philadelphia';
+    const description = `${monthLabel || 'Philadelphia'} traditions, festivals, family-friendly fun, concerts, and markets from the most comprehensive events calendar in Philadelphia.`;
+    if (typeof document !== 'undefined') {
+      document.title = pageTitle;
+    }
+    setMetaTag('description', description);
+    setPropertyTag('og:title', pageTitle);
+    setPropertyTag('og:description', description);
+    setPropertyTag('og:url', canonicalUrl);
+    setPropertyTag('og:image', heroImage);
+    setMetaTag('twitter:card', 'summary_large_image');
+    setMetaTag('twitter:title', pageTitle);
+    setMetaTag('twitter:description', description);
+    setMetaTag('twitter:image', heroImage);
+    setCanonicalLink(canonicalUrl);
+  }, [monthIndex, yearNum, monthLabel, canonicalUrl, firstImage, monthStart]);
+
+  const countText = `${events.length} traditions in ${headingLabel}!`;
+
+  if (!hasValidParams) {
+    return (
+      <div className="flex flex-col min-h-screen bg-white">
+        <Navbar />
+        <main className="flex-1 pt-36 pb-16 flex items-center justify-center">
+          <p className="text-gray-600">Redirecting to the latest Philadelphia traditions…</p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <Navbar />
+      <main className="flex-1 pt-36 md:pt-40 pb-16">
+        <div className="container mx-auto px-4 max-w-5xl">
+          <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e] text-center">
+            Philly Traditions in {headingLabel}
+          </h1>
+          <p className="mt-6 text-lg text-gray-700 text-center max-w-3xl mx-auto">
+            Welcome to the most comprehensive events calendar in Philadelphia. Explore {headingLabel} traditions covering markets, festivals, concerts, and family-friendly outings so your plans stay rich all month long.
+          </p>
+
+          <div className="mt-10 md:sticky md:top-24 bg-white/90 border border-gray-200 rounded-2xl shadow-sm px-4 py-3 flex flex-wrap items-center justify-center gap-4">
+            <Link to={prevSlug} className="text-sm font-semibold text-indigo-600 hover:underline">
+              ← {prevLabel || 'Previous'}
+            </Link>
+            <span className="hidden md:block text-gray-300">|</span>
+            <Link to="/this-weekend-in-philadelphia" className="text-sm font-semibold text-indigo-600 hover:underline">
+              This Weekend →
+            </Link>
+            <span className="hidden md:block text-gray-300">|</span>
+            <Link to={nextSlug} className="text-sm font-semibold text-indigo-600 hover:underline">
+              {nextLabel || 'Next'} →
+            </Link>
+          </div>
+
+          <p className="mt-8 text-xl font-semibold text-[#28313e] text-center">{countText}</p>
+
+          <section className="mt-10 bg-white border border-gray-200 rounded-2xl shadow-sm">
+            {loading ? (
+              <p className="p-6 text-gray-500">Loading this month’s traditions…</p>
+            ) : events.length === 0 ? (
+              <p className="p-6 text-gray-500">No events match this month just yet. Check back soon!</p>
+            ) : (
+              <div className="divide-y divide-gray-200">
+                {events.map(evt => (
+                  <div key={evt.id} className="flex flex-col md:flex-row gap-4 px-6 py-6">
+                    <div className="md:w-48 w-full flex-shrink-0">
+                      <img
+                        src={evt.imageUrl || ''}
+                        alt={evt.title}
+                        loading="lazy"
+                        className="w-full h-40 md:h-32 object-cover rounded-xl"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <Link to={`/events/${evt.slug}`} className="text-2xl font-semibold text-[#28313e] hover:underline">
+                        {evt.title}
+                      </Link>
+                      <p className="mt-3 text-sm text-gray-600 leading-relaxed">
+                        <span className="font-semibold text-gray-700">What to Expect:</span> {evt.description || 'Stay tuned for details — we’ll share updates soon.'}
+                      </p>
+                      <p className="mt-3 text-sm font-semibold text-gray-700">
+                        {formatEventDateRange(evt.startDate, evt.endDate, PHILLY_TIME_ZONE)}
+                      </p>
+                      <FavoriteState event_id={evt.id} source_table="events">
+                        {({ isFavorite, toggleFavorite, loading: favLoading }) => (
+                          <button
+                            onClick={() => {
+                              if (!user) {
+                                navigate('/login');
+                                return;
+                              }
+                              toggleFavorite();
+                            }}
+                            disabled={favLoading}
+                            className={`mt-4 inline-flex items-center px-4 py-2 border border-indigo-600 rounded-full font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+                          >
+                            {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                          </button>
+                        )}
+                      </FavoriteState>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {!user && (
+            <section className="mt-16">
+              <div className="bg-indigo-600/10 border border-indigo-200 rounded-3xl px-6 py-12 flex flex-col items-center text-center gap-6">
+                <h2 className="text-3xl sm:text-4xl font-[Barrio] text-[#28313e]">Keep your Philly traditions organized</h2>
+                <Link
+                  to="/signup"
+                  className="inline-flex items-center justify-center px-10 py-4 bg-indigo-600 text-white text-xl font-semibold rounded-full shadow-lg hover:bg-indigo-700 transition"
+                >
+                  Sign up to save your favorite traditions
+                </Link>
+              </div>
+            </section>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/ThisWeekendInPhiladelphia.jsx
+++ b/src/ThisWeekendInPhiladelphia.jsx
@@ -1,0 +1,1083 @@
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Filter, List, XCircle } from 'lucide-react';
+import { RRule } from 'rrule';
+import { FaStar } from 'react-icons/fa';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import { supabase } from './supabaseClient';
+import { AuthContext } from './AuthProvider';
+import useEventFavorite from './utils/useEventFavorite';
+import {
+  PHILLY_TIME_ZONE,
+  getWeekendWindow,
+  parseISODate,
+  parseMonthDayYear,
+  overlaps,
+  setEndOfDay,
+  setStartOfDay,
+  formatWeekdayAbbrev,
+  formatMonthDay,
+  formatDateRangeForTitle,
+  getZonedDate,
+} from './utils/dateUtils';
+
+const pillStyles = [
+  'bg-green-100 text-indigo-800',
+  'bg-teal-100 text-teal-800',
+  'bg-pink-100 text-pink-800',
+  'bg-blue-100 text-blue-800',
+  'bg-orange-100 text-orange-800',
+  'bg-yellow-100 text-yellow-800',
+  'bg-purple-100 text-purple-800',
+  'bg-red-100 text-red-800',
+];
+
+const popularTags = [
+  { slug: 'nomnomslurp', label: 'nomnomslurp' },
+  { slug: 'markets', label: 'markets' },
+  { slug: 'music', label: 'music' },
+  { slug: 'family', label: 'family' },
+  { slug: 'arts', label: 'arts' },
+];
+
+const dayViewOptions = ['weekend', 'friday', 'saturday', 'sunday'];
+
+const dayViewLabels = {
+  weekend: 'this weekend',
+  friday: 'Friday',
+  saturday: 'Saturday',
+  sunday: 'Sunday',
+};
+
+const DEFAULT_OG_IMAGE = 'https://ourphilly.org/og-image.png';
+const CANONICAL_URL = 'https://ourphilly.org/this-weekend-in-philadelphia/';
+
+function setMetaTag(name, content) {
+  if (typeof document === 'undefined') return;
+  let tag = document.querySelector(`meta[name="${name}"]`);
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute('name', name);
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', content);
+}
+
+function setPropertyTag(property, content) {
+  if (typeof document === 'undefined') return;
+  let tag = document.querySelector(`meta[property="${property}"]`);
+  if (!tag) {
+    tag = document.createElement('meta');
+    tag.setAttribute('property', property);
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', content);
+}
+
+function setCanonicalLink(url) {
+  if (typeof document === 'undefined') return;
+  let link = document.querySelector('link[rel="canonical"]');
+  if (!link) {
+    link = document.createElement('link');
+    link.setAttribute('rel', 'canonical');
+    document.head.appendChild(link);
+  }
+  link.setAttribute('href', url);
+}
+
+function formatTime(timeStr) {
+  if (!timeStr) return '';
+  const [hoursStr, minutesStr] = timeStr.split(':');
+  let hours = parseInt(hoursStr, 10);
+  const minutes = minutesStr ? minutesStr.padStart(2, '0') : '00';
+  const ampm = hours >= 12 ? 'p.m.' : 'a.m.';
+  hours = hours % 12 || 12;
+  return `${hours}:${minutes} ${ampm}`;
+}
+
+function TagFilterModal({ open, tags, selectedTags, onToggle, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="bg-white w-full max-w-2xl rounded-lg shadow-xl p-8 relative">
+        <h2 className="text-lg font-semibold mb-6 text-center">Select Tags</h2>
+        <div className="flex flex-wrap gap-3 mb-6">
+          {tags.map((tag, i) => {
+            const isSel = selectedTags.includes(tag.slug);
+            const cls = isSel ? pillStyles[i % pillStyles.length] : 'bg-gray-200 text-gray-700';
+            return (
+              <button
+                key={tag.slug}
+                onClick={() => onToggle(tag.slug, !isSel)}
+                className={`${cls} px-4 py-2 rounded-full text-sm font-semibold`}
+              >
+                {tag.name}
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex justify-center">
+          <button
+            onClick={onClose}
+            className="px-6 py-2 bg-indigo-600 text-white rounded-md shadow hover:bg-indigo-700 transition"
+          >
+            Done
+          </button>
+        </div>
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-3 text-gray-400 hover:text-gray-600 text-xl"
+          aria-label="Close"
+        >
+          &times;
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FavoriteState({ event_id, source_table, children }) {
+  const state = useEventFavorite({ event_id, source_table });
+  return children(state);
+}
+
+function resolveGroup(groups) {
+  if (!groups) return null;
+  if (Array.isArray(groups)) return groups[0] || null;
+  return groups;
+}
+
+export default function ThisWeekendInPhiladelphia() {
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const { start: weekendStart, end: weekendEnd } = useMemo(() => getWeekendWindow(new Date(), PHILLY_TIME_ZONE), []);
+  const weekendStartMs = weekendStart.getTime();
+  const weekendEndMs = weekendEnd.getTime();
+
+  const [allEventsData, setAllEventsData] = useState([]);
+  const [bigBoardEvents, setBigBoardEvents] = useState([]);
+  const [traditionEvents, setTraditionEvents] = useState([]);
+  const [groupEvents, setGroupEvents] = useState([]);
+  const [recurringRaw, setRecurringRaw] = useState([]);
+  const [recurringEvents, setRecurringEvents] = useState([]);
+  const [sportsEventsRaw, setSportsEventsRaw] = useState([]);
+  const [sportsEvents, setSportsEvents] = useState([]);
+  const [allTags, setAllTags] = useState([]);
+  const [tagMap, setTagMap] = useState({});
+  const [selectedTags, setSelectedTags] = useState([]);
+  const [selectedDayView, setSelectedDayView] = useState('weekend');
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+  const [isListView, setIsListView] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const today = useMemo(() => setStartOfDay(getZonedDate(new Date(), PHILLY_TIME_ZONE)), []);
+
+  useEffect(() => {
+    supabase
+      .from('tags')
+      .select('name,slug')
+      .order('name', { ascending: true })
+      .then(({ data, error }) => {
+        if (error) {
+          console.error('tags load error', error);
+          return;
+        }
+        setAllTags(data || []);
+      });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const clientId = import.meta.env.VITE_SEATGEEK_CLIENT_ID;
+    if (!clientId) {
+      setSportsEventsRaw([]);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    (async () => {
+      try {
+        const teamSlugs = [
+          'philadelphia-phillies',
+          'philadelphia-76ers',
+          'philadelphia-eagles',
+          'philadelphia-flyers',
+          'philadelphia-union',
+        ];
+
+        const requests = teamSlugs.map(slug =>
+          fetch(
+            `https://api.seatgeek.com/2/events?performers.slug=${slug}&venue.city=Philadelphia&per_page=50&sort=datetime_local.asc&client_id=${clientId}`
+          )
+            .then(res => (res.ok ? res.json() : Promise.reject(new Error(`SeatGeek request failed: ${res.status}`))))
+            .catch(error => {
+              console.error('SeatGeek fetch failed for', slug, error);
+              return { events: [] };
+            })
+        );
+
+        const results = await Promise.all(requests);
+        const collected = results.flatMap(result => result.events || []);
+        const mapped = collected
+          .map(event => {
+            const dt = new Date(event.datetime_local);
+            const startIso = dt.toISOString().slice(0, 10);
+            const startDate = parseISODate(startIso, PHILLY_TIME_ZONE);
+            if (!startDate) return null;
+            const endDate = setEndOfDay(new Date(startDate));
+            const performers = event.performers || [];
+            const home = performers.find(p => p.home_team) || performers[0] || {};
+            const away = performers.find(p => p.id !== home.id) || {};
+            const title =
+              event.short_title ||
+              `${(home.name || '').replace(/^Philadelphia\s+/, '')} vs ${(away.name || '').replace(/^Philadelphia\s+/, '')}`;
+            return {
+              id: `sg-${event.id}`,
+              title,
+              imageUrl: home.image || away.image || '',
+              start_date: startIso,
+              start_time: dt.toTimeString().slice(0, 5),
+              startDate,
+              endDate,
+              href: `/sports/${event.id}`,
+              url: event.url,
+              isSports: true,
+              isBigBoard: false,
+              isTradition: false,
+              isGroupEvent: false,
+              isRecurring: false,
+              source_table: 'sg_events',
+              taggableId: `sg-${event.id}`,
+            };
+          })
+          .filter(Boolean);
+        if (!cancelled) {
+          setSportsEventsRaw(mapped);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Error fetching sports events', error);
+          setSportsEventsRaw([]);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const fetchAllEvents = supabase
+      .from('all_events')
+      .select(`
+        id,
+        name,
+        description,
+        image,
+        start_date,
+        end_date,
+        start_time,
+        end_time,
+        slug,
+        venue_id,
+        venues:venue_id (
+          name,
+          slug,
+          latitude,
+          longitude
+        )
+      `)
+      .order('start_date', { ascending: true });
+
+    const fetchBigBoard = supabase
+      .from('big_board_events')
+      .select(`
+        id,
+        title,
+        description,
+        start_date,
+        end_date,
+        start_time,
+        end_time,
+        slug,
+        latitude,
+        longitude,
+        big_board_posts!big_board_posts_event_id_fkey (
+          image_url,
+          user_id
+        )
+      `)
+      .order('start_date', { ascending: true });
+
+    const fetchTraditions = supabase
+      .from('events')
+      .select(`
+        id,
+        "E Name",
+        "E Description",
+        Dates,
+        "End Date",
+        "E Image",
+        slug
+      `)
+      .order('Dates', { ascending: true });
+
+    const fetchGroupEvents = supabase
+      .from('group_events')
+      .select(`
+        *,
+        groups(Name, imag, slug)
+      `)
+      .order('start_date', { ascending: true });
+
+    const fetchRecurring = supabase
+      .from('recurring_events')
+      .select(`
+        id,
+        name,
+        slug,
+        description,
+        address,
+        link,
+        start_date,
+        end_date,
+        start_time,
+        end_time,
+        rrule,
+        image_url,
+        latitude,
+        longitude
+      `)
+      .eq('is_active', true);
+
+    let cancelled = false;
+    setLoading(true);
+
+    Promise.all([fetchAllEvents, fetchBigBoard, fetchTraditions, fetchGroupEvents, fetchRecurring])
+      .then(([allRes, bigRes, tradRes, groupRes, recurringRes]) => {
+        if (cancelled) return;
+
+        const allRecords = (allRes.data || [])
+          .map(evt => {
+            const startDate = parseISODate(evt.start_date, PHILLY_TIME_ZONE);
+            const endDateRaw = parseISODate(evt.end_date || evt.start_date, PHILLY_TIME_ZONE);
+            if (!startDate || !endDateRaw) return null;
+            const endDate = setEndOfDay(new Date(endDateRaw));
+            if (!overlaps(startDate, endDate, weekendStart, weekendEnd)) return null;
+            return {
+              id: evt.id,
+              title: evt.name,
+              name: evt.name,
+              description: evt.description,
+              imageUrl: evt.image || '',
+              start_date: evt.start_date,
+              end_date: evt.end_date,
+              startDate,
+              endDate,
+              start_time: evt.start_time,
+              end_time: evt.end_time,
+              slug: evt.slug,
+              venues: evt.venues,
+              isTradition: false,
+              isBigBoard: false,
+              isGroupEvent: false,
+              isRecurring: false,
+              isSports: false,
+              source_table: 'all_events',
+              taggableId: String(evt.id),
+            };
+          })
+          .filter(Boolean);
+
+        const bigRecords = (bigRes.data || [])
+          .map(evt => {
+            const startDate = parseISODate(evt.start_date, PHILLY_TIME_ZONE);
+            const endDateRaw = parseISODate(evt.end_date || evt.start_date, PHILLY_TIME_ZONE);
+            if (!startDate || !endDateRaw) return null;
+            const endDate = setEndOfDay(new Date(endDateRaw));
+            if (!overlaps(startDate, endDate, weekendStart, weekendEnd)) return null;
+            let imageUrl = '';
+            const storageKey = evt.big_board_posts?.[0]?.image_url;
+            if (storageKey) {
+              const {
+                data: { publicUrl },
+              } = supabase.storage.from('big-board').getPublicUrl(storageKey);
+              imageUrl = publicUrl || '';
+            }
+            return {
+              id: evt.id,
+              title: evt.title,
+              description: evt.description,
+              imageUrl,
+              start_date: evt.start_date,
+              end_date: evt.end_date,
+              startDate,
+              endDate,
+              start_time: evt.start_time,
+              end_time: evt.end_time,
+              slug: evt.slug,
+              latitude: evt.latitude,
+              longitude: evt.longitude,
+              owner_id: evt.big_board_posts?.[0]?.user_id || null,
+              isTradition: false,
+              isBigBoard: true,
+              isGroupEvent: false,
+              isRecurring: false,
+              isSports: false,
+              source_table: 'big_board_events',
+              taggableId: String(evt.id),
+            };
+          })
+          .filter(Boolean);
+
+        const traditionRecords = (tradRes.data || [])
+          .map(evt => {
+            const startDate = parseMonthDayYear(evt.Dates, PHILLY_TIME_ZONE);
+            const endDateRaw = parseMonthDayYear(evt['End Date'], PHILLY_TIME_ZONE) || startDate;
+            if (!startDate || !endDateRaw) return null;
+            const endDate = setEndOfDay(new Date(endDateRaw));
+            if (!overlaps(startDate, endDate, weekendStart, weekendEnd)) return null;
+            return {
+              id: evt.id,
+              title: evt['E Name'],
+              name: evt['E Name'],
+              description: evt['E Description'],
+              imageUrl: evt['E Image'] || '',
+              startDate,
+              endDate,
+              slug: evt.slug,
+              isTradition: true,
+              isBigBoard: false,
+              isGroupEvent: false,
+              isRecurring: false,
+              isSports: false,
+              source_table: 'events',
+              taggableId: String(evt.id),
+            };
+          })
+          .filter(Boolean);
+
+        const groupRecords = (groupRes.data || [])
+          .map(evt => {
+            const group = resolveGroup(evt.groups);
+            const startDate = parseISODate(evt.start_date, PHILLY_TIME_ZONE);
+            const endDateRaw = parseISODate(evt.end_date || evt.start_date, PHILLY_TIME_ZONE);
+            if (!startDate || !endDateRaw) return null;
+            const endDate = setEndOfDay(new Date(endDateRaw));
+            if (!overlaps(startDate, endDate, weekendStart, weekendEnd)) return null;
+            return {
+              id: evt.id,
+              title: evt.title,
+              name: evt.title,
+              description: evt.description,
+              imageUrl: group?.imag || '',
+              start_date: evt.start_date,
+              end_date: evt.end_date,
+              startDate,
+              endDate,
+              start_time: evt.start_time,
+              end_time: evt.end_time,
+              href: group?.slug ? `/groups/${group.slug}/events/${evt.id}` : null,
+              groupName: group?.Name || group?.name || '',
+              isTradition: false,
+              isBigBoard: false,
+              isGroupEvent: true,
+              isRecurring: false,
+              isSports: false,
+              source_table: 'group_events',
+              taggableId: String(evt.id),
+            };
+          })
+          .filter(Boolean);
+
+        setAllEventsData(allRecords);
+        setBigBoardEvents(bigRecords);
+        setTraditionEvents(traditionRecords);
+        setGroupEvents(groupRecords);
+        setRecurringRaw(recurringRes.data || []);
+        setLoading(false);
+      })
+      .catch(error => {
+        console.error('Error loading weekend data', error);
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [weekendStartMs, weekendEndMs]);
+  useEffect(() => {
+    if (!recurringRaw.length) {
+      setRecurringEvents([]);
+      return;
+    }
+    const startBoundary = new Date(weekendStartMs);
+    const endBoundary = new Date(weekendEndMs);
+
+    const occs = recurringRaw.flatMap(series => {
+      if (!series.rrule) return [];
+      let opts;
+      try {
+        opts = RRule.parseString(series.rrule);
+      } catch (error) {
+        console.error('Invalid recurring rule', series.id, error);
+        return [];
+      }
+      opts.dtstart = new Date(`${series.start_date}T${series.start_time || '00:00'}`);
+      if (series.end_date) {
+        opts.until = new Date(`${series.end_date}T23:59:59`);
+      }
+      const rule = new RRule(opts);
+      return rule
+        .between(startBoundary, endBoundary, true)
+        .map(instance => {
+          const local = new Date(instance.getFullYear(), instance.getMonth(), instance.getDate());
+          const yyyy = local.getFullYear();
+          const mm = String(local.getMonth() + 1).padStart(2, '0');
+          const dd = String(local.getDate()).padStart(2, '0');
+          const dateStr = `${yyyy}-${mm}-${dd}`;
+          const startDate = parseISODate(dateStr, PHILLY_TIME_ZONE);
+          if (!startDate) return null;
+          const endDate = setEndOfDay(new Date(startDate));
+          return {
+            id: `${series.id}::${dateStr}`,
+            title: series.name,
+            name: series.name,
+            description: series.description,
+            imageUrl: series.image_url || '',
+            start_date: dateStr,
+            startDate,
+            endDate,
+            start_time: series.start_time,
+            end_time: series.end_time,
+            link: `/${series.slug}/${dateStr}`,
+            address: series.address,
+            isTradition: false,
+            isBigBoard: false,
+            isGroupEvent: false,
+            isRecurring: true,
+            isSports: false,
+            source_table: 'recurring_events',
+            taggableId: String(series.id),
+            slug: series.slug,
+          };
+        })
+        .filter(Boolean);
+    });
+    setRecurringEvents(occs);
+  }, [recurringRaw, weekendStartMs, weekendEndMs]);
+
+  useEffect(() => {
+    const filtered = sportsEventsRaw
+      .filter(evt => overlaps(evt.startDate, evt.endDate, weekendStart, weekendEnd))
+      .map(evt => ({ ...evt }));
+    setSportsEvents(filtered);
+  }, [sportsEventsRaw, weekendStart, weekendEnd]);
+
+  const combinedEvents = useMemo(
+    () => [
+      ...sportsEvents,
+      ...bigBoardEvents,
+      ...groupEvents,
+      ...recurringEvents,
+      ...traditionEvents,
+      ...allEventsData,
+    ],
+    [sportsEvents, bigBoardEvents, groupEvents, recurringEvents, traditionEvents, allEventsData]
+  );
+
+  const weekendEventCount = combinedEvents.length;
+  const formattedWeekendEventCount = useMemo(
+    () => weekendEventCount.toLocaleString('en-US'),
+    [weekendEventCount]
+  );
+
+  useEffect(() => {
+    if (!combinedEvents.length) {
+      setTagMap({});
+      return;
+    }
+    const idsByType = combinedEvents.reduce((acc, evt) => {
+      const table = evt.isSports ? 'sg_events' : evt.source_table;
+      if (!table || !evt.taggableId) return acc;
+      if (!acc[table]) acc[table] = new Set();
+      acc[table].add(String(evt.taggableId));
+      return acc;
+    }, {});
+
+    const promises = Object.entries(idsByType)
+      .filter(([type]) => type !== 'sg_events')
+      .map(([type, ids]) =>
+        supabase
+          .from('taggings')
+          .select('tags(name,slug),taggable_id')
+          .eq('taggable_type', type)
+          .in('taggable_id', Array.from(ids))
+      );
+
+    Promise.all(promises)
+      .then(results => {
+        const map = {};
+        results.forEach(({ data, error }) => {
+          if (error) {
+            console.error('taggings fetch failed:', error);
+            return;
+          }
+          data.forEach(({ taggable_id, tags }) => {
+            if (!taggable_id || !tags) return;
+            const key = String(taggable_id);
+            map[key] = map[key] || [];
+            map[key].push(tags);
+          });
+        });
+        const sportsTag = allTags.find(tag => tag.slug === 'sports');
+        if (sportsTag && idsByType.sg_events) {
+          Array.from(idsByType.sg_events).forEach(id => {
+            const key = String(id);
+            map[key] = map[key] || [];
+            map[key].push(sportsTag);
+          });
+        }
+        setTagMap(map);
+      })
+      .catch(err => {
+        console.error('error loading tags for weekend', err);
+      });
+  }, [combinedEvents, allTags]);
+
+  const filteredEvents = useMemo(() => {
+    if (!selectedTags.length) return combinedEvents;
+    return combinedEvents.filter(evt => {
+      const key = String(evt.taggableId);
+      const tags = tagMap[key] || [];
+      return tags.some(tag => selectedTags.includes(tag.slug));
+    });
+  }, [combinedEvents, selectedTags, tagMap]);
+
+  const dayWindows = useMemo(() => {
+    const fridayStart = setStartOfDay(new Date(weekendStart));
+    const fridayEnd = setEndOfDay(new Date(fridayStart));
+    const saturdayStart = setStartOfDay(new Date(fridayStart));
+    saturdayStart.setDate(fridayStart.getDate() + 1);
+    const saturdayEnd = setEndOfDay(new Date(saturdayStart));
+    const sundayStart = setStartOfDay(new Date(fridayStart));
+    sundayStart.setDate(fridayStart.getDate() + 2);
+    const sundayEnd = setEndOfDay(new Date(sundayStart));
+    return {
+      weekend: { start: new Date(weekendStart), end: new Date(weekendEnd) },
+      friday: { start: fridayStart, end: fridayEnd },
+      saturday: { start: saturdayStart, end: saturdayEnd },
+      sunday: { start: sundayStart, end: sundayEnd },
+    };
+  }, [weekendStart, weekendEnd]);
+
+  const dayFilteredEvents = useMemo(() => {
+    if (!selectedDayView || selectedDayView === 'weekend') return filteredEvents;
+    const window = dayWindows[selectedDayView];
+    if (!window) return filteredEvents;
+    return filteredEvents.filter(evt => overlaps(evt.startDate, evt.endDate, window.start, window.end));
+  }, [filteredEvents, selectedDayView, dayWindows]);
+
+  const sortedEvents = useMemo(() => {
+    return [...dayFilteredEvents].sort((a, b) => {
+      if (!a.startDate || !b.startDate) return 0;
+      const diff = a.startDate.getTime() - b.startDate.getTime();
+      if (diff !== 0) return diff;
+      const timeA = a.start_time || '';
+      const timeB = b.start_time || '';
+      return timeA.localeCompare(timeB);
+    });
+  }, [dayFilteredEvents]);
+
+  const firstEventImage = useMemo(() => {
+    for (const evt of combinedEvents) {
+      if (evt.imageUrl) return evt.imageUrl;
+      if (evt.image) return evt.image;
+    }
+    return null;
+  }, [combinedEvents]);
+
+  const traditionLinks = useMemo(() => {
+    const days = [0, 1, 2].map(offset => {
+      const d = setStartOfDay(new Date(weekendStart));
+      d.setDate(d.getDate() + offset);
+      return d;
+    });
+    return traditionEvents
+      .slice()
+      .sort((a, b) => (a.startDate?.getTime() || 0) - (b.startDate?.getTime() || 0))
+      .map((evt, index) => {
+        const overlapDay = days.find(day => overlaps(evt.startDate, evt.endDate, day, setEndOfDay(new Date(day))));
+        const label = formatWeekdayAbbrev(overlapDay || evt.startDate, PHILLY_TIME_ZONE);
+        return (
+          <React.Fragment key={evt.id}>
+            {index > 0 && ', '}
+            <Link to={`/events/${evt.slug}`} className="text-indigo-600 hover:underline">
+              {evt.title} ({label})
+            </Link>
+          </React.Fragment>
+        );
+      });
+  }, [traditionEvents, weekendStart]);
+
+  const rangeForTitle = formatDateRangeForTitle(weekendStart, weekendEnd, PHILLY_TIME_ZONE);
+  const introRange = `${formatMonthDay(weekendStart, PHILLY_TIME_ZONE)} through ${formatMonthDay(weekendEnd, PHILLY_TIME_ZONE)}`;
+
+  useEffect(() => {
+    const heroImage = firstEventImage || DEFAULT_OG_IMAGE;
+    const title = `Things to Do in Philadelphia This Weekend (${rangeForTitle})`;
+    const description = 'Plan this weekend in Philly with the most comprehensive events calendar in Philadelphia. Explore free events, family-friendly outings, concerts, festivals, and markets happening all across the city.';
+    if (typeof document !== 'undefined') {
+      document.title = title;
+    }
+    setMetaTag('description', description);
+    setPropertyTag('og:title', title);
+    setPropertyTag('og:description', description);
+    setPropertyTag('og:url', CANONICAL_URL);
+    setPropertyTag('og:image', heroImage);
+    setMetaTag('twitter:card', 'summary_large_image');
+    setMetaTag('twitter:title', title);
+    setMetaTag('twitter:description', description);
+    setMetaTag('twitter:image', heroImage);
+    setCanonicalLink(CANONICAL_URL);
+  }, [rangeForTitle, firstEventImage]);
+
+  const handleTagToggle = (slug, checked) => {
+    setSelectedTags(prev => (checked ? [...prev, slug] : prev.filter(tag => tag !== slug)));
+  };
+
+  const hasFilters = selectedTags.length > 0 || selectedDayView !== 'weekend';
+
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <Navbar />
+      <main className="flex-1 pt-36 md:pt-40 pb-16">
+        <div className="container mx-auto px-4 max-w-6xl">
+          <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e] text-center">
+            Things to Do in Philadelphia This Weekend
+          </h1>
+          <p className="mt-6 text-lg text-gray-700 text-center max-w-3xl mx-auto">
+            Use this guide from the most comprehensive events calendar in Philadelphia to plan your {introRange} adventures. We curated {formattedWeekendEventCount} festivals, markets, concerts, and family-friendly events for you to make the most of your weekend.
+          </p>
+
+          <div className="mt-10 flex justify-end items-center gap-2">
+            {hasFilters && (
+              <button
+                onClick={() => {
+                  setSelectedTags([]);
+                  setSelectedDayView('weekend');
+                }}
+                className="text-sm text-gray-500 hover:underline"
+              >
+                Clear filters
+              </button>
+            )}
+            <button
+              onClick={() => setIsListView(v => !v)}
+              className="flex items-center gap-1 px-4 py-2 text-sm font-semibold text-indigo-600 border-2 border-indigo-600 rounded-full shadow-lg"
+            >
+              <List className="w-4 h-4" />
+              {isListView ? 'Card View' : 'List View'}
+            </button>
+            <button
+              onClick={() => setIsFiltersOpen(true)}
+              className="flex items-center gap-1 px-4 py-2 text-sm font-semibold text-indigo-600 border-2 border-indigo-600 rounded-full shadow-lg"
+            >
+              <Filter className="w-4 h-4" />
+              {`Filters${selectedTags.length ? ` (${selectedTags.length})` : ''}`}
+            </button>
+          </div>
+
+          <div className="mt-6 flex items-center gap-2 overflow-x-auto scrollbar-hide whitespace-nowrap pb-2">
+            {dayViewOptions.map(option => {
+              const isActive = selectedDayView === option;
+              const label = option === 'weekend' ? 'All Weekend' : option.charAt(0).toUpperCase() + option.slice(1);
+              return (
+                <button
+                  key={option}
+                  onClick={() => setSelectedDayView(option)}
+                  className={`text-sm px-4 py-2 rounded-full border-2 font-semibold shadow-lg transition-colors flex-shrink-0 ${
+                    isActive
+                      ? 'bg-indigo-600 text-white border-indigo-600'
+                      : 'bg-white text-indigo-600 border-indigo-600 hover:bg-indigo-600 hover:text-white'
+                  }`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="mt-6 flex items-center gap-2 overflow-x-auto scrollbar-hide whitespace-nowrap pb-2">
+            <span className="text-sm text-gray-700 font-semibold flex-shrink-0">Popular tags:</span>
+            {popularTags.map((tag, i) => {
+              const isSel = selectedTags.includes(tag.slug);
+              return (
+                <button
+                  key={tag.slug}
+                  onClick={() => handleTagToggle(tag.slug, !isSel)}
+                  className={`${pillStyles[i % pillStyles.length]} px-3 py-1 rounded-full text-sm font-semibold shadow-lg hover:opacity-80 transition flex-shrink-0 ${isSel ? 'ring-2 ring-offset-2 ring-indigo-500' : ''}`}
+                >
+                  #{tag.label}
+                </button>
+              );
+            })}
+            {selectedTags.length > 0 && (
+              <button
+                onClick={() => setSelectedTags([])}
+                className="ml-2 text-gray-500 hover:text-gray-700 flex-shrink-0"
+                aria-label="Clear filters"
+              >
+                <XCircle className="w-5 h-5" />
+              </button>
+            )}
+          </div>
+
+          <TagFilterModal
+            open={isFiltersOpen}
+            tags={allTags}
+            selectedTags={selectedTags}
+            onToggle={handleTagToggle}
+            onClose={() => setIsFiltersOpen(false)}
+          />
+
+          <section className="mt-12">
+            <h2 className="text-xl font-semibold text-[#28313e] tracking-wide">PHILLY TRADITIONS THIS WEEKEND</h2>
+            <p className="mt-2 text-gray-700">
+              {traditionLinks.length ? traditionLinks : 'No traditions are on the calendar this weekend — check back soon!'}
+            </p>
+          </section>
+
+          <section className="mt-12">
+            <div className="flex items-baseline justify-between flex-wrap gap-2">
+              <h2 className="text-2xl font-semibold text-[#28313e]">
+                {sortedEvents.length} picks for {dayViewLabels[selectedDayView] || 'this weekend'}
+              </h2>
+              <span className="text-sm text-gray-500">Updated for {rangeForTitle}</span>
+            </div>
+            {loading ? (
+              <p className="mt-8 text-gray-500">Loading events…</p>
+            ) : sortedEvents.length === 0 ? (
+              <p className="mt-8 text-gray-500">No events match the current filters. Try clearing a tag to see more.</p>
+            ) : (
+              <div className={isListView ? 'flex flex-col divide-y divide-gray-200' : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-8'}>
+                {sortedEvents.map(evt => {
+                  const key = evt.isRecurring ? `${evt.taggableId}-${evt.id}` : evt.id;
+                  const tags = tagMap[String(evt.taggableId)] || [];
+                  const shown = tags.slice(0, 2);
+                  const extra = Math.max(0, tags.length - shown.length);
+                  const startDate = evt.startDate || weekendStart;
+                  const isToday = startDate.getTime() === today.getTime();
+                  const diffDays = Math.round((startDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+                  const bubbleLabel = isToday
+                    ? 'Today'
+                    : diffDays === 1
+                      ? 'Tomorrow'
+                      : formatMonthDay(startDate, PHILLY_TIME_ZONE);
+                  const bubbleTime = evt.start_time ? ` ${formatTime(evt.start_time)}` : '';
+                  const Wrapper = Link;
+                  let linkProps = { to: '/' };
+                  if (evt.isGroupEvent && evt.href) linkProps = { to: evt.href };
+                  else if (evt.isRecurring && evt.slug && evt.start_date) linkProps = { to: evt.link || `/series/${evt.slug}/${evt.start_date}` };
+                  else if (evt.isTradition && evt.slug) linkProps = { to: `/events/${evt.slug}` };
+                  else if (evt.isBigBoard && evt.slug) linkProps = { to: `/big-board/${evt.slug}` };
+                  else if (evt.isSports && evt.href) linkProps = { to: evt.href };
+                  else if (evt.venues?.slug && evt.slug) linkProps = { to: `/${evt.venues.slug}/${evt.slug}` };
+                  else if (evt.slug) linkProps = { to: `/events/${evt.slug}` };
+
+                  return (
+                    <FavoriteState
+                      key={key}
+                      event_id={evt.isSports ? null : evt.isRecurring ? evt.taggableId : evt.id}
+                      source_table={evt.isSports ? null : evt.source_table}
+                    >
+                      {({ isFavorite, toggleFavorite, loading: favLoading }) => (
+                        isListView ? (
+                          <Wrapper
+                            {...linkProps}
+                            className={`flex items-center justify-between p-4 transition-colors ${isFavorite ? 'bg-purple-100' : 'bg-white hover:bg-purple-50'}`}
+                          >
+                            <div className="flex items-center gap-4">
+                              <img
+                                src={evt.imageUrl || evt.image || ''}
+                                alt={evt.title || evt.name}
+                                className="w-20 h-20 object-cover rounded-lg"
+                              />
+                              <div>
+                                <h3 className="text-lg font-semibold text-gray-800">{evt.title || evt.name}</h3>
+                                <p className="text-sm text-gray-500">{formatMonthDay(startDate, PHILLY_TIME_ZONE)}{bubbleTime}</p>
+                                <div className="flex flex-wrap gap-2 mt-2">
+                                  {shown.map((tag, i) => (
+                                    <Link
+                                      key={tag.slug}
+                                      to={`/tags/${tag.slug}`}
+                                      className={`${pillStyles[i % pillStyles.length]} text-xs px-2 py-1 rounded-full font-semibold`}
+                                      onClick={e => e.stopPropagation()}
+                                    >
+                                      #{tag.name}
+                                    </Link>
+                                  ))}
+                                  {extra > 0 && <span className="text-xs text-gray-500">+{extra} more</span>}
+                                </div>
+                              </div>
+                            </div>
+                            {evt.isSports ? (
+                              evt.url && (
+                                <a
+                                  href={evt.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="ml-4 border border-indigo-600 rounded-md px-3 py-1 text-sm font-semibold text-indigo-600 bg-white hover:bg-indigo-600 hover:text-white transition-colors"
+                                  onClick={e => e.stopPropagation()}
+                                >
+                                  Get Tickets
+                                </a>
+                              )
+                            ) : (
+                              <button
+                                onClick={e => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  if (!user) {
+                                    navigate('/login');
+                                    return;
+                                  }
+                                  toggleFavorite();
+                                }}
+                                disabled={favLoading}
+                                className={`ml-4 border border-indigo-600 rounded-md px-3 py-1 text-sm font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+                              >
+                                {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                              </button>
+                            )}
+                          </Wrapper>
+                        ) : (
+                          <Wrapper
+                            {...linkProps}
+                            className={`block rounded-xl overflow-hidden shadow hover:shadow-lg transition flex flex-col ${
+                              evt.isSports
+                                ? 'bg-green-50 border-2 border-green-500'
+                                : `bg-white ${isFavorite ? 'ring-2 ring-indigo-600' : ''}`
+                            }`}
+                          >
+                            <div className="relative w-full h-48">
+                              <img
+                                src={evt.imageUrl || evt.image || ''}
+                                alt={evt.title || evt.name}
+                                className="w-full h-full object-cover"
+                              />
+                              <div className="absolute top-2 left-2 bg-white bg-opacity-90 px-2 py-1 rounded-full text-xs font-semibold text-gray-800">
+                                {bubbleLabel}{bubbleTime}
+                              </div>
+                              {isFavorite && !evt.isSports && (
+                                <div className="absolute top-2 right-2 bg-indigo-600 text-white text-xs px-2 py-1 rounded">
+                                  In the plans!
+                                </div>
+                              )}
+                              {evt.isGroupEvent && (
+                                <div className="absolute inset-x-0 bottom-0 bg-green-600 text-white text-xs uppercase text-center py-1">
+                                  Group Event
+                                </div>
+                              )}
+                              {evt.isBigBoard && (
+                                <div className="absolute inset-x-0 bottom-0 bg-indigo-600 text-white text-xs uppercase text-center py-1">
+                                  Submission
+                                </div>
+                              )}
+                              {evt.isTradition && (
+                                <div className="absolute inset-x-0 bottom-0 border-2 border-yellow-400 bg-yellow-100 text-yellow-800 text-xs uppercase font-semibold text-center py-1 flex items-center justify-center gap-1">
+                                  <FaStar className="text-yellow-500" />
+                                  Tradition
+                                </div>
+                              )}
+                            </div>
+                            <div className="p-4 flex-1 flex flex-col justify-between items-center text-center">
+                              <div>
+                                <h3 className="text-lg font-bold text-gray-800 line-clamp-2 mb-1">
+                                  {evt.title || evt.name}
+                                </h3>
+                                {evt.isRecurring ? (
+                                  evt.address && <p className="text-sm text-gray-600">at {evt.address}</p>
+                                ) : (
+                                  evt.venues?.name && <p className="text-sm text-gray-600">at {evt.venues.name}</p>
+                                )}
+                              </div>
+                              <div className="flex flex-wrap justify-center items-center gap-2 mt-4">
+                                {shown.map((tag, i) => (
+                                  <Link
+                                    key={tag.slug}
+                                    to={`/tags/${tag.slug}`}
+                                    className={`${pillStyles[i % pillStyles.length]} text-[0.6rem] sm:text-sm px-2 sm:px-3 py-1 sm:py-2 rounded-full font-semibold`}
+                                    onClick={e => e.stopPropagation()}
+                                  >
+                                    #{tag.name}
+                                  </Link>
+                                ))}
+                                {extra > 0 && <span className="text-[0.6rem] sm:text-sm text-gray-600">+{extra} more</span>}
+                              </div>
+                              {evt.isSports ? (
+                                evt.url && (
+                                  <a
+                                    href={evt.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="mt-4 w-full border border-indigo-600 rounded-md py-2 font-semibold text-indigo-600 bg-white hover:bg-indigo-600 hover:text-white transition-colors text-center"
+                                    onClick={e => e.stopPropagation()}
+                                  >
+                                    Get Tickets
+                                  </a>
+                                )
+                              ) : (
+                                <button
+                                  onClick={e => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    if (!user) {
+                                      navigate('/login');
+                                      return;
+                                    }
+                                    toggleFavorite();
+                                  }}
+                                  disabled={favLoading}
+                                  className={`mt-4 w-full border border-indigo-600 rounded-md py-2 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
+                                >
+                                  {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                                </button>
+                              )}
+                            </div>
+                          </Wrapper>
+                        )
+                      )}
+                    </FavoriteState>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          {!user && (
+            <section className="mt-20">
+              <div className="bg-indigo-600/10 border border-indigo-200 rounded-3xl px-6 py-16 flex flex-col items-center text-center gap-6">
+                <h2 className="text-3xl sm:text-4xl font-[Barrio] text-[#28313e]">Keep your weekend on track</h2>
+                <p className="text-lg text-gray-700 max-w-2xl">
+                  Save favorites, build plans, and unlock more from the most comprehensive events calendar in Philadelphia.
+                </p>
+                <Link
+                  to="/signup"
+                  className="inline-flex items-center justify-center px-10 py-4 bg-indigo-600 text-white text-xl font-semibold rounded-full shadow-lg hover:bg-indigo-700 transition"
+                >
+                  Sign up to save your weekend plans
+                </Link>
+              </div>
+            </section>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/ViewRouter.jsx
+++ b/src/ViewRouter.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import MainEvents from './MainEvents.jsx';
+import ThisMonthInPhiladelphia from './ThisMonthInPhiladelphia.jsx';
+
+const MONTH_VIEW_REGEX = /^philadelphia-events-([a-z-]+)-(\d{4})$/i;
+
+export default function ViewRouter() {
+  const { view } = useParams();
+  const matchesMonthView = typeof view === 'string' && MONTH_VIEW_REGEX.test(view);
+
+  if (matchesMonthView) {
+    return <ThisMonthInPhiladelphia />;
+  }
+
+  return <MainEvents />;
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -53,6 +53,9 @@ import GroupsFAQ from './GroupsFAQ.jsx'
 import RecurringPage from './RecurringEventPage.jsx'
 import SportsEventPage from './SportsEventPage.jsx'
 import AboutPage from './AboutPage.jsx'
+import ThisWeekendInPhiladelphia from './ThisWeekendInPhiladelphia.jsx';
+import PhiladelphiaEventsIndex from './PhiladelphiaEventsIndex.jsx';
+import ViewRouter from './ViewRouter.jsx';
 
 
 
@@ -72,7 +75,11 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <ScrollToTop />
         <Routes>
           <Route path="/" element={<MainEvents />} />
-          <Route path="/:view" element={<MainEvents />} />
+          <Route path="/this-weekend-in-philadelphia" element={<ThisWeekendInPhiladelphia />} />
+          <Route path="/this-weekend-in-philadelphia/" element={<ThisWeekendInPhiladelphia />} />
+          <Route path="/philadelphia-events" element={<PhiladelphiaEventsIndex />} />
+          <Route path="/philadelphia-events/" element={<PhiladelphiaEventsIndex />} />
+          <Route path="/:view" element={<ViewRouter />} />
           <Route path="/old" element={<App />} />
           <Route path="/sports" element={<SportsPage />} />
           <Route path="/sports/:id" element={<SportsEventPage />} />

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,250 @@
+export const PHILLY_TIME_ZONE = 'America/New_York';
+
+const intlApi = typeof globalThis !== 'undefined' ? globalThis.Intl : undefined;
+
+function formatterFromDate(date, timeZone, options) {
+  if (intlApi?.DateTimeFormat) {
+    return new intlApi.DateTimeFormat('en-US', {
+      timeZone,
+      ...options,
+    }).format(date);
+  }
+  return new Date(date).toLocaleString('en-US', options);
+}
+
+function getParts(date, timeZone) {
+  if (intlApi?.DateTimeFormat) {
+    const formatter = new intlApi.DateTimeFormat('en-US', {
+      timeZone,
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    const parts = formatter.formatToParts(date);
+    const map = {};
+    parts.forEach(({ type, value }) => {
+      map[type] = value;
+    });
+    return map;
+  }
+
+  const fallback = new Date(date);
+  return {
+    year: String(fallback.getFullYear()),
+    month: String(fallback.getMonth() + 1).padStart(2, '0'),
+    day: String(fallback.getDate()).padStart(2, '0'),
+    hour: String(fallback.getHours()).padStart(2, '0'),
+    minute: String(fallback.getMinutes()).padStart(2, '0'),
+    second: String(fallback.getSeconds()).padStart(2, '0'),
+  };
+}
+
+export function getZonedDate(date = new Date(), timeZone = PHILLY_TIME_ZONE) {
+  const map = getParts(date, timeZone);
+  return new Date(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    Number(map.hour),
+    Number(map.minute),
+    Number(map.second),
+  );
+}
+
+export function setStartOfDay(date) {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+export function setEndOfDay(date) {
+  const copy = new Date(date);
+  copy.setHours(23, 59, 59, 999);
+  return copy;
+}
+
+export function parseMonthDayYear(value, timeZone = PHILLY_TIME_ZONE) {
+  if (!value) return null;
+  const parts = value.split('/').map(Number);
+  if (parts.length !== 3) return null;
+  const [month, day, year] = parts;
+  if (Number.isNaN(month) || Number.isNaN(day) || Number.isNaN(year)) return null;
+  const utc = new Date(Date.UTC(year, month - 1, day, 5, 0, 0));
+  const zoned = getZonedDate(utc, timeZone);
+  return setStartOfDay(zoned);
+}
+
+export function parseISODate(value, timeZone = PHILLY_TIME_ZONE) {
+  if (!value) return null;
+  const parts = value.split('-').map(Number);
+  if (parts.length !== 3) return null;
+  const [year, month, day] = parts;
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) return null;
+  const utc = new Date(Date.UTC(year, month - 1, day, 5, 0, 0));
+  const zoned = getZonedDate(utc, timeZone);
+  return setStartOfDay(zoned);
+}
+
+export function overlaps(startA, endA, startB, endB) {
+  if (!startA || !endA || !startB || !endB) return false;
+  return !(endA.getTime() < startB.getTime() || startA.getTime() > endB.getTime());
+}
+
+export function getWeekendWindow(reference = new Date(), timeZone = PHILLY_TIME_ZONE) {
+  const zonedNow = getZonedDate(reference, timeZone);
+  const day = zonedNow.getDay();
+  let friday = setStartOfDay(zonedNow);
+
+  if (day >= 1 && day <= 4) {
+    friday.setDate(friday.getDate() + (5 - day));
+  } else if (day === 6) {
+    friday.setDate(friday.getDate() - 1);
+  } else if (day === 0) {
+    friday.setDate(friday.getDate() - 2);
+  }
+
+  const sunday = setStartOfDay(new Date(friday));
+  sunday.setDate(friday.getDate() + 2);
+  const sundayEnd = setEndOfDay(sunday);
+
+  return {
+    start: friday,
+    end: sundayEnd,
+  };
+}
+
+export function getMonthWindow(year, monthIndex, timeZone = PHILLY_TIME_ZONE) {
+  const startUTC = new Date(Date.UTC(year, monthIndex - 1, 1, 5, 0, 0));
+  const endUTC = new Date(Date.UTC(year, monthIndex, 0, 5, 0, 0));
+  const start = setStartOfDay(getZonedDate(startUTC, timeZone));
+  const end = setEndOfDay(getZonedDate(endUTC, timeZone));
+  return { start, end };
+}
+
+export function formatWeekdayAbbrev(date, timeZone = PHILLY_TIME_ZONE) {
+  if (!date) return '';
+  return formatterFromDate(date, timeZone, { weekday: 'short' });
+}
+
+export function formatMonthAbbrev(date, timeZone = PHILLY_TIME_ZONE) {
+  if (!date) return '';
+  return formatterFromDate(date, timeZone, { month: 'short' });
+}
+
+export function formatMonthDay(date, timeZone = PHILLY_TIME_ZONE) {
+  if (!date) return '';
+  return formatterFromDate(date, timeZone, { month: 'short', day: 'numeric' });
+}
+
+export function formatLongWeekday(date, timeZone = PHILLY_TIME_ZONE) {
+  if (!date) return '';
+  return formatterFromDate(date, timeZone, { weekday: 'long' });
+}
+
+export function formatMonthYear(date, timeZone = PHILLY_TIME_ZONE) {
+  if (!date) return '';
+  return formatterFromDate(date, timeZone, { month: 'long', year: 'numeric' });
+}
+
+const MONTH_SLUGS = [
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+];
+
+export function monthSlugToIndex(slug) {
+  if (!slug) return null;
+  const idx = MONTH_SLUGS.indexOf(slug.toLowerCase());
+  return idx === -1 ? null : idx + 1;
+}
+
+export function indexToMonthSlug(index) {
+  if (!index) return null;
+  const normalized = ((index - 1) % 12 + 12) % 12;
+  return MONTH_SLUGS[normalized];
+}
+
+export function formatDateRangeForTitle(start, end, timeZone = PHILLY_TIME_ZONE) {
+  if (!start || !end) return '';
+  const sameMonth =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth();
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const startMonth = formatMonthAbbrev(start, timeZone);
+  const endMonth = formatMonthAbbrev(end, timeZone);
+  const startDay = formatterFromDate(start, timeZone, { day: 'numeric' });
+  const endDay = formatterFromDate(end, timeZone, { day: 'numeric' });
+  if (sameMonth && sameYear) {
+    return `${startMonth} ${startDay}–${endDay}, ${start.getFullYear()}`;
+  }
+  if (sameYear) {
+    return `${startMonth} ${startDay}–${endMonth} ${endDay}, ${start.getFullYear()}`;
+  }
+  return `${startMonth} ${startDay}, ${start.getFullYear()}–${endMonth} ${endDay}, ${end.getFullYear()}`;
+}
+
+export function formatEventDateRange(start, end, timeZone = PHILLY_TIME_ZONE) {
+  if (!start || !end) return '';
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+  if (sameDay) {
+    if (intlApi?.DateTimeFormat) {
+      return new intlApi.DateTimeFormat('en-US', {
+        timeZone,
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+      }).format(start);
+    }
+    return start.toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    });
+  }
+
+  if (intlApi?.DateTimeFormat) {
+    const startStr = new intlApi.DateTimeFormat('en-US', {
+      timeZone,
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    }).format(start);
+    const endStr = new intlApi.DateTimeFormat('en-US', {
+      timeZone,
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    }).format(end);
+    return `${startStr} – ${endStr}`;
+  }
+
+  const startStr = start.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+  const endStr = end.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+  return `${startStr} – ${endStr}`;
+}
+
+export { MONTH_SLUGS };


### PR DESCRIPTION
## Summary
- remove the weekend title suffix, introduce a dynamic event-count intro, and keep the hero content clear beneath the navbar
- retitle the monthly traditions hub, push content below the nav, refresh SEO metadata, and streamline the signup spotlight for logged-out visitors
- surface both new experiences from a desktop dropdown and mobile links in the primary navigation so they stay easy to find

## Testing
- npm run build
- npm run lint *(fails: repository script still passes the deprecated `--ext` flag when using `eslint.config.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2b07d710832ca6b3057523281865