### PR TITLE
Ensure monthly category routes are generated

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* eslint-disable no-console */
 // scripts/generate-sitemap.js
 import fs from 'fs'
 import path from 'path'
@@ -10,6 +12,7 @@ import {
   indexToMonthSlug,
 } from '../src/utils/dateUtils.js'
 import getDetailPathForItem from '../src/utils/eventDetailPaths.js'
+import { CATEGORY_ORDER } from '../src/utils/monthlyCategoryConfig.js'
 
 // Load .env into process.env
 dotenv.config()
@@ -48,7 +51,21 @@ if (currentMonthlyPath) {
     priority: '0.8',
     changefreq: 'monthly',
   })
+
+  CATEGORY_ORDER.forEach(cat => {
+    staticPages.push({
+      path: `/${cat.slug}-events-in-philadelphia-${currentMonthSlug}-${currentYear}/`,
+      priority: '0.8',
+      changefreq: 'weekly',
+    })
+  })
 }
+
+staticPages.push({
+  path: '/all-guides/',
+  priority: '0.7',
+  changefreq: 'weekly',
+})
 
 if (currentMonthlyPath && currentMonthlyLabel) {
   console.log(

--- a/src/AllGuidesPage.jsx
+++ b/src/AllGuidesPage.jsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import Seo from './components/Seo.jsx';
+import { CATEGORY_ORDER } from './utils/monthlyCategoryConfig.js';
+import {
+  PHILLY_TIME_ZONE,
+  getZonedDate,
+  indexToMonthSlug,
+  formatMonthYear,
+} from './utils/dateUtils.js';
+import { SITE_BASE_URL } from './utils/seoHelpers.js';
+
+export default function AllGuidesPage() {
+  const now = useMemo(() => getZonedDate(new Date(), PHILLY_TIME_ZONE), []);
+  const monthSlug = indexToMonthSlug(now.getMonth() + 1);
+  const year = now.getFullYear();
+  const monthLabel = formatMonthYear(now, PHILLY_TIME_ZONE);
+
+  const categoryButtons = CATEGORY_ORDER.map(cat => ({
+    label: `${cat.label} (${monthLabel})`,
+    href: `/${cat.slug}-events-in-philadelphia-${monthSlug}-${year}/`,
+  }));
+
+  const buttons = [
+    {
+      label: 'Philly Traditions Calendar',
+      href: `/philadelphia-events-${monthSlug}-${year}/`,
+    },
+    {
+      label: 'This Weekend in Philadelphia',
+      href: '/this-weekend-in-philadelphia/',
+    },
+    ...categoryButtons,
+  ];
+
+  const pageTitle = `All Guides – Philadelphia Events & Traditions (${monthLabel})`;
+  const description = `Browse Our Philly guides: traditions calendar, this weekend picks, and ${monthLabel} event roundups by category.`;
+  const canonicalUrl = `${SITE_BASE_URL}/all-guides/`;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white">
+      <Seo
+        title={pageTitle}
+        description={description}
+        canonicalUrl={canonicalUrl}
+        ogImage={`${SITE_BASE_URL}/og-image.png`}
+        ogType="website"
+      />
+      <Navbar />
+      <main className="flex-1 pt-36 pb-16">
+        <div className="mx-auto w-full max-w-5xl px-4">
+          <header className="text-center">
+            <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e]">All Guides</h1>
+            <p className="mt-4 text-lg text-gray-700">
+              Quick links to every Our Philly guide, updated for {monthLabel}.
+            </p>
+          </header>
+          <div className="mt-12 grid gap-6 sm:grid-cols-2">
+            {buttons.map(button => (
+              <Link
+                key={button.href}
+                to={button.href}
+                className="flex items-center justify-center rounded-3xl bg-indigo-600 px-6 py-8 text-center text-xl font-semibold text-white shadow-lg transition hover:bg-indigo-700 focus:outline-none focus-visible:ring-4 focus-visible:ring-indigo-300"
+              >
+                {button.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/MonthlyCategoryEventsPage.jsx
+++ b/src/MonthlyCategoryEventsPage.jsx
@@ -1,0 +1,576 @@
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import Seo from './components/Seo.jsx';
+import { AuthContext } from './AuthProvider';
+import useEventFavorite from './utils/useEventFavorite';
+import { fetchUnifiedEventRows } from './utils/fetchAllEventRows.js';
+import { supabase } from './supabaseClient';
+import {
+  PHILLY_TIME_ZONE,
+  monthSlugToIndex,
+  getMonthWindow,
+  formatMonthYear,
+  indexToMonthSlug,
+  formatEventDateRange,
+  getZonedDate,
+} from './utils/dateUtils';
+import { buildIsoDateTime, DEFAULT_OG_IMAGE, SITE_BASE_URL } from './utils/seoHelpers.js';
+import { CATEGORY_ORDER, getCategoryConfig } from './utils/monthlyCategoryConfig.js';
+
+const PAGE_SIZE = 50;
+
+function formatTimeLabel(time) {
+  if (!time) return '';
+  const [hourPart, minutePart] = time.split(':');
+  const hours = Number(hourPart);
+  if (Number.isNaN(hours)) return time;
+  const minutes = (minutePart || '00').slice(0, 2).padStart(2, '0');
+  const period = hours >= 12 ? 'p.m.' : 'a.m.';
+  const displayHour = ((hours % 12) || 12).toString();
+  return `${displayHour}:${minutes} ${period}`;
+}
+
+function formatAgeFlag(flag) {
+  if (!flag) return null;
+  const normalized = flag.toString().toLowerCase();
+  if (normalized.includes('all')) return 'All Ages';
+  if (normalized.includes('21')) return '21+';
+  return flag;
+}
+
+function formatPriceFlag(flag) {
+  if (!flag) return null;
+  if (flag === true || flag === 'free') return 'Free';
+  if (flag === false) return '$$';
+  const normalized = flag.toString().toLowerCase();
+  if (normalized === 'free' || normalized === '0') return 'Free';
+  return flag;
+}
+
+function FavoriteButton({ event }) {
+  const navigate = useNavigate();
+  const { user } = useContext(AuthContext);
+  const canFavorite = Boolean(event?.favoriteId) && Boolean(event?.source_table);
+  const { isFavorite, toggleFavorite, loading } = useEventFavorite({
+    event_id: event?.favoriteId,
+    source_table: event?.source_table,
+  });
+
+  if (!canFavorite) return null;
+
+  const handleClick = () => {
+    if (!user) {
+      navigate('/login');
+      return;
+    }
+    toggleFavorite();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={loading}
+      className={`inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition ${
+        isFavorite
+          ? 'bg-indigo-600 text-white shadow-md'
+          : 'border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white'
+      } ${loading ? 'opacity-70 cursor-not-allowed' : ''}`}
+    >
+      {isFavorite ? 'In the Plans' : 'Add to Plans'}
+    </button>
+  );
+}
+
+function buildJsonLd({ events, title, description }) {
+  const itemList = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: title,
+    description: description,
+    numberOfItems: events.length,
+    itemListOrder: 'https://schema.org/ItemListOrderAscending',
+    itemListElement: events.map((event, index) => {
+      const url = event.canonicalPath
+        ? `${SITE_BASE_URL}${event.canonicalPath}`
+        : event.detailUrl;
+      const startDateIso = buildIsoDateTime(event.start_date, event.start_time) || event.start_date;
+      const endDateIso = buildIsoDateTime(event.end_date, event.end_time) || event.end_date || event.start_date;
+      const locationName = event.venue || event.neighborhood || 'Philadelphia';
+      const postalCode = event.zip ? event.zip.toString() : undefined;
+      return {
+        '@type': 'ListItem',
+        position: index + 1,
+        url,
+        item: {
+          '@type': 'Event',
+          name: event.title,
+          startDate: startDateIso,
+          endDate: endDateIso,
+          eventStatus:
+            event.status === 'cancelled'
+              ? 'https://schema.org/EventCancelled'
+              : 'https://schema.org/EventScheduled',
+          location: {
+            '@type': 'Place',
+            name: locationName,
+            address: {
+              '@type': 'PostalAddress',
+              addressLocality: 'Philadelphia',
+              addressRegion: 'PA',
+              addressCountry: 'US',
+              ...(postalCode ? { postalCode } : {}),
+            },
+          },
+          ...(event.image_url ? { image: [event.image_url] } : {}),
+          ...(url ? { url } : {}),
+        },
+      };
+    }),
+  };
+  return itemList;
+}
+
+function truncate(text, max = 200) {
+  if (!text) return '';
+  const normalized = text.toString().replace(/\s+/g, ' ').trim();
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 1).trimEnd()}…`;
+}
+
+export default function MonthlyCategoryEventsPage({ categorySlugOverride } = {}) {
+  const params = useParams();
+  const navigate = useNavigate();
+  const categorySlugParam = categorySlugOverride || params.categorySlug;
+  const category = getCategoryConfig(categorySlugParam);
+  const monthSlugParam = params.month ? params.month.toLowerCase() : null;
+  const monthIndex = monthSlugParam ? monthSlugToIndex(monthSlugParam) : null;
+  const yearParam = params.year ? Number(params.year) : NaN;
+  const hasValidYear = Number.isInteger(yearParam) && yearParam >= 2000 && yearParam <= 2100;
+  const hasValidMonth = Boolean(monthIndex);
+  const isValid = Boolean(category && hasValidMonth && hasValidYear);
+
+  const monthWindow = useMemo(() => {
+    if (!isValid) return { start: null, end: null };
+    return getMonthWindow(yearParam, monthIndex, PHILLY_TIME_ZONE);
+  }, [isValid, monthIndex, yearParam]);
+
+  const { start: monthStart, end: monthEnd } = monthWindow;
+  const monthStartMs = monthStart ? monthStart.getTime() : null;
+  const monthEndMs = monthEnd ? monthEnd.getTime() : null;
+
+  const [allEvents, setAllEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [page, setPage] = useState(1);
+  const [tagLabelMap, setTagLabelMap] = useState({});
+
+  useEffect(() => {
+    setPage(1);
+  }, [categorySlugParam, monthStartMs, monthEndMs]);
+
+  useEffect(() => {
+    let cancelled = false;
+    supabase
+      .from('tags')
+      .select('slug,name')
+      .then(({ data, error: tagsError }) => {
+        if (cancelled || tagsError) return;
+        const map = {};
+        (data || []).forEach(({ slug, name }) => {
+          if (!slug) return;
+          map[slug.toLowerCase()] = name || slug;
+        });
+        setTagLabelMap(map);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isValid || !monthStart || !monthEnd) {
+      setAllEvents([]);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchUnifiedEventRows({ monthStart, monthEnd })
+      .then(rows => {
+        if (cancelled) return;
+        setAllEvents(rows || []);
+        setLoading(false);
+      })
+      .catch(err => {
+        console.error('monthly category load failed', err);
+        if (cancelled) return;
+        setError('We had trouble loading events. Please try again soon.');
+        setAllEvents([]);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isValid, monthStartMs, monthEndMs]);
+
+  useEffect(() => {
+    if (!isValid) {
+      const timer = setTimeout(() => {
+        navigate('/philadelphia-events/', { replace: true });
+      }, 1200);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [isValid, navigate]);
+
+  const categoryTagSet = useMemo(() => {
+    if (!category) return new Set();
+    return new Set((category.tags || []).map(tag => tag.toLowerCase()));
+  }, [category]);
+
+  const filteredEvents = useMemo(() => {
+    if (!isValid) return [];
+    return allEvents
+      .filter(evt => evt && evt.status !== 'cancelled')
+      .filter(evt => {
+        if (!evt?.tags || evt.tags.length === 0) return false;
+        return evt.tags.some(tag => categoryTagSet.has(tag.toLowerCase()));
+      });
+  }, [allEvents, categoryTagSet, isValid]);
+
+  const sortedEvents = useMemo(() => {
+    return [...filteredEvents].sort((a, b) => {
+      const aStart = a.startDate instanceof Date ? a.startDate.getTime() : 0;
+      const bStart = b.startDate instanceof Date ? b.startDate.getTime() : 0;
+      if (aStart !== bStart) return aStart - bStart;
+      const aTime = a.start_time || '';
+      const bTime = b.start_time || '';
+      if (aTime && !bTime) return -1;
+      if (!aTime && bTime) return 1;
+      if (aTime && bTime) {
+        const cmp = aTime.localeCompare(bTime);
+        if (cmp !== 0) return cmp;
+      }
+      return (a.title || '').localeCompare(b.title || '');
+    });
+  }, [filteredEvents]);
+
+  const monthLabel = monthStart ? formatMonthYear(monthStart, PHILLY_TIME_ZONE) : '';
+  const canonicalMonthSlug = monthIndex ? indexToMonthSlug(monthIndex) : monthSlugParam;
+  const canonicalUrl =
+    category && canonicalMonthSlug && hasValidYear
+      ? `${SITE_BASE_URL}/${category.slug}-events-in-philadelphia-${canonicalMonthSlug}-${yearParam}/`
+      : `${SITE_BASE_URL}/philadelphia-events/`;
+
+  const pageTitle = category && monthLabel
+    ? `${category.label} Events in Philadelphia – ${monthLabel}`
+    : 'Philadelphia Events – Our Philly';
+
+  const metaDescription = category && monthLabel
+    ? `Plan ${monthLabel} in Philadelphia with ${category.label.toLowerCase()} events, festivals, and happenings curated by Our Philly.`
+    : 'Discover monthly event guides for Philadelphia, curated by Our Philly.';
+
+  const firstImage = useMemo(() => {
+    for (const evt of sortedEvents) {
+      if (evt?.image_url) return evt.image_url;
+    }
+    return null;
+  }, [sortedEvents]);
+
+  const jsonLd = useMemo(() => buildJsonLd({ events: sortedEvents, title: pageTitle, description: metaDescription }), [sortedEvents, pageTitle, metaDescription]);
+
+  const paginatedEvents = useMemo(() => {
+    const totalPages = Math.max(1, Math.ceil(sortedEvents.length / PAGE_SIZE));
+    const safePage = Math.min(Math.max(page, 1), totalPages);
+    const start = (safePage - 1) * PAGE_SIZE;
+    const end = start + PAGE_SIZE;
+    return {
+      totalPages,
+      items: sortedEvents.slice(start, end),
+      currentPage: safePage,
+    };
+  }, [sortedEvents, page]);
+
+  const updatedStamp = useMemo(() => {
+    const zoned = getZonedDate(new Date(), PHILLY_TIME_ZONE);
+    return zoned.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+  }, []);
+
+  const monthNavLinks = useMemo(() => {
+    if (!canonicalMonthSlug || !hasValidYear) return [];
+    return CATEGORY_ORDER.map(cat => ({
+      slug: cat.slug,
+      label: cat.label,
+      href: `/${cat.slug}-events-in-philadelphia-${canonicalMonthSlug}-${yearParam}/`,
+    }));
+  }, [canonicalMonthSlug, hasValidYear, yearParam]);
+
+  if (!isValid) {
+    return (
+      <div className="min-h-screen flex flex-col">
+        <Navbar />
+        <main className="flex-1 flex items-center justify-center bg-white px-4">
+          <p className="text-gray-600 text-center max-w-md">
+            We couldn’t find that month of events. Redirecting you to the latest guide…
+          </p>
+        </main>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white">
+      <Seo
+        title={pageTitle}
+        description={metaDescription}
+        canonicalUrl={canonicalUrl}
+        ogImage={firstImage || DEFAULT_OG_IMAGE}
+        ogType="website"
+        jsonLd={jsonLd}
+      />
+      <Navbar />
+      <main className="flex-1 pt-36 pb-16">
+        <div className="mx-auto w-full max-w-6xl px-4">
+          <div className="text-center">
+            <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e]">
+              {category.label} Events in Philadelphia – {monthLabel}
+            </h1>
+            <p className="mt-4 text-lg text-gray-700">
+              Updated {updatedStamp}. Explore {category.label.toLowerCase()} happenings all month long.
+            </p>
+          </div>
+
+          <nav className="mt-8 flex flex-wrap justify-center gap-3">
+            {monthNavLinks.map(link => {
+              const isActive = link.slug === category.slug;
+              return (
+                <Link
+                  key={link.slug}
+                  to={link.href}
+                  className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    isActive
+                      ? 'bg-indigo-600 text-white shadow-lg'
+                      : 'border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white'
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+
+          <div className="mt-12">
+            {loading ? (
+              <p className="text-gray-500">Loading {category.label.toLowerCase()} events…</p>
+            ) : error ? (
+              <p className="text-red-600">{error}</p>
+            ) : paginatedEvents.items.length === 0 ? (
+              <p className="text-gray-600">No events match this category yet. Check back soon!</p>
+            ) : (
+              <div className="space-y-8">
+                {paginatedEvents.items.map(event => {
+                  const detailHref = event.canonicalPath || event.detailUrl || '';
+                  const hasLink = Boolean(detailHref);
+                  const isExternal = hasLink && /^https?:\/\//i.test(detailHref);
+                  const dateRange = formatEventDateRange(event.startDate, event.endDate, PHILLY_TIME_ZONE);
+                  const timeLabel = formatTimeLabel(event.start_time);
+                  const displayTags = (event.tags || []).map(slug => ({
+                    slug,
+                    label: tagLabelMap[slug] || slug,
+                  }));
+                  const ageLabel = formatAgeFlag(event.age_flag);
+                  const priceLabel = formatPriceFlag(event.price_flag);
+
+                  const badge = event.isTradition ? (
+                    <span className="absolute left-4 top-4 rounded-full bg-amber-500 px-3 py-1 text-xs font-bold uppercase tracking-widest text-white shadow-lg">
+                      Tradition
+                    </span>
+                  ) : null;
+
+                  const imageNode = event.image_url ? (
+                    hasLink
+                      ? isExternal
+                        ? (
+                          <a
+                            href={detailHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="block"
+                          >
+                            <div className="relative h-56 w-full bg-gray-100">
+                              <img
+                                src={event.image_url}
+                                alt={event.title}
+                                loading="lazy"
+                                className="h-full w-full object-cover"
+                              />
+                              {badge}
+                            </div>
+                          </a>
+                        )
+                        : (
+                          <Link to={detailHref} className="block">
+                            <div className="relative h-56 w-full bg-gray-100">
+                              <img
+                                src={event.image_url}
+                                alt={event.title}
+                                loading="lazy"
+                                className="h-full w-full object-cover"
+                              />
+                              {badge}
+                            </div>
+                          </Link>
+                        )
+                      : (
+                        <div className="relative h-56 w-full bg-gray-100">
+                          <img
+                            src={event.image_url}
+                            alt={event.title}
+                            loading="lazy"
+                            className="h-full w-full object-cover"
+                          />
+                          {badge}
+                        </div>
+                      )
+                  ) : null;
+
+                  const titleNode = hasLink
+                    ? isExternal
+                      ? (
+                        <a
+                          href={detailHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-2xl font-semibold text-[#28313e] hover:underline"
+                        >
+                          {event.title}
+                        </a>
+                      )
+                      : (
+                        <Link to={detailHref} className="text-2xl font-semibold text-[#28313e] hover:underline">
+                          {event.title}
+                        </Link>
+                      )
+                    : (
+                      <span className="text-2xl font-semibold text-[#28313e]">
+                        {event.title}
+                      </span>
+                    );
+
+                  return (
+                    <article
+                      key={`${event.source_table}-${event.id}`}
+                      className="overflow-hidden rounded-2xl border border-gray-200 shadow-sm"
+                    >
+                      {imageNode}
+                      <div className="flex flex-col gap-4 p-6">
+                        <div className="flex flex-col gap-2">
+                          {titleNode}
+                          <p className="text-sm font-semibold text-gray-700">
+                            {dateRange}
+                            {timeLabel ? ` • ${timeLabel}` : ''}
+                          </p>
+                          {(event.neighborhood || event.venue) && (
+                            <p className="text-sm text-gray-600">
+                              {[event.neighborhood, event.venue].filter(Boolean).join(' · ')}
+                            </p>
+                          )}
+                          {event.description && (
+                            <p className="text-sm text-gray-700">
+                              {truncate(event.description)}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          {displayTags.slice(0, 6).map(tag => (
+                            <span
+                              key={tag.slug}
+                              className="rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-700"
+                            >
+                              #{tag.label}
+                            </span>
+                          ))}
+                          {priceLabel && (
+                            <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                              {priceLabel}
+                            </span>
+                          )}
+                          {ageLabel && (
+                            <span className="rounded-full bg-purple-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-purple-700">
+                              {ageLabel}
+                            </span>
+                          )}
+                        </div>
+                        <div className="mt-2 flex flex-wrap items-center gap-3">
+                          <FavoriteButton event={event} />
+                          {hasLink && (
+                            isExternal ? (
+                              <a
+                                href={detailHref}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-sm font-semibold text-indigo-600 hover:underline"
+                              >
+                                View Details
+                              </a>
+                            ) : (
+                              <Link
+                                to={detailHref}
+                                className="text-sm font-semibold text-indigo-600 hover:underline"
+                              >
+                                View Details
+                              </Link>
+                            )
+                          )}
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {paginatedEvents.totalPages > 1 && (
+            <div className="mt-12 flex items-center justify-between rounded-full border border-gray-200 bg-white px-4 py-3 text-sm shadow-sm">
+              <button
+                type="button"
+                onClick={() => setPage(prev => Math.max(1, prev - 1))}
+                disabled={paginatedEvents.currentPage === 1}
+                className={`rounded-full px-4 py-2 font-semibold transition ${
+                  paginatedEvents.currentPage === 1
+                    ? 'cursor-not-allowed bg-gray-100 text-gray-400'
+                    : 'bg-indigo-600 text-white hover:bg-indigo-700'
+                }`}
+              >
+                Previous
+              </button>
+              <span className="text-gray-600">
+                Page {paginatedEvents.currentPage} of {paginatedEvents.totalPages}
+              </span>
+              <button
+                type="button"
+                onClick={() => setPage(prev => Math.min(paginatedEvents.totalPages, prev + 1))}
+                disabled={paginatedEvents.currentPage === paginatedEvents.totalPages}
+                className={`rounded-full px-4 py-2 font-semibold transition ${
+                  paginatedEvents.currentPage === paginatedEvents.totalPages
+                    ? 'cursor-not-allowed bg-gray-100 text-gray-400'
+                    : 'bg-indigo-600 text-white hover:bg-indigo-700'
+                }`}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/PhiladelphiaEventsIndex.jsx
+++ b/src/PhiladelphiaEventsIndex.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getZonedDate, PHILLY_TIME_ZONE, indexToMonthSlug } from './utils/dateUtils';
+import { CATEGORY_ORDER } from './utils/monthlyCategoryConfig.js';
 
 export default function PhiladelphiaEventsIndex() {
   const navigate = useNavigate();
@@ -9,7 +10,8 @@ export default function PhiladelphiaEventsIndex() {
     const now = getZonedDate(new Date(), PHILLY_TIME_ZONE);
     const slug = indexToMonthSlug(now.getMonth() + 1);
     const year = now.getFullYear();
-    navigate(`/philadelphia-events-${slug}-${year}/`, { replace: true });
+    const defaultCategory = CATEGORY_ORDER[0]?.slug || 'family-friendly';
+    navigate(`/${defaultCategory}-events-in-philadelphia-${slug}-${year}/`, { replace: true });
   }, [navigate]);
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -56,6 +56,9 @@ import AboutPage from './AboutPage.jsx'
 import ThisWeekendInPhiladelphia from './ThisWeekendInPhiladelphia.jsx';
 import ThisMonthInPhiladelphia from './ThisMonthInPhiladelphia.jsx';
 import PhiladelphiaEventsIndex from './PhiladelphiaEventsIndex.jsx';
+import MonthlyCategoryEventsPage from './MonthlyCategoryEventsPage.jsx';
+import { CATEGORY_SLUGS } from './utils/monthlyCategoryConfig.js';
+import AllGuidesPage from './AllGuidesPage.jsx';
 import ViewRouter from './ViewRouter.jsx';
 import HeadProvider from './components/HeadProvider.jsx'
 import SlashGuard from './components/SlashGuard.jsx'
@@ -89,6 +92,18 @@ ReactDOM.createRoot(document.getElementById('root')).render(
               path="/philadelphia-events-:month-:year/"
               element={<ThisMonthInPhiladelphia />}
             />
+            {CATEGORY_SLUGS.map(slug => (
+              <Route
+                key={`category-${slug}`}
+                path={`/${slug}-events-in-philadelphia-:month-:year/`}
+                element={<MonthlyCategoryEventsPage categorySlugOverride={slug} />}
+              />
+            ))}
+            <Route
+              path="/:categorySlug-events-in-philadelphia-:month-:year/"
+              element={<MonthlyCategoryEventsPage />}
+            />
+            <Route path="/all-guides/" element={<AllGuidesPage />} />
             <Route path="/:view" element={<ViewRouter />} />
             <Route path="/old" element={<App />} />
             <Route path="/sports" element={<SportsPage />} />

--- a/src/utils/fetchAllEventRows.js
+++ b/src/utils/fetchAllEventRows.js
@@ -1,0 +1,491 @@
+/* eslint-disable no-console */
+import { RRule } from 'rrule';
+import { supabase } from '../supabaseClient';
+import {
+  PHILLY_TIME_ZONE,
+  parseEventDateValue,
+  setEndOfDay,
+  setStartOfDay,
+  overlaps,
+} from './dateUtils';
+import { ensureAbsoluteUrl } from './seoHelpers.js';
+import { getDetailPathForItem } from './eventDetailPaths.js';
+
+const SOURCE_PRIORITY = {
+  events: 0,
+  all_events: 1,
+  big_board_events: 2,
+};
+
+const EVENT_SOURCES = [
+  { table: 'events', taggableType: 'events', priority: SOURCE_PRIORITY.events },
+  { table: 'all_events', taggableType: 'all_events', priority: SOURCE_PRIORITY.all_events },
+  { table: 'big_board_events', taggableType: 'big_board_events', priority: SOURCE_PRIORITY.big_board_events },
+  { table: 'group_events', taggableType: 'group_events', priority: 10 },
+  { table: 'recurring_events', taggableType: 'recurring_events', priority: 11 },
+  { table: 'seasonal_events', taggableType: 'seasonal_events', priority: 12 },
+];
+
+function pickFirst(...candidates) {
+  for (const value of candidates) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) return trimmed;
+      continue;
+    }
+    if (Array.isArray(value) && value.length) return value;
+    if (typeof value === 'number' && !Number.isNaN(value)) return value;
+    if (typeof value === 'boolean') return value;
+    if (value) return value;
+  }
+  return null;
+}
+
+function normalizeTime(value) {
+  if (value === undefined || value === null) return null;
+  const str = String(value).trim();
+  if (!str) return null;
+  if (/^\d{1,2}:\d{2}(:\d{2})?$/.test(str)) {
+    const [h, m] = str.split(':');
+    return `${h.padStart(2, '0')}:${m.padStart(2, '0')}`;
+  }
+  return str;
+}
+
+function formatDateValue(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseDateRange(row, { monthStart, monthEnd }) {
+  const startRaw = pickFirst(
+    row.start_date,
+    row.startDate,
+    row.Dates,
+    row.date,
+    row['Start Date'],
+    row['E Start Date'],
+  );
+  const endRaw = pickFirst(
+    row.end_date,
+    row.endDate,
+    row['End Date'],
+    row['E End Date'],
+    startRaw,
+  );
+  const startDate = parseEventDateValue(startRaw, PHILLY_TIME_ZONE);
+  const endDateBase = parseEventDateValue(endRaw, PHILLY_TIME_ZONE) || startDate;
+  if (!startDate || !endDateBase) return null;
+  const endDate = setEndOfDay(endDateBase);
+  if (!overlaps(startDate, endDate, monthStart, monthEnd)) return null;
+  return { startDate, endDate };
+}
+
+function normalizeTags(candidate) {
+  const set = new Set();
+  if (!candidate) return set;
+  if (Array.isArray(candidate)) {
+    candidate.forEach(entry => {
+      if (typeof entry === 'string') {
+        const slug = entry.trim().toLowerCase();
+        if (slug) set.add(slug);
+      } else if (entry && typeof entry === 'object') {
+        const slug = pickFirst(entry.slug, entry.name);
+        if (typeof slug === 'string') {
+          const normalized = slug.trim().toLowerCase();
+          if (normalized) set.add(normalized);
+        }
+      }
+    });
+  } else if (typeof candidate === 'string') {
+    candidate
+      .split(/[,|]/)
+      .map(part => part.trim().toLowerCase())
+      .filter(Boolean)
+      .forEach(slug => set.add(slug));
+  }
+  return set;
+}
+
+function normalizePriceFlag(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'boolean') return value ? 'free' : '$$';
+  const str = String(value).trim();
+  if (!str) return null;
+  if (str === '0') return 'free';
+  if (str.toLowerCase() === 'free') return 'free';
+  return str;
+}
+
+function normalizeAgeFlag(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'boolean') return value ? 'all-ages' : null;
+  const str = String(value).trim();
+  if (!str) return null;
+  return str;
+}
+
+function baseEventShape({ row, source_table, priority, monthStart, monthEnd }) {
+  const range = parseDateRange(row, { monthStart, monthEnd });
+  if (!range) return null;
+  const { startDate, endDate } = range;
+  const start_date = formatDateValue(startDate);
+  const end_date = formatDateValue(endDate);
+  const statusRaw = pickFirst(row.status, row.Status) || 'scheduled';
+  const tags = normalizeTags(pickFirst(row.tags, row.tag_slugs, row.tagList));
+  const title = pickFirst(row.title, row.name, row['E Name'], row.event_name) || 'Untitled Event';
+  const primaryId = pickFirst(row.id, row.event_id, row.eventId, row.uuid, row.slug);
+  const fallbackId = `${source_table}-${start_date || 'unknown'}-${title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)}`;
+  const resolvedId = primaryId != null ? String(primaryId) : fallbackId;
+
+  const event = {
+    id: resolvedId,
+    originalId: primaryId ?? null,
+    source_table,
+    priority,
+    global_event_id: pickFirst(row.global_event_id, row.globalEventId, row.global_id),
+    title,
+    description: pickFirst(row.description, row['E Description'], row.summary, row.details) || '',
+    startDate,
+    endDate,
+    start_date,
+    end_date,
+    start_time: normalizeTime(pickFirst(row.start_time, row['E Start Time'], row.time)),
+    end_time: normalizeTime(pickFirst(row.end_time, row['E End Time'])),
+    neighborhood: pickFirst(row.neighborhood, row.neighborhood_name, row['E Neighborhood']),
+    venue: pickFirst(row.venue, row.venue_name, row['E Venue'], row.location),
+    zip: pickFirst(row.zip, row.postal_code, row['E Zip'], row['E Zip Code']),
+    address: pickFirst(row.address, row.street, row.street_address),
+    status: typeof statusRaw === 'string' ? statusRaw.toLowerCase() : String(statusRaw).toLowerCase(),
+    image_url: pickFirst(row.image_url, row.image, row['E Image']),
+    link: pickFirst(row.detail_url, row['Detail URL'], row.link, row.url, row['E Link']),
+    age_flag: normalizeAgeFlag(pickFirst(row.age_flag, row['Age Flag'], row.age_restriction, row.kid_flag)),
+    price_flag: normalizePriceFlag(pickFirst(row.price_flag, row['Price Flag'], row.price_level, row.is_free)),
+    taggableId: primaryId ?? null,
+    tags: Array.from(tags),
+    raw: row,
+    favoriteId: primaryId ?? null,
+    isTradition: source_table === 'events',
+  };
+
+  return event;
+}
+
+function finalizeEvent(event) {
+  if (!event) return null;
+  const detailCandidate = getDetailPathForItem({
+    ...event.raw,
+    source_table: event.source_table,
+  });
+  const canonicalPath = detailCandidate || null;
+  const detailUrl = canonicalPath
+    ? `https://ourphilly.org${canonicalPath}`
+    : ensureAbsoluteUrl(event.link);
+
+  return {
+    ...event,
+    canonicalPath,
+    detailUrl,
+  };
+}
+
+async function fetchEventsSource({ monthStart, monthEnd }) {
+  const { data, error } = await supabase.from('events').select('*');
+  if (error) {
+    console.error('Failed to load events table', error);
+    return [];
+  }
+  return data
+    .map(row => baseEventShape({ row, source_table: 'events', priority: SOURCE_PRIORITY.events, monthStart, monthEnd }))
+    .map(finalizeEvent)
+    .filter(Boolean);
+}
+
+async function fetchAllEventsSource({ monthStart, monthEnd }) {
+  const { data, error } = await supabase
+    .from('all_events')
+    .select('*, venues:venue_id (slug, name, neighborhood, zip)');
+  if (error) {
+    console.error('Failed to load all_events', error);
+    return [];
+  }
+  return data
+    .map(row => {
+      const event = baseEventShape({ row, source_table: 'all_events', priority: SOURCE_PRIORITY.all_events, monthStart, monthEnd });
+      if (!event) return null;
+      event.venues = row.venues;
+      if (!event.venue && row.venues?.name) event.venue = row.venues.name;
+      if (!event.zip && row.venues?.zip) event.zip = row.venues.zip;
+      return finalizeEvent(event);
+    })
+    .filter(Boolean);
+}
+
+function resolveBigBoardImage(row) {
+  if (row.image_url) return row.image_url;
+  const storageKey = row.big_board_posts?.[0]?.image_url;
+  if (!storageKey) return null;
+  const { data } = supabase.storage.from('big-board').getPublicUrl(storageKey);
+  return data?.publicUrl || null;
+}
+
+async function fetchBigBoardEvents({ monthStart, monthEnd }) {
+  const { data, error } = await supabase
+    .from('big_board_events')
+    .select('*, big_board_posts!big_board_posts_event_id_fkey(image_url)');
+  if (error) {
+    console.error('Failed to load big_board_events', error);
+    return [];
+  }
+  return data
+    .map(row => {
+      const event = baseEventShape({ row, source_table: 'big_board_events', priority: SOURCE_PRIORITY.big_board_events, monthStart, monthEnd });
+      if (!event) return null;
+      event.image_url = event.image_url || resolveBigBoardImage(row);
+      event.favoriteId = row.id;
+      return finalizeEvent(event);
+    })
+    .filter(Boolean);
+}
+
+async function fetchGroupEvents({ monthStart, monthEnd }) {
+  const { data, error } = await supabase
+    .from('group_events')
+    .select('*, groups:group_id(slug,Name,imag)');
+  if (error) {
+    console.error('Failed to load group_events', error);
+    return [];
+  }
+  return data
+    .map(row => {
+      const event = baseEventShape({ row, source_table: 'group_events', priority: 10, monthStart, monthEnd });
+      if (!event) return null;
+      const group = Array.isArray(row.groups) ? row.groups[0] : row.groups;
+      const detailCandidate = getDetailPathForItem({
+        ...row,
+        source_table: 'group_events',
+        group_slug: group?.slug,
+        groups: row.groups,
+      });
+      const canonicalPath = detailCandidate || null;
+      const detailUrl = canonicalPath
+        ? `https://ourphilly.org${canonicalPath}`
+        : ensureAbsoluteUrl(event.link);
+      event.canonicalPath = canonicalPath;
+      event.detailUrl = detailUrl;
+      event.image_url = event.image_url || group?.imag || null;
+      event.favoriteId = row.id;
+      return event;
+    })
+    .filter(Boolean);
+}
+
+function buildRecurringOccurrences(row, { monthStart, monthEnd }) {
+  if (!row.rrule) return [];
+  try {
+    const opts = RRule.parseString(row.rrule);
+    const startTime = normalizeTime(pickFirst(row.start_time, row.startTime)) || '00:00';
+    const baseStart = row.start_date ? new Date(`${row.start_date}T${startTime}:00`) : null;
+    if (!baseStart || Number.isNaN(baseStart.getTime())) return [];
+    opts.dtstart = baseStart;
+    if (row.end_date) {
+      const until = new Date(`${row.end_date}T23:59:59`);
+      if (!Number.isNaN(until.getTime())) opts.until = until;
+    }
+    const rule = new RRule(opts);
+    const occurrences = rule.between(monthStart, monthEnd, true);
+    return occurrences.map(occurrence => {
+      const startDate = setStartOfDay(new Date(occurrence));
+      const endDate = setEndOfDay(new Date(occurrence));
+      const start_date = formatDateValue(startDate);
+      const end_date = formatDateValue(endDate);
+      const statusRaw = pickFirst(row.status, row.Status) || 'scheduled';
+      const tags = normalizeTags(row.tags);
+      const event = {
+        id: `${row.id}::${start_date}`,
+        originalId: row.id,
+        source_table: 'recurring_events',
+        priority: 11,
+        global_event_id: pickFirst(row.global_event_id, row.globalEventId),
+        title: pickFirst(row.name, row.title) || 'Recurring Event',
+        description: pickFirst(row.description, row.summary) || '',
+        startDate,
+        endDate,
+        start_date,
+        end_date,
+        start_time: normalizeTime(pickFirst(row.start_time, row.startTime)),
+        end_time: normalizeTime(pickFirst(row.end_time, row.endTime)),
+        neighborhood: pickFirst(row.neighborhood, row.address_neighborhood),
+        venue: pickFirst(row.venue, row.venue_name),
+        zip: pickFirst(row.zip, row.postal_code),
+        address: pickFirst(row.address, row.location),
+        status: typeof statusRaw === 'string' ? statusRaw.toLowerCase() : String(statusRaw).toLowerCase(),
+        image_url: pickFirst(row.image_url, row.image),
+        link: pickFirst(row.detail_url, row.link, row.url),
+        age_flag: pickFirst(row.age_flag, row.age_restriction),
+        price_flag: pickFirst(row.price_flag, row.is_free),
+        taggableId: row.id,
+        tags: Array.from(tags),
+        occurrenceDate: start_date,
+        raw: row,
+        favoriteId: row.id,
+      };
+      const detailCandidate = getDetailPathForItem({
+        ...row,
+        source_table: 'recurring_events',
+        occurrence_date: start_date,
+      });
+      event.canonicalPath = detailCandidate || null;
+      event.detailUrl = event.canonicalPath
+        ? `https://ourphilly.org${event.canonicalPath}`
+        : ensureAbsoluteUrl(event.link);
+      return event;
+    });
+  } catch (error) {
+    console.error('Failed to build recurring occurrences', error);
+    return [];
+  }
+}
+
+async function fetchRecurringEvents({ monthStart, monthEnd }) {
+  const { data, error } = await supabase
+    .from('recurring_events')
+    .select('*')
+    .eq('is_active', true);
+  if (error) {
+    console.error('Failed to load recurring_events', error);
+    return [];
+  }
+  return data.flatMap(row => buildRecurringOccurrences(row, { monthStart, monthEnd }));
+}
+
+async function fetchSeasonalEvents({ monthStart, monthEnd }) {
+  const { data, error } = await supabase
+    .from('seasonal_events')
+    .select('*');
+  if (error) {
+    console.error('Failed to load seasonal_events', error);
+    return [];
+  }
+  return data
+    .map(row => baseEventShape({ row, source_table: 'seasonal_events', priority: 12, monthStart, monthEnd }))
+    .map(finalizeEvent)
+    .filter(Boolean);
+}
+
+function getPriority(table) {
+  if (typeof SOURCE_PRIORITY[table] === 'number') return SOURCE_PRIORITY[table];
+  const matching = EVENT_SOURCES.find(entry => entry.table === table);
+  if (matching?.priority !== undefined) return matching.priority;
+  return 100 + (table ? table.charCodeAt(0) : 0);
+}
+
+function dedupeEvents(events) {
+  const map = new Map();
+  events.forEach(event => {
+    if (!event) return;
+    const key = event.global_event_id
+      ? `gid:${String(event.global_event_id)}`
+      : `fallback:${(event.title || '').toLowerCase().replace(/\s+/g, ' ').trim()}|${event.start_date || ''}|${(event.venue || event.zip || '').toLowerCase()}`;
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, event);
+      return;
+    }
+    const currentPriority = getPriority(event.source_table);
+    const existingPriority = getPriority(existing.source_table);
+    if (currentPriority < existingPriority) {
+      map.set(key, event);
+    } else if (currentPriority === existingPriority && (event.source_table || '') < (existing.source_table || '')) {
+      map.set(key, event);
+    }
+  });
+  return Array.from(map.values());
+}
+
+async function attachTags(events) {
+  const idsByType = new Map();
+  events.forEach(event => {
+    if (!event?.source_table || !event.taggableId) return;
+    const type = event.source_table;
+    const key = `${type}`;
+    if (!idsByType.has(key)) idsByType.set(key, new Set());
+    idsByType.get(key).add(String(event.taggableId));
+  });
+  const queries = [];
+  idsByType.forEach((ids, type) => {
+    if (ids.size === 0) return;
+    queries.push(
+      supabase
+        .from('taggings')
+        .select('taggable_id, tags(slug)')
+        .eq('taggable_type', type)
+        .in('taggable_id', Array.from(ids))
+        .then(result => ({ type, result }))
+    );
+  });
+  const responses = await Promise.all(queries);
+  const tagMap = new Map();
+  responses.forEach(({ type, result }) => {
+    if (!result || result.error) {
+      if (result?.error) console.error(`Tag load failed for ${type}`, result.error);
+      return;
+    }
+    (result.data || []).forEach(({ taggable_id, tags }) => {
+      if (!taggable_id) return;
+      const slug = pickFirst(tags?.slug, tags?.name);
+      if (!slug) return;
+      const normalized = slug.trim().toLowerCase();
+      if (!normalized) return;
+      const key = `${type}:${String(taggable_id)}`;
+      if (!tagMap.has(key)) tagMap.set(key, new Set());
+      tagMap.get(key).add(normalized);
+    });
+  });
+  return events.map(event => {
+    if (!event?.source_table || !event.taggableId) return event;
+    const key = `${event.source_table}:${String(event.taggableId)}`;
+    const merged = new Set(event.tags || []);
+    const extra = tagMap.get(key);
+    if (extra) {
+      extra.forEach(slug => merged.add(slug));
+    }
+    return {
+      ...event,
+      tags: Array.from(merged),
+    };
+  });
+}
+
+export async function fetchUnifiedEventRows({ monthStart, monthEnd }) {
+  const ranges = { monthStart, monthEnd };
+  const [eventsRows, allEventsRows, bigBoardRows, groupRows, recurringRows, seasonalRows] = await Promise.all([
+    fetchEventsSource(ranges),
+    fetchAllEventsSource(ranges),
+    fetchBigBoardEvents(ranges),
+    fetchGroupEvents(ranges),
+    fetchRecurringEvents(ranges),
+    fetchSeasonalEvents(ranges),
+  ]);
+  const combined = [
+    ...eventsRows,
+    ...allEventsRows,
+    ...bigBoardRows,
+    ...groupRows,
+    ...recurringRows,
+    ...seasonalRows,
+  ].filter(Boolean);
+  const deduped = dedupeEvents(combined);
+  const withTags = await attachTags(deduped);
+  return withTags;
+}
+
+export { dedupeEvents };

--- a/src/utils/monthlyCategoryConfig.js
+++ b/src/utils/monthlyCategoryConfig.js
@@ -1,0 +1,52 @@
+export const CATEGORY_CONFIG = {
+  'family-friendly': {
+    slug: 'family-friendly',
+    label: 'Family-Friendly',
+    description: 'family-friendly',
+    tags: ['family', 'kids'],
+  },
+  'arts-culture': {
+    slug: 'arts-culture',
+    label: 'Arts & Culture',
+    description: 'arts and culture',
+    tags: ['arts', 'markets'],
+  },
+  'food-drink': {
+    slug: 'food-drink',
+    label: 'Food & Drink',
+    description: 'food and drink',
+    tags: ['nomnomslurp'],
+  },
+  fitness: {
+    slug: 'fitness',
+    label: 'Fitness & Wellness',
+    description: 'fitness and wellness',
+    tags: ['fitness'],
+  },
+  music: {
+    slug: 'music',
+    label: 'Music',
+    description: 'music',
+    tags: ['music'],
+  },
+};
+
+export const CATEGORY_ORDER = [
+  CATEGORY_CONFIG['family-friendly'],
+  CATEGORY_CONFIG['arts-culture'],
+  CATEGORY_CONFIG['food-drink'],
+  CATEGORY_CONFIG.fitness,
+  CATEGORY_CONFIG.music,
+];
+
+export const CATEGORY_SLUGS = Object.keys(CATEGORY_CONFIG);
+
+export function isValidCategorySlug(slug) {
+  if (!slug) return false;
+  return Boolean(CATEGORY_CONFIG[slug.toLowerCase()]);
+}
+
+export function getCategoryConfig(slug) {
+  if (!slug) return null;
+  return CATEGORY_CONFIG[slug.toLowerCase()] || null;
+}


### PR DESCRIPTION
## Summary
- allow MonthlyCategoryEventsPage to accept an override slug so specific category routes can be declared explicitly
- register individual routes for each configured category and drive the monthly index redirect from the shared config so every category page is generated

## Testing
- `npm run lint` *(fails: eslint flat config rejects legacy --ext flag from existing script)*

------
https://chatgpt.com/codex/tasks/task_e_68cdfaf6d28c832c839059ea9236f1f3