### PR TITLE
Create reusable head management components

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@600&display=swap" rel="stylesheet">
@@ -10,12 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Barrio&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Reenie+Beanie&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Our Philly – Philadelphia Events &amp; Groups</title>
-    <meta name="description" content="Discover upcoming events, concerts and community groups across Philadelphia." />
-    <link rel="canonical" href="https://ourphilly.org/" />
-    <meta property="og:title" content="Our Philly" />
-    <meta property="og:description" content="Discover upcoming events, concerts and community groups across Philadelphia." />
-    <meta property="og:url" content="https://ourphilly.org/" />
+    <title>Our Philly</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/HeadProvider.jsx
+++ b/src/components/HeadProvider.jsx
@@ -1,0 +1,153 @@
+import { createContext, useContext, useMemo, useRef } from 'react'
+
+const MANAGED_KEY_ATTR = 'data-head-key'
+
+const HeadContext = createContext(null)
+
+const createRecord = () => ({
+  element: null,
+  entries: new Map(),
+  order: [],
+})
+
+export const HeadProvider = ({ children }) => {
+  const elementsRef = useRef(new Map())
+  const titleStateRef = useRef({
+    defaultTitle: typeof document !== 'undefined' ? document.title : '',
+    order: [],
+    values: new Map(),
+  })
+
+  const contextValue = useMemo(() => {
+    const applyEntryToDom = (key, record, entry) => {
+      if (typeof document === 'undefined') return
+      let element = record.element
+
+      if (!element || element.tagName.toLowerCase() !== entry.type) {
+        if (element?.parentNode) {
+          element.parentNode.removeChild(element)
+        }
+        element = document.createElement(entry.type)
+        element.setAttribute(MANAGED_KEY_ATTR, key)
+        document.head.appendChild(element)
+        record.element = element
+      }
+
+      const attributeNames = Array.from(element.attributes)
+        .map((attr) => attr.name)
+        .filter((name) => name !== MANAGED_KEY_ATTR)
+
+      attributeNames.forEach((name) => {
+        element.removeAttribute(name)
+      })
+
+      Object.entries(entry.props || {}).forEach(([name, value]) => {
+        if (value !== undefined && value !== null) {
+          element.setAttribute(name, value)
+        }
+      })
+
+      if (entry.textContent !== undefined) {
+        element.textContent = entry.textContent
+      } else if (element.textContent) {
+        element.textContent = ''
+      }
+    }
+
+    const upsertElement = ({ key, owner, type, props = {}, textContent }) => {
+      if (typeof document === 'undefined') return null
+      if (!key || !owner) {
+        throw new Error('upsertElement requires a key and owner')
+      }
+
+      let record = elementsRef.current.get(key)
+      if (!record) {
+        record = createRecord()
+        elementsRef.current.set(key, record)
+      }
+
+      const entry = { type, props, textContent }
+      record.entries.set(owner, entry)
+      record.order = record.order.filter((existingOwner) => existingOwner !== owner)
+      record.order.push(owner)
+      applyEntryToDom(key, record, entry)
+      return record.element
+    }
+
+    const removeElement = ({ key, owner }) => {
+      const record = elementsRef.current.get(key)
+      if (!record || !record.entries.has(owner)) {
+        return
+      }
+
+      record.entries.delete(owner)
+      record.order = record.order.filter((existingOwner) => existingOwner !== owner)
+
+      if (record.order.length === 0) {
+        if (record.element?.parentNode) {
+          record.element.parentNode.removeChild(record.element)
+        }
+        elementsRef.current.delete(key)
+        return
+      }
+
+      const nextOwner = record.order[record.order.length - 1]
+      const nextEntry = record.entries.get(nextOwner)
+      if (nextEntry) {
+        applyEntryToDom(key, record, nextEntry)
+      }
+    }
+
+    const setTitle = (owner, value) => {
+      if (typeof document === 'undefined') return
+      if (!owner) {
+        throw new Error('setTitle requires an owner')
+      }
+
+      const state = titleStateRef.current
+      state.values.set(owner, value)
+      state.order = state.order.filter((existingOwner) => existingOwner !== owner)
+      state.order.push(owner)
+      document.title = value
+    }
+
+    const removeTitle = (owner) => {
+      if (typeof document === 'undefined') return
+      const state = titleStateRef.current
+      if (!state.values.has(owner)) return
+
+      state.values.delete(owner)
+      state.order = state.order.filter((existingOwner) => existingOwner !== owner)
+
+      const nextOwner = state.order[state.order.length - 1]
+      if (nextOwner) {
+        const nextTitle = state.values.get(nextOwner)
+        if (typeof nextTitle === 'string') {
+          document.title = nextTitle
+          return
+        }
+      }
+
+      document.title = state.defaultTitle
+    }
+
+    return {
+      upsertElement,
+      removeElement,
+      setTitle,
+      removeTitle,
+    }
+  }, [])
+
+  return <HeadContext.Provider value={contextValue}>{children}</HeadContext.Provider>
+}
+
+export const useHeadManager = () => {
+  const context = useContext(HeadContext)
+  if (!context) {
+    throw new Error('useHeadManager must be used within a HeadProvider')
+  }
+  return context
+}
+
+export default HeadProvider

--- a/src/components/Seo.jsx
+++ b/src/components/Seo.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from 'react'
+import { useHeadManager } from './HeadProvider'
+
+const TWITTER_CARD_TYPE = 'summary_large_image'
+const DEFAULT_OG_TYPE = 'website'
+
+const buildKey = (prefix, suffix) => `${prefix}:${suffix}`
+
+const Seo = ({
+  title,
+  description,
+  canonicalUrl,
+  ogImage,
+  ogType = DEFAULT_OG_TYPE,
+  jsonLd,
+}) => {
+  const { upsertElement, removeElement, setTitle, removeTitle } = useHeadManager()
+  const instanceIdRef = useRef(Symbol('seo'))
+
+  useEffect(() => {
+    const owner = instanceIdRef.current
+    if (title) {
+      setTitle(owner, title)
+    } else {
+      removeTitle(owner)
+    }
+
+    return () => {
+      removeTitle(owner)
+    }
+  }, [title, setTitle, removeTitle])
+
+  useEffect(() => {
+    const owner = instanceIdRef.current
+    const keys = []
+    const register = (key, type, props, textContent) => {
+      if (!props && textContent === undefined) return
+      upsertElement({ key, owner, type, props, textContent })
+      keys.push(key)
+    }
+
+    if (description) {
+      register(buildKey('meta', 'description'), 'meta', {
+        name: 'description',
+        content: description,
+      })
+    }
+
+    if (canonicalUrl) {
+      register(buildKey('link', 'canonical'), 'link', {
+        rel: 'canonical',
+        href: canonicalUrl,
+      })
+    }
+
+    const ogTitle = title || ''
+    if (ogTitle) {
+      register(buildKey('meta', 'og:title'), 'meta', {
+        property: 'og:title',
+        content: ogTitle,
+      })
+      register(buildKey('meta', 'twitter:title'), 'meta', {
+        name: 'twitter:title',
+        content: ogTitle,
+      })
+    }
+
+    if (description) {
+      register(buildKey('meta', 'og:description'), 'meta', {
+        property: 'og:description',
+        content: description,
+      })
+      register(buildKey('meta', 'twitter:description'), 'meta', {
+        name: 'twitter:description',
+        content: description,
+      })
+    }
+
+    const resolvedUrl =
+      canonicalUrl ||
+      (typeof globalThis !== 'undefined' && globalThis.location
+        ? globalThis.location.href
+        : undefined)
+    if (resolvedUrl) {
+      register(buildKey('meta', 'og:url'), 'meta', {
+        property: 'og:url',
+        content: resolvedUrl,
+      })
+    }
+
+    if (ogImage) {
+      register(buildKey('meta', 'og:image'), 'meta', {
+        property: 'og:image',
+        content: ogImage,
+      })
+      register(buildKey('meta', 'twitter:image'), 'meta', {
+        name: 'twitter:image',
+        content: ogImage,
+      })
+    }
+
+    register(buildKey('meta', 'og:type'), 'meta', {
+      property: 'og:type',
+      content: ogType || DEFAULT_OG_TYPE,
+    })
+
+    register(buildKey('meta', 'twitter:card'), 'meta', {
+      name: 'twitter:card',
+      content: TWITTER_CARD_TYPE,
+    })
+
+    if (jsonLd) {
+      const scriptKey = buildKey('script', 'ld+json')
+      const jsonContent = JSON.stringify(jsonLd, null, 2)
+      register(scriptKey, 'script', { type: 'application/ld+json' }, jsonContent)
+    } else {
+      removeElement({ key: buildKey('script', 'ld+json'), owner })
+    }
+
+    return () => {
+      keys.forEach((key) => removeElement({ key, owner }))
+    }
+  }, [
+    title,
+    description,
+    canonicalUrl,
+    ogImage,
+    ogType,
+    jsonLd,
+    upsertElement,
+    removeElement,
+  ])
+
+  return null
+}
+
+export default Seo

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,7 +16,7 @@ import ProfilePage from './ProfilePage.jsx';
 import PublicProfilePage from './PublicProfilePage.jsx';
 import OnboardingFlow from './OnboardingFlow.jsx';
 import { AuthProvider } from './AuthProvider.jsx'
-import MomentsExplorer from './MomentsExplorer.jsx' 
+import MomentsExplorer from './MomentsExplorer.jsx'
 import EventDetailPage from './EventDetailPage.jsx'
 import MonthlyEvents from './MonthlyEvents.jsx'
 import AdminClaimRequests from './AdminClaimRequests';
@@ -56,6 +56,7 @@ import AboutPage from './AboutPage.jsx'
 import ThisWeekendInPhiladelphia from './ThisWeekendInPhiladelphia.jsx';
 import PhiladelphiaEventsIndex from './PhiladelphiaEventsIndex.jsx';
 import ViewRouter from './ViewRouter.jsx';
+import HeadProvider from './components/HeadProvider.jsx'
 
 
 
@@ -71,101 +72,155 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     {/* Wrap entire app with AuthProvider to supply session & user */}
     <AuthProvider>
-      <BrowserRouter>
-      <ScrollToTop />
-        <Routes>
-          <Route path="/" element={<MainEvents />} />
-          <Route path="/this-weekend-in-philadelphia" element={<ThisWeekendInPhiladelphia />} />
-          <Route path="/this-weekend-in-philadelphia/" element={<ThisWeekendInPhiladelphia />} />
-          <Route path="/philadelphia-events" element={<PhiladelphiaEventsIndex />} />
-          <Route path="/philadelphia-events/" element={<PhiladelphiaEventsIndex />} />
-          <Route path="/:view" element={<ViewRouter />} />
-          <Route path="/old" element={<App />} />
-          <Route path="/sports" element={<SportsPage />} />
-          <Route path="/sports/:id" element={<SportsEventPage />} />
-          <Route path="/trivia" element={<TriviaNights />} />
-          <Route path="/voicemail" element={<VoicemailPage />} />
-          <Route path="/groups" element={<GroupsPage />} />
-          <Route path="/volunteer" element={<VolunteerGroups />} />
-          <Route path="/concerts" element={<ConcertPage />} />
-          <Route path="/groups/:slug" element={<GroupDetailPage />} />
-          <Route path="/groups/type/:tagSlug" element={<GroupTypePage />} />
-          {/* Auth route for login */}
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignUpPage />} />
-          <Route path="/profile" element={<ProfilePage />} />
-          <Route path="/onboarding-preview" element={<OnboardingFlow demo />} />
-          <Route path="/u/:slug" element={<PublicProfilePage />} />
-          <Route path="/moments" element={<MomentsExplorer />} />
-          <Route path="/moments/:id" element={<MomentsExplorer />} />
-          <Route path="/events" element={<MonthlyEvents />} />
-          <Route path="/events/:slug" element={<EventDetailPage />} />
-          <Route path="/admin/claims" element={<AdminClaimRequests />} />
-          <Route path="/update-password" element={<UpdatePasswordPage />} />
-          <Route path="/test-updates" element={<TestGroupUpdates />} />
-          <Route path="/seasonal/:slug" element={<SeasonalEventDetails />} />
-          <Route path="/bulletin" element={<Bulletin />} />
-          <Route path="/upcoming-events" element={<EventsPage />} />
-          <Route path="/unsubscribe" element={<Unsubscribe />} />
-          <Route path="/privacy" element={<PrivacyPage />} />
-          <Route path="/outlets/:slug" element={<OutletDetailPage />} />
-          <Route path="/board" element={<BigBoardPage />} />
-          <Route path="/admin/users" element={<AdminUsers />} />
-          <Route path="/admin/reviews" element={<AdminReviews />} />
-          <Route path="/admin/updates" element={<AdminGroupUpdates />} />
-          <Route path="/admin/comments" element={<AdminComments />} />
-          <Route path="/admin" element={<AdminDashboard />} />
-          <Route path="/admin/activity" element={<AdminActivity />} />
-          <Route path="/social-video-arts" element={<SocialVideoCarousel tag="arts" />} />
-          <Route path="/social-video-food" element={<SocialVideoCarousel tag="nomnomslurp" />} />
-          <Route path="/social-video-fitness" element={<SocialVideoCarousel tag="fitness" />} />
-          <Route path="/plans-video-arts" element={<PlansVideoCarousel tag="arts" />} />
-          <Route path="/plans-video-food" element={<PlansVideoCarousel tag="nomnomslurp" />} />
-          <Route path="/plans-video-birds" element={<PlansVideoCarousel tag="birds" />} />
-          <Route path="/plans-video-fitness" element={<PlansVideoCarousel tag="fitness" limit={40} />} />
-          <Route path="/plans-video-music" element={<PlansVideoCarousel tag="music" />} />
-          <Route path="/plans-video-oktoberfest" element={<PlansVideoCarousel tag="oktoberfest" />} />
-          <Route path="/plans-video/traditions-video" element={<TraditionsVideo />} />
-          <Route
-            path="/plans-video/traditions-gallery"
-            element={<PlansVideoCarousel onlyEvents headline="Traditions gAllery" limit={30} />}
-          />
-          <Route path="/plans-video-peco" element={<PlansVideoCarousel tag="peco-multicultural" />} />
-          <Route path="/plans-video-markets" element={<PlansVideoCarousel tag="markets" />} />
-          <Route
-            path="/plans-video/today"
-            element={<PlansVideoCarousel today headline="Events Today in Philly" limit={30} />}
-          />
-        <Route
-          path="/plans-video/weekend-plans"
-          element={<PlansVideoCarousel weekend headline="Events This Weekend in Philly" limit={30} />}
-        />
-        <Route
-          path="/plans-video/this-sunday"
-          element={<PlansVideoCarousel sunday headline="Events This Sunday in Philly" limit={30} />}
-        />
-        <Route path="/plans-video" element={<PlansVideoIndex />} />
-          <Route path="/big-board/:slug"  element={<BigBoardEventPage />} />
-          <Route path="/board-carousel" element={<BigBoardCarousel />} />
-          <Route path="/:venue" element={<VenuePage />} />
-          <Route path="/:venue/:slug" element={<MainEventsDetail />} />
-          <Route path="/groups/:slug/events/:eventId" element={<GroupEventDetailPage />} />
-          <Route path="/tags/:slug" element={<TagPage />} />
-          <Route path="/contact" element={<ContactPage />} />
-          <Route path="/traditions-faq" element={<TraditionsFAQ />} />
-          <Route path="/groups-faq" element={<GroupsFAQ />} />
-          <Route path="/about" element={<AboutPage />} />
-          <Route path="/series/:slug/:date" element={<RecurringPage />} />
-
-
-
-
-
-
-
-          
-        </Routes>
-      </BrowserRouter>
+      <HeadProvider>
+        <BrowserRouter>
+          <ScrollToTop />
+          <Routes>
+            <Route path="/" element={<MainEvents />} />
+            <Route
+              path="/this-weekend-in-philadelphia"
+              element={<ThisWeekendInPhiladelphia />}
+            />
+            <Route
+              path="/this-weekend-in-philadelphia/"
+              element={<ThisWeekendInPhiladelphia />}
+            />
+            <Route path="/philadelphia-events" element={<PhiladelphiaEventsIndex />} />
+            <Route path="/philadelphia-events/" element={<PhiladelphiaEventsIndex />} />
+            <Route path="/:view" element={<ViewRouter />} />
+            <Route path="/old" element={<App />} />
+            <Route path="/sports" element={<SportsPage />} />
+            <Route path="/sports/:id" element={<SportsEventPage />} />
+            <Route path="/trivia" element={<TriviaNights />} />
+            <Route path="/voicemail" element={<VoicemailPage />} />
+            <Route path="/groups" element={<GroupsPage />} />
+            <Route path="/volunteer" element={<VolunteerGroups />} />
+            <Route path="/concerts" element={<ConcertPage />} />
+            <Route path="/groups/:slug" element={<GroupDetailPage />} />
+            <Route path="/groups/type/:tagSlug" element={<GroupTypePage />} />
+            {/* Auth route for login */}
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignUpPage />} />
+            <Route path="/profile" element={<ProfilePage />} />
+            <Route path="/onboarding-preview" element={<OnboardingFlow demo />} />
+            <Route path="/u/:slug" element={<PublicProfilePage />} />
+            <Route path="/moments" element={<MomentsExplorer />} />
+            <Route path="/moments/:id" element={<MomentsExplorer />} />
+            <Route path="/events" element={<MonthlyEvents />} />
+            <Route path="/events/:slug" element={<EventDetailPage />} />
+            <Route path="/admin/claims" element={<AdminClaimRequests />} />
+            <Route path="/update-password" element={<UpdatePasswordPage />} />
+            <Route path="/test-updates" element={<TestGroupUpdates />} />
+            <Route path="/seasonal/:slug" element={<SeasonalEventDetails />} />
+            <Route path="/bulletin" element={<Bulletin />} />
+            <Route path="/upcoming-events" element={<EventsPage />} />
+            <Route path="/unsubscribe" element={<Unsubscribe />} />
+            <Route path="/privacy" element={<PrivacyPage />} />
+            <Route path="/outlets/:slug" element={<OutletDetailPage />} />
+            <Route path="/board" element={<BigBoardPage />} />
+            <Route path="/admin/users" element={<AdminUsers />} />
+            <Route path="/admin/reviews" element={<AdminReviews />} />
+            <Route path="/admin/updates" element={<AdminGroupUpdates />} />
+            <Route path="/admin/comments" element={<AdminComments />} />
+            <Route path="/admin" element={<AdminDashboard />} />
+            <Route path="/admin/activity" element={<AdminActivity />} />
+            <Route
+              path="/social-video-arts"
+              element={<SocialVideoCarousel tag="arts" />}
+            />
+            <Route
+              path="/social-video-food"
+              element={<SocialVideoCarousel tag="nomnomslurp" />}
+            />
+            <Route
+              path="/social-video-fitness"
+              element={<SocialVideoCarousel tag="fitness" />}
+            />
+            <Route
+              path="/plans-video-arts"
+              element={<PlansVideoCarousel tag="arts" />}
+            />
+            <Route
+              path="/plans-video-food"
+              element={<PlansVideoCarousel tag="nomnomslurp" />}
+            />
+            <Route
+              path="/plans-video-birds"
+              element={<PlansVideoCarousel tag="birds" />}
+            />
+            <Route
+              path="/plans-video-fitness"
+              element={<PlansVideoCarousel tag="fitness" limit={40} />}
+            />
+            <Route
+              path="/plans-video-music"
+              element={<PlansVideoCarousel tag="music" />}
+            />
+            <Route
+              path="/plans-video-oktoberfest"
+              element={<PlansVideoCarousel tag="oktoberfest" />}
+            />
+            <Route path="/plans-video/traditions-video" element={<TraditionsVideo />} />
+            <Route
+              path="/plans-video/traditions-gallery"
+              element={
+                <PlansVideoCarousel
+                  onlyEvents
+                  headline="Traditions gAllery"
+                  limit={30}
+                />
+              }
+            />
+            <Route
+              path="/plans-video-peco"
+              element={<PlansVideoCarousel tag="peco-multicultural" />}
+            />
+            <Route
+              path="/plans-video-markets"
+              element={<PlansVideoCarousel tag="markets" />}
+            />
+            <Route
+              path="/plans-video/today"
+              element={<PlansVideoCarousel today headline="Events Today in Philly" limit={30} />}
+            />
+            <Route
+              path="/plans-video/weekend-plans"
+              element={
+                <PlansVideoCarousel
+                  weekend
+                  headline="Events This Weekend in Philly"
+                  limit={30}
+                />
+              }
+            />
+            <Route
+              path="/plans-video/this-sunday"
+              element={
+                <PlansVideoCarousel
+                  sunday
+                  headline="Events This Sunday in Philly"
+                  limit={30}
+                />
+              }
+            />
+            <Route path="/plans-video" element={<PlansVideoIndex />} />
+            <Route path="/big-board/:slug" element={<BigBoardEventPage />} />
+            <Route path="/board-carousel" element={<BigBoardCarousel />} />
+            <Route path="/:venue" element={<VenuePage />} />
+            <Route path="/:venue/:slug" element={<MainEventsDetail />} />
+            <Route
+              path="/groups/:slug/events/:eventId"
+              element={<GroupEventDetailPage />}
+            />
+            <Route path="/tags/:slug" element={<TagPage />} />
+            <Route path="/contact" element={<ContactPage />} />
+            <Route path="/traditions-faq" element={<TraditionsFAQ />} />
+            <Route path="/groups-faq" element={<GroupsFAQ />} />
+            <Route path="/about" element={<AboutPage />} />
+            <Route path="/series/:slug/:date" element={<RecurringPage />} />
+          </Routes>
+        </BrowserRouter>
+      </HeadProvider>
     </AuthProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- add a HeadProvider context that manages DOM head elements with stack-aware updates for titles and meta tags
- create a reusable Seo component that updates title, canonical, social tags, and optional JSON-LD through the provider
- simplify index.html head markup and wrap the app in the new provider

## Testing
- yarn lint *(fails: Invalid option '--ext' with eslint flat config)*
- npx eslint . *(fails: repository-wide parsing/no-undef issues pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8027e968832ca66728fc8621c075