### PR TITLE
Implement monthly events page SEO and filtering

### DIFF
--- a/src/ThisMonthInPhiladelphia.jsx
+++ b/src/ThisMonthInPhiladelphia.jsx
@@ -5,61 +5,31 @@ import Footer from './Footer';
 import { supabase } from './supabaseClient';
 import { AuthContext } from './AuthProvider';
 import useEventFavorite from './utils/useEventFavorite';
+import Seo from './components/Seo.jsx';
 import {
   PHILLY_TIME_ZONE,
   monthSlugToIndex,
-  indexToMonthSlug,
   getMonthWindow,
-  parseMonthDayYear,
+  indexToMonthSlug,
   overlaps,
   setEndOfDay,
   formatMonthYear,
   formatEventDateRange,
+  parseEventDateValue,
 } from './utils/dateUtils';
 
 const DEFAULT_OG_IMAGE = 'https://ourphilly.org/og-image.png';
 const CANONICAL_BASE = 'https://ourphilly.org/philadelphia-events-';
 const CANONICAL_INDEX = 'https://ourphilly.org/philadelphia-events/';
-
-function setMetaTag(name, content) {
-  if (typeof document === 'undefined') return;
-  let tag = document.querySelector(`meta[name="${name}"]`);
-  if (!tag) {
-    tag = document.createElement('meta');
-    tag.setAttribute('name', name);
-    document.head.appendChild(tag);
-  }
-  tag.setAttribute('content', content);
-}
-
-function setPropertyTag(property, content) {
-  if (typeof document === 'undefined') return;
-  let tag = document.querySelector(`meta[property="${property}"]`);
-  if (!tag) {
-    tag = document.createElement('meta');
-    tag.setAttribute('property', property);
-    document.head.appendChild(tag);
-  }
-  tag.setAttribute('content', content);
-}
-
-function setCanonicalLink(url) {
-  if (typeof document === 'undefined') return;
-  let link = document.querySelector('link[rel="canonical"]');
-  if (!link) {
-    link = document.createElement('link');
-    link.setAttribute('rel', 'canonical');
-    document.head.appendChild(link);
-  }
-  link.setAttribute('href', url);
-}
+const MONTH_VIEW_REGEX = /^philadelphia-events-([a-z-]+)-(\d{4})$/i;
+const GENERIC_TITLE = 'Philadelphia Events & Traditions – Our Philly';
+const GENERIC_DESCRIPTION =
+  'Explore Philadelphia events, traditions, festivals, and family-friendly plans updated regularly.';
 
 function FavoriteState({ event_id, source_table, children }) {
   const state = useEventFavorite({ event_id, source_table });
   return children(state);
 }
-
-const MONTH_VIEW_REGEX = /^philadelphia-events-([a-z-]+)-(\d{4})$/i;
 
 export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverride } = {}) {
   const params = useParams();
@@ -68,43 +38,57 @@ export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverrid
 
   const viewParam = params.view;
   const viewMatch = useMemo(() => {
-    if (viewParam) {
-      const match = viewParam.match(MONTH_VIEW_REGEX);
-      if (match) {
-        return { monthSlug: match[1].toLowerCase(), year: match[2] };
-      }
-    }
-    return null;
+    if (!viewParam) return null;
+    const match = viewParam.match(MONTH_VIEW_REGEX);
+    if (!match) return null;
+    return { monthSlug: match[1].toLowerCase(), year: match[2] };
   }, [viewParam]);
 
-  const monthSlugParam = monthSlugOverride || params.monthSlug || (viewMatch ? viewMatch.monthSlug : null);
+  const monthSlugParam = monthSlugOverride || params.month || (viewMatch ? viewMatch.monthSlug : null);
   const yearParam = yearOverride || params.year || (viewMatch ? viewMatch.year : null);
 
   const normalizedMonthSlug = monthSlugParam ? monthSlugParam.toLowerCase() : null;
   const monthIndex = normalizedMonthSlug ? monthSlugToIndex(normalizedMonthSlug) : null;
   const yearNum = yearParam ? Number(yearParam) : NaN;
-  const hasValidParams = Boolean(monthIndex && !Number.isNaN(yearNum));
-
-  useEffect(() => {
-    if (!hasValidParams) {
-      navigate('/philadelphia-events/', { replace: true });
-    }
-  }, [hasValidParams, navigate]);
+  const hasValidYear = Number.isInteger(yearNum) && yearNum >= 2000 && yearNum <= 2100;
+  const hasValidParams = Boolean(monthIndex && hasValidYear);
 
   const monthWindow = useMemo(() => {
-    if (!monthIndex || Number.isNaN(yearNum)) return { start: null, end: null };
+    if (!hasValidParams) {
+      return { start: null, end: null };
+    }
     return getMonthWindow(yearNum, monthIndex, PHILLY_TIME_ZONE);
-  }, [monthIndex, yearNum]);
+  }, [hasValidParams, monthIndex, yearNum]);
 
   const monthStart = monthWindow.start;
   const monthEnd = monthWindow.end;
+  const monthStartMs = monthStart ? monthStart.getTime() : null;
+  const monthEndMs = monthEnd ? monthEnd.getTime() : null;
 
-  const [events, setEvents] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [monthlyEvents, setMonthlyEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [ogImage, setOgImage] = useState(DEFAULT_OG_IMAGE);
 
   useEffect(() => {
-    if (!monthIndex || Number.isNaN(yearNum) || !monthStart || !monthEnd) return;
+    if (hasValidParams || monthSlugOverride || yearOverride) return;
+    const timer = setTimeout(() => {
+      navigate('/philadelphia-events/', { replace: true });
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [hasValidParams, navigate, monthSlugOverride, yearOverride]);
+
+  useEffect(() => {
+    if (!hasValidParams || !monthStart || !monthEnd) {
+      setMonthlyEvents([]);
+      setLoading(false);
+      setOgImage(DEFAULT_OG_IMAGE);
+      return;
+    }
+
+    let cancelled = false;
     setLoading(true);
+    setOgImage(DEFAULT_OG_IMAGE);
+
     supabase
       .from('events')
       .select(`
@@ -118,24 +102,30 @@ export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverrid
       `)
       .order('Dates', { ascending: true })
       .then(({ data, error }) => {
+        if (cancelled) return;
         if (error) {
           console.error('Error loading monthly events', error);
-          setEvents([]);
+          setMonthlyEvents([]);
           setLoading(false);
           return;
         }
+
         const filtered = (data || [])
           .map(evt => {
-            const startDate = parseMonthDayYear(evt.Dates, PHILLY_TIME_ZONE);
-            const endDateRaw = parseMonthDayYear(evt['End Date'], PHILLY_TIME_ZONE) || startDate;
-            if (!startDate || !endDateRaw) return null;
-            const endDate = setEndOfDay(new Date(endDateRaw));
+            const startRaw =
+              evt['E Start Date'] || evt.Dates || evt['Start Date'] || evt.start_date;
+            const endRaw =
+              evt['E End Date'] || evt['End Date'] || evt.end_date || startRaw;
+            const startDate = parseEventDateValue(startRaw, PHILLY_TIME_ZONE);
+            const endDateBase = parseEventDateValue(endRaw, PHILLY_TIME_ZONE) || startDate;
+            if (!startDate || !endDateBase) return null;
+            const endDate = setEndOfDay(endDateBase);
             if (!overlaps(startDate, endDate, monthStart, monthEnd)) return null;
             return {
               id: evt.id,
               title: evt['E Name'],
               description: evt['E Description'],
-              imageUrl: evt['E Image'] || '',
+              imageUrl: evt['E Image'] || null,
               startDate,
               endDate,
               slug: evt.slug,
@@ -144,167 +134,127 @@ export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverrid
           })
           .filter(Boolean)
           .sort((a, b) => (a.startDate?.getTime() || 0) - (b.startDate?.getTime() || 0));
-        setEvents(filtered);
+
+        setMonthlyEvents(filtered);
         setLoading(false);
       });
-  }, [monthIndex, yearNum, monthStart, monthEnd]);
 
-  const monthLabel = monthStart ? formatMonthYear(monthStart, PHILLY_TIME_ZONE) : '';
-  const headingLabel = monthLabel || 'Philadelphia';
-  const prevMonthIndex = monthIndex ? (monthIndex === 1 ? 12 : monthIndex - 1) : null;
-  const prevYear = monthIndex === 1 ? yearNum - 1 : yearNum;
-  const nextMonthIndex = monthIndex ? (monthIndex === 12 ? 1 : monthIndex + 1) : null;
-  const nextYear = monthIndex === 12 ? yearNum + 1 : yearNum;
-
-  const prevWindow = prevMonthIndex ? getMonthWindow(prevYear, prevMonthIndex, PHILLY_TIME_ZONE) : null;
-  const nextWindow = nextMonthIndex ? getMonthWindow(nextYear, nextMonthIndex, PHILLY_TIME_ZONE) : null;
-
-  const prevSlug = prevMonthIndex
-    ? `/philadelphia-events-${indexToMonthSlug(prevMonthIndex)}-${prevYear}/`
-    : '/philadelphia-events/';
-  const nextSlug = nextMonthIndex
-    ? `/philadelphia-events-${indexToMonthSlug(nextMonthIndex)}-${nextYear}/`
-    : '/philadelphia-events/';
-
-  const prevLabel = prevWindow ? formatMonthYear(prevWindow.start, PHILLY_TIME_ZONE) : '';
-  const nextLabel = nextWindow ? formatMonthYear(nextWindow.start, PHILLY_TIME_ZONE) : '';
-
-  const firstImage = useMemo(() => {
-    for (const evt of events) {
-      if (evt.imageUrl) return evt.imageUrl;
-    }
-    return null;
-  }, [events]);
-
-  const canonicalUrl = monthIndex && !Number.isNaN(yearNum)
-    ? `${CANONICAL_BASE}${indexToMonthSlug(monthIndex)}-${yearNum}/`
-    : CANONICAL_INDEX;
+    return () => {
+      cancelled = true;
+    };
+  }, [hasValidParams, monthStartMs, monthEndMs, monthSlugOverride, yearOverride]);
 
   useEffect(() => {
-    if (!monthIndex || Number.isNaN(yearNum) || !monthStart) return;
-    const heroImage = firstImage || DEFAULT_OG_IMAGE;
-    const pageTitle = monthLabel ? `Philly Traditions in ${monthLabel}` : 'Philly Traditions in Philadelphia';
-    const description = `${monthLabel || 'Philadelphia'} traditions, festivals, family-friendly fun, concerts, and markets from the most comprehensive events calendar in Philadelphia.`;
-    if (typeof document !== 'undefined') {
-      document.title = pageTitle;
+    if (!hasValidParams) return;
+    const firstWithImage = monthlyEvents.find(evt => evt.imageUrl);
+    if (firstWithImage?.imageUrl) {
+      setOgImage(firstWithImage.imageUrl);
     }
-    setMetaTag('description', description);
-    setPropertyTag('og:title', pageTitle);
-    setPropertyTag('og:description', description);
-    setPropertyTag('og:url', canonicalUrl);
-    setPropertyTag('og:image', heroImage);
-    setMetaTag('twitter:card', 'summary_large_image');
-    setMetaTag('twitter:title', pageTitle);
-    setMetaTag('twitter:description', description);
-    setMetaTag('twitter:image', heroImage);
-    setCanonicalLink(canonicalUrl);
-  }, [monthIndex, yearNum, monthLabel, canonicalUrl, firstImage, monthStart]);
+  }, [monthlyEvents, hasValidParams]);
 
-  const countText = `${events.length} traditions in ${headingLabel}!`;
+  const monthLabel = monthStart ? formatMonthYear(monthStart, PHILLY_TIME_ZONE) : '';
+  const canonicalSlug = monthIndex ? indexToMonthSlug(monthIndex) : null;
+  const canonicalUrl = hasValidParams && canonicalSlug
+    ? `${CANONICAL_BASE}${canonicalSlug}-${yearNum}/`
+    : CANONICAL_INDEX;
 
-  if (!hasValidParams) {
-    return (
-      <div className="flex flex-col min-h-screen bg-white">
-        <Navbar />
-        <main className="flex-1 pt-36 pb-16 flex items-center justify-center">
-          <p className="text-gray-600">Redirecting to the latest Philadelphia traditions…</p>
-        </main>
-        <Footer />
-      </div>
-    );
-  }
+  const seoTitle = hasValidParams && monthLabel
+    ? `Events in Philadelphia – ${monthLabel} (Traditions, Festivals, Markets)`
+    : GENERIC_TITLE;
+
+  const seoDescription = hasValidParams && monthLabel
+    ? `Explore ${monthLabel} events in Philadelphia, including traditions, festivals, and family-friendly plans.`
+    : GENERIC_DESCRIPTION;
+
+  const countText = hasValidParams && monthLabel ? `${monthlyEvents.length} traditions in ${monthLabel}!` : '';
 
   return (
     <div className="flex flex-col min-h-screen bg-white">
+      <Seo
+        title={seoTitle}
+        description={seoDescription}
+        canonicalUrl={canonicalUrl}
+        ogImage={ogImage}
+        ogType="website"
+      />
       <Navbar />
       <main className="flex-1 pt-36 md:pt-40 pb-16">
         <div className="container mx-auto px-4 max-w-5xl">
-          <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e] text-center">
-            Philly Traditions in {headingLabel}
-          </h1>
-          <p className="mt-6 text-lg text-gray-700 text-center max-w-3xl mx-auto">
-            Welcome to the most comprehensive events calendar in Philadelphia. Explore {headingLabel} traditions covering markets, festivals, concerts, and family-friendly outings so your plans stay rich all month long.
-          </p>
+          {hasValidParams ? (
+            <>
+              <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e] text-center">{countText}</h1>
+              <p className="mt-6 text-lg text-gray-700 text-center max-w-3xl mx-auto">
+                Browse traditions, festivals, and family-friendly events happening throughout {monthLabel}.
+              </p>
 
-          <div className="mt-10 md:sticky md:top-24 bg-white/90 border border-gray-200 rounded-2xl shadow-sm px-4 py-3 flex flex-wrap items-center justify-center gap-4">
-            <Link to={prevSlug} className="text-sm font-semibold text-indigo-600 hover:underline">
-              ← {prevLabel || 'Previous'}
-            </Link>
-            <span className="hidden md:block text-gray-300">|</span>
-            <Link to="/this-weekend-in-philadelphia/" className="text-sm font-semibold text-indigo-600 hover:underline">
-              This Weekend →
-            </Link>
-            <span className="hidden md:block text-gray-300">|</span>
-            <Link to={nextSlug} className="text-sm font-semibold text-indigo-600 hover:underline">
-              {nextLabel || 'Next'} →
-            </Link>
-          </div>
-
-          <p className="mt-8 text-xl font-semibold text-[#28313e] text-center">{countText}</p>
-
-          <section className="mt-10 bg-white border border-gray-200 rounded-2xl shadow-sm">
-            {loading ? (
-              <p className="p-6 text-gray-500">Loading this month’s traditions…</p>
-            ) : events.length === 0 ? (
-              <p className="p-6 text-gray-500">No events match this month just yet. Check back soon!</p>
-            ) : (
-              <div className="divide-y divide-gray-200">
-                {events.map(evt => (
-                  <div key={evt.id} className="flex flex-col md:flex-row gap-4 px-6 py-6">
-                    <div className="md:w-48 w-full flex-shrink-0">
-                      <img
-                        src={evt.imageUrl || ''}
-                        alt={evt.title}
-                        loading="lazy"
-                        className="w-full h-40 md:h-32 object-cover rounded-xl"
-                      />
-                    </div>
-                    <div className="flex-1">
-                      <Link to={`/events/${evt.slug}`} className="text-2xl font-semibold text-[#28313e] hover:underline">
-                        {evt.title}
-                      </Link>
-                      <p className="mt-3 text-sm text-gray-600 leading-relaxed">
-                        <span className="font-semibold text-gray-700">What to Expect:</span> {evt.description || 'Stay tuned for details — we’ll share updates soon.'}
-                      </p>
-                      <p className="mt-3 text-sm font-semibold text-gray-700">
-                        {formatEventDateRange(evt.startDate, evt.endDate, PHILLY_TIME_ZONE)}
-                      </p>
-                      <FavoriteState event_id={evt.id} source_table="events">
-                        {({ isFavorite, toggleFavorite, loading: favLoading }) => (
-                          <button
-                            onClick={() => {
-                              if (!user) {
-                                navigate('/login');
-                                return;
-                              }
-                              toggleFavorite();
-                            }}
-                            disabled={favLoading}
-                            className={`mt-4 inline-flex items-center px-4 py-2 border border-indigo-600 rounded-full font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
-                          >
-                            {isFavorite ? 'In the Plans' : 'Add to Plans'}
-                          </button>
-                        )}
-                      </FavoriteState>
-                    </div>
+              <section className="mt-10 bg-white border border-gray-200 rounded-2xl shadow-sm">
+                {loading ? (
+                  <p className="p-6 text-gray-500">Loading {monthLabel} traditions…</p>
+                ) : monthlyEvents.length === 0 ? (
+                  <p className="p-6 text-gray-500">No traditions posted yet for {monthLabel}. Check back soon.</p>
+                ) : (
+                  <div className="divide-y divide-gray-200">
+                    {monthlyEvents.map(evt => {
+                      const summary = evt.description?.trim() || 'Details coming soon.';
+                      return (
+                        <article key={evt.id} className="flex flex-col md:flex-row gap-4 px-6 py-6">
+                          <div className="md:w-48 w-full flex-shrink-0">
+                            <div className="relative w-full overflow-hidden rounded-xl bg-gray-100 aspect-[4/3]">
+                              <img
+                                src={evt.imageUrl || DEFAULT_OG_IMAGE}
+                                alt={evt.title}
+                                loading="lazy"
+                                className="absolute inset-0 h-full w-full object-cover"
+                              />
+                            </div>
+                          </div>
+                          <div className="flex-1 flex flex-col">
+                            <Link
+                              to={`/events/${evt.slug}`}
+                              className="text-2xl font-semibold text-[#28313e] hover:underline"
+                            >
+                              {evt.title}
+                            </Link>
+                            <p className="mt-2 text-sm font-semibold text-gray-700">
+                              {formatEventDateRange(evt.startDate, evt.endDate, PHILLY_TIME_ZONE)}
+                            </p>
+                            <p className="mt-2 text-sm text-gray-600">{summary}</p>
+                            <div className="mt-4">
+                              <FavoriteState event_id={evt.id} source_table="events">
+                                {({ isFavorite, toggleFavorite, loading: favLoading }) => (
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      if (!user) {
+                                        navigate('/login');
+                                        return;
+                                      }
+                                      toggleFavorite();
+                                    }}
+                                    disabled={favLoading}
+                                    className={`inline-flex items-center px-4 py-2 border border-indigo-600 rounded-full font-semibold transition-colors ${
+                                      isFavorite
+                                        ? 'bg-indigo-600 text-white'
+                                        : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'
+                                    }`}
+                                  >
+                                    {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                                  </button>
+                                )}
+                              </FavoriteState>
+                            </div>
+                          </div>
+                        </article>
+                      );
+                    })}
                   </div>
-                ))}
-              </div>
-            )}
-          </section>
-
-          {!user && (
-            <section className="mt-16">
-              <div className="bg-indigo-600/10 border border-indigo-200 rounded-3xl px-6 py-12 flex flex-col items-center text-center gap-6">
-                <h2 className="text-3xl sm:text-4xl font-[Barrio] text-[#28313e]">Keep your Philly traditions organized</h2>
-                <Link
-                  to="/signup"
-                  className="inline-flex items-center justify-center px-10 py-4 bg-indigo-600 text-white text-xl font-semibold rounded-full shadow-lg hover:bg-indigo-700 transition"
-                >
-                  Sign up to save your favorite traditions
-                </Link>
-              </div>
-            </section>
+                )}
+              </section>
+            </>
+          ) : (
+            <div className="py-24 text-center text-gray-600">
+              <p>Redirecting to the latest Philadelphia traditions…</p>
+            </div>
           )}
         </div>
       </main>
@@ -312,4 +262,3 @@ export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverrid
     </div>
   );
 }
-

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -89,6 +89,22 @@ export function parseISODate(value, timeZone = PHILLY_TIME_ZONE) {
   return setStartOfDay(zoned);
 }
 
+export function parseEventDateValue(value, timeZone = PHILLY_TIME_ZONE) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return setStartOfDay(value);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      return parseISODate(trimmed, timeZone);
+    }
+    return parseMonthDayYear(trimmed, timeZone);
+  }
+  return null;
+}
+
 export function overlaps(startA, endA, startB, endB) {
   if (!startA || !endA || !startB || !endB) return false;
   return !(endA.getTime() < startB.getTime() || startA.getTime() > endB.getTime());


### PR DESCRIPTION
## Summary
- add Monthly page param parsing, validation, and canonical SEO metadata via `<Seo>`
- filter Supabase events for overlapping month range, render row layout with counter and plans action
- introduce `parseEventDateValue` helper to normalize event date formats
- align the monthly Supabase query with available date columns and broaden start/end fallbacks so traditions load without errors

## Testing
- npm run lint *(fails: eslint CLI options incompatible with repo config)*

------
https://chatgpt.com/codex/tasks/task_e_68cc90f0924c832cbd05d422a0be772e