### PR TITLE
Normalize all_events fetching across event views

### DIFF
--- a/src/utils/allEvents.js
+++ b/src/utils/allEvents.js
@@ -1,0 +1,65 @@
+export const ALL_EVENTS_SELECT = `
+  id,
+  name,
+  description,
+  link,
+  image,
+  start_date,
+  end_date,
+  start_time,
+  end_time,
+  slug,
+  venue_id,
+  venues:venue_id (
+    name,
+    slug,
+    latitude,
+    longitude
+  )
+`
+
+function normalizeVenue(venue) {
+  if (!venue) return null
+  const source = Array.isArray(venue) ? venue[0] : venue
+  if (!source) return null
+  return {
+    name: source.name ?? null,
+    slug: source.slug ?? null,
+    latitude: source.latitude ?? null,
+    longitude: source.longitude ?? null,
+  }
+}
+
+export function normalizeAllEventRow(row) {
+  if (!row) return null
+  const venues = normalizeVenue(row.venues ?? row.venue_id)
+  const startDate = row.start_date ?? null
+  const endDate = row.end_date ?? startDate ?? null
+
+  return {
+    id: row.id ?? null,
+    title: row.name || row.title || '',
+    name: row.name || row.title || '',
+    description: row.description || '',
+    imageUrl: row.image || '',
+    link: row.link || null,
+    start_date: startDate,
+    end_date: endDate,
+    start_time: row.start_time || null,
+    end_time: row.end_time || null,
+    slug: row.slug || null,
+    venues,
+    venue_id: row.venue_id ?? null,
+    isTradition: false,
+    isBigBoard: false,
+    isGroupEvent: false,
+    isRecurring: false,
+    isSports: false,
+    source_table: 'all_events',
+    taggableId: row.id != null ? String(row.id) : null,
+  }
+}
+
+export function normalizeAllEvents(rows) {
+  return (rows || []).map(normalizeAllEventRow).filter(Boolean)
+}


### PR DESCRIPTION
## Summary
- add a shared all_events select clause and normalizer so every view pulls consistent columns
- update the tag page, home aggregation, and weekend page to reuse the helper and attach canonical hrefs for each all_events row
- ensure all_events entries keep their tagging metadata so they surface alongside other sources when filtered

## Testing
- npm run lint *(fails: repository lint script still uses legacy --ext flag with eslint.config.js)*
- npx eslint src/utils/allEvents.js

------
https://chatgpt.com/codex/tasks/task_e_68cde0a897d0832ca563bd6f93a8c289