### PR TITLE
Handle Supabase date objects when filtering all_events

### DIFF
--- a/src/ThisWeekendInPhiladelphia.jsx
+++ b/src/ThisWeekendInPhiladelphia.jsx
@@ -21,6 +21,7 @@ import {
   formatMonthDay,
   formatDateRangeForTitle,
   getZonedDate,
+  normalizeIsoDateString,
 } from './utils/dateUtils';
 
 const pillStyles = [
@@ -359,8 +360,12 @@ export default function ThisWeekendInPhiladelphia() {
 
         const allRecords = (allRes.data || [])
           .map(evt => {
-            const startDate = parseISODate(evt.start_date, PHILLY_TIME_ZONE);
-            const endDateRaw = parseISODate(evt.end_date || evt.start_date, PHILLY_TIME_ZONE);
+            const startIso = normalizeIsoDateString(evt.start_date);
+            if (!startIso) return null;
+            const endIso = normalizeIsoDateString(evt.end_date || evt.start_date) || startIso;
+            if (startIso !== endIso) return null;
+            const startDate = parseISODate(startIso, PHILLY_TIME_ZONE);
+            const endDateRaw = parseISODate(endIso, PHILLY_TIME_ZONE);
             if (!startDate || !endDateRaw) return null;
             const endDate = setEndOfDay(new Date(endDateRaw));
             if (!overlaps(startDate, endDate, weekendStart, weekendEnd)) return null;

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -55,6 +55,28 @@ export function getZonedDate(date = new Date(), timeZone = PHILLY_TIME_ZONE) {
   );
 }
 
+export function normalizeIsoDateString(value) {
+  if (!value) return null;
+
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    return value.toISOString().slice(0, 10);
+  }
+
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString().slice(0, 10);
+    }
+  }
+
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})/);
+  return match ? match[1] : null;
+}
+
 export function setStartOfDay(date) {
   const copy = new Date(date);
   copy.setHours(0, 0, 0, 0);
@@ -79,11 +101,9 @@ export function parseMonthDayYear(value, timeZone = PHILLY_TIME_ZONE) {
 }
 
 export function parseISODate(value, timeZone = PHILLY_TIME_ZONE) {
-  if (!value) return null;
-  const parts = value.split('-').map(Number);
-  if (parts.length !== 3) return null;
-  const [year, month, day] = parts;
-  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) return null;
+  const normalized = normalizeIsoDateString(value);
+  if (!normalized) return null;
+  const [year, month, day] = normalized.split('-').map(Number);
   const utc = new Date(Date.UTC(year, month - 1, day, 5, 0, 0));
   const zoned = getZonedDate(utc, timeZone);
   return setStartOfDay(zoned);


### PR DESCRIPTION
## Summary
- add a shared normalizeIsoDateString helper so Supabase date values normalize even when returned as Date instances
- reuse the shared normalizer on the home and weekend pages so their single-day all_events filters continue to include valid rows

## Testing
- npm run lint *(fails: Invalid option '--ext' with eslint.config.js setup)*
- npx eslint . *(fails: existing parsing and environment lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cde49b79f0832cb3e733196f9819a3