### PR TITLE
Add SPA fallback and redirect for Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,19 @@
 {
-    "rewrites": [
-      {
-        "source": "/groups/:slug",
-        "destination": "/index.html"
-      },
-      {
-        "source": "/:path*",
-        "destination": "/index.html"
-      }
-    ]
-  }
-  
+  "rewrites": [
+    {
+      "source": "/groups/:slug",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/this-weekend-in-philly",
+      "destination": "/this-weekend-in-philadelphia",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- update the Vercel configuration so all non-asset routes fall back to index.html for the SPA
- add a permanent redirect from /this-weekend-in-philly to /this-weekend-in-philadelphia

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc4d87d3a8832c9e6a2eaf281be95f