### PR TITLE
Add trailing slash handling for weekend and monthly routes

### DIFF
--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -1830,7 +1830,7 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
             </section>
             <section className="px-4 mb-12">
               <Link
-                to="/this-weekend-in-philadelphia"
+                to="/this-weekend-in-philadelphia/"
                 className="block group"
               >
                 <div className="max-w-screen-xl mx-auto">

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -124,7 +124,7 @@ export default function Navbar({ style }) {
                 {guidesOpen && (
                   <div className="absolute right-0 mt-3 w-64 bg-white border border-gray-200 rounded-xl shadow-lg py-3 z-50">
                     <Link
-                      to="/this-weekend-in-philadelphia"
+                      to="/this-weekend-in-philadelphia/"
                       className="block px-4 py-2 text-sm text-gray-700 hover:bg-indigo-50 hover:text-indigo-700"
                       onClick={() => setGuidesOpen(false)}
                     >
@@ -235,7 +235,7 @@ export default function Navbar({ style }) {
               </a>
             </div>
             <Link
-              to="/this-weekend-in-philadelphia"
+              to="/this-weekend-in-philadelphia/"
               className="block"
               onClick={() => setMenuOpen(false)}
             >

--- a/src/ThisMonthInPhiladelphia.jsx
+++ b/src/ThisMonthInPhiladelphia.jsx
@@ -19,6 +19,7 @@ import {
 
 const DEFAULT_OG_IMAGE = 'https://ourphilly.org/og-image.png';
 const CANONICAL_BASE = 'https://ourphilly.org/philadelphia-events-';
+const CANONICAL_INDEX = 'https://ourphilly.org/philadelphia-events/';
 
 function setMetaTag(name, content) {
   if (typeof document === 'undefined') return;
@@ -86,7 +87,7 @@ export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverrid
 
   useEffect(() => {
     if (!hasValidParams) {
-      navigate('/philadelphia-events', { replace: true });
+      navigate('/philadelphia-events/', { replace: true });
     }
   }, [hasValidParams, navigate]);
 
@@ -177,7 +178,7 @@ export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverrid
 
   const canonicalUrl = monthIndex && !Number.isNaN(yearNum)
     ? `${CANONICAL_BASE}${indexToMonthSlug(monthIndex)}-${yearNum}/`
-    : `${CANONICAL_BASE}`;
+    : CANONICAL_INDEX;
 
   useEffect(() => {
     if (!monthIndex || Number.isNaN(yearNum) || !monthStart) return;
@@ -230,7 +231,7 @@ export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverrid
               ← {prevLabel || 'Previous'}
             </Link>
             <span className="hidden md:block text-gray-300">|</span>
-            <Link to="/this-weekend-in-philadelphia" className="text-sm font-semibold text-indigo-600 hover:underline">
+            <Link to="/this-weekend-in-philadelphia/" className="text-sm font-semibold text-indigo-600 hover:underline">
               This Weekend →
             </Link>
             <span className="hidden md:block text-gray-300">|</span>

--- a/src/components/SlashGuard.jsx
+++ b/src/components/SlashGuard.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+const needsSlash = pathname =>
+  pathname === '/this-weekend-in-philadelphia' ||
+  /^\/philadelphia-events-[a-z]+-\d{4}$/.test(pathname)
+
+export default function SlashGuard() {
+  const { pathname, search, hash } = useLocation()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (needsSlash(pathname)) {
+      navigate(`${pathname}/${search}${hash}`, { replace: true })
+    }
+  }, [pathname, search, hash, navigate])
+
+  return null
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -54,9 +54,11 @@ import RecurringPage from './RecurringEventPage.jsx'
 import SportsEventPage from './SportsEventPage.jsx'
 import AboutPage from './AboutPage.jsx'
 import ThisWeekendInPhiladelphia from './ThisWeekendInPhiladelphia.jsx';
+import ThisMonthInPhiladelphia from './ThisMonthInPhiladelphia.jsx';
 import PhiladelphiaEventsIndex from './PhiladelphiaEventsIndex.jsx';
 import ViewRouter from './ViewRouter.jsx';
 import HeadProvider from './components/HeadProvider.jsx'
+import SlashGuard from './components/SlashGuard.jsx'
 
 
 
@@ -75,18 +77,18 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <HeadProvider>
         <BrowserRouter>
           <ScrollToTop />
+          <SlashGuard />
           <Routes>
             <Route path="/" element={<MainEvents />} />
-            <Route
-              path="/this-weekend-in-philadelphia"
-              element={<ThisWeekendInPhiladelphia />}
-            />
             <Route
               path="/this-weekend-in-philadelphia/"
               element={<ThisWeekendInPhiladelphia />}
             />
-            <Route path="/philadelphia-events" element={<PhiladelphiaEventsIndex />} />
             <Route path="/philadelphia-events/" element={<PhiladelphiaEventsIndex />} />
+            <Route
+              path="/philadelphia-events-:month-:year/"
+              element={<ThisMonthInPhiladelphia />}
+            />
             <Route path="/:view" element={<ViewRouter />} />
             <Route path="/old" element={<App />} />
             <Route path="/sports" element={<SportsPage />} />

--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,18 @@
 {
-    "rewrites": [
-      {
-        "source": "/groups/:slug",
-        "destination": "/index.html"
-      },
-      {
-        "source": "/:path*",
-        "destination": "/index.html"
-      }
-    ]
-  }
+  "rewrites": [
+    {
+      "source": "/groups/:slug",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/:path*",
+      "destination": "/index.html"
+    }
+  ],
+  "redirects": [
+    { "source": "/this-weekend-in-philly", "destination": "/this-weekend-in-philadelphia/", "permanent": false },
+    { "source": "/this-weekend-in-philadelphia", "destination": "/this-weekend-in-philadelphia/", "permanent": true },
+    { "source": "/philadelphia-events-:month-:year", "destination": "/philadelphia-events-:month-:year/", "permanent": true }
+  ]
+}
   


### PR DESCRIPTION
## Summary
- add Vercel redirects so unslashed weekend and monthly URLs resolve to trailing-slash versions
- update the React router to define the slashed weekend and monthly routes and mount a SlashGuard helper
- refresh internal links and canonical helpers so navigation and SEO metadata consistently use the trailing slash paths

## Testing
- `npm run lint` *(fails: eslint.config.js no longer supports --ext option in the packaged script)*
- `npx eslint .` *(fails: existing parsing/no-undef errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8a3e05f8832ca78dae12cb5c4a78