### PR TITLE
Ensure SPA rewrites cover dynamic detail routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,44 +1,80 @@
 {
   "rewrites": [
     {
+      "source": "/api/:path*",
+      "destination": "/api/:path*"
+    },
+    {
       "source": "/events/:slug",
-      "destination": "/index.html"
+      "destination": "/"
     },
     {
       "source": "/seasonal/:slug",
-      "destination": "/index.html"
+      "destination": "/"
     },
     {
       "source": "/big-board/:slug",
-      "destination": "/index.html"
+      "destination": "/"
     },
     {
       "source": "/groups/:slug",
-      "destination": "/index.html"
+      "destination": "/"
     },
     {
       "source": "/groups/:slug/events/:eventId",
-      "destination": "/index.html"
+      "destination": "/"
     },
     {
       "source": "/series/:slug",
-      "destination": "/index.html"
+      "destination": "/"
     },
     {
       "source": "/series/:slug/:date",
-      "destination": "/index.html"
+      "destination": "/"
     },
     {
       "source": "/sports/:id",
-      "destination": "/index.html"
+      "destination": "/"
+    },
+    {
+      "source": "/outlets/:slug",
+      "destination": "/"
+    },
+    {
+      "source": "/u/:slug",
+      "destination": "/"
+    },
+    {
+      "source": "/moments/:id",
+      "destination": "/"
+    },
+    {
+      "source": "/tags/:slug",
+      "destination": "/"
+    },
+    {
+      "source": "/groups/type/:tagSlug",
+      "destination": "/"
+    },
+    {
+      "source": "/:venue",
+      "destination": "/",
+      "missing": [
+        { "type": "file" },
+        { "type": "dir" }
+      ]
     },
     {
       "source": "/:venue/:slug",
-      "destination": "/index.html"
+      "destination": "/"
     },
     {
       "source": "/:path*",
-      "destination": "/index.html"
+      "destination": "/",
+      "missing": [
+        { "type": "file" },
+        { "type": "dir" }
+      ]
     }
   ],
   "redirects": [


### PR DESCRIPTION
## Summary
- add explicit Vercel rewrites for every event, group, and venue detail pattern so deep refreshes serve the SPA shell
- keep catch-all rewrite while excluding real files and directories so static assets and XML endpoints stay untouched
- safeguard API routes by short-circuiting `/api/*` before SPA handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb0b274a0832c89773243e23fb3ce