### PR TITLE
Add family-friendly monthly events page and update sitemap

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -42,6 +42,8 @@ const staticPages = [
   { path: '/this-weekend-in-philadelphia/', priority: '0.8', changefreq: 'weekly' },
 ]
 
+staticPages.push({ path: '/all-guides/', priority: '0.6', changefreq: 'weekly' })
+
 if (currentMonthlyPath) {
   staticPages.push({
     path: currentMonthlyPath,
@@ -53,6 +55,27 @@ if (currentMonthlyPath) {
 if (currentMonthlyPath && currentMonthlyLabel) {
   console.log(
     `ℹ️ Including monthly page for ${currentMonthlyLabel}: ${HOST}${currentMonthlyPath.slice(1)}`
+  )
+}
+
+const MONTH_WINDOW = 2
+const familyFriendlyMonths = []
+for (let offset = -MONTH_WINDOW; offset <= MONTH_WINDOW; offset += 1) {
+  const ref = new Date(zonedNow)
+  ref.setMonth(ref.getMonth() + offset)
+  const slug = indexToMonthSlug(ref.getMonth() + 1)
+  if (!slug) continue
+  familyFriendlyMonths.push({
+    path: `/family-friendly-events-in-philadelphia-${slug}-${ref.getFullYear()}/`,
+    label: formatMonthYear(ref, PHILLY_TIME_ZONE),
+    offset,
+  })
+}
+
+const currentFamilyMonth = familyFriendlyMonths.find(entry => entry.offset === 0)
+if (currentFamilyMonth) {
+  console.log(
+    `ℹ️ Including family-friendly guide for ${currentFamilyMonth.label}: ${HOST}${currentFamilyMonth.path.slice(1)}`
   )
 }
 
@@ -151,6 +174,14 @@ async function buildSitemap() {
       loc: page.path,
       changefreq: page.changefreq,
       priority: page.priority,
+    })
+  }
+
+  for (let entry of familyFriendlyMonths) {
+    addUrlEntry({
+      loc: entry.path,
+      changefreq: 'monthly',
+      priority: '0.7',
     })
   }
 

--- a/src/AllGuidesPage.jsx
+++ b/src/AllGuidesPage.jsx
@@ -1,0 +1,81 @@
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import Seo from './components/Seo.jsx';
+import {
+  getZonedDate,
+  PHILLY_TIME_ZONE,
+  formatMonthYear,
+  indexToMonthSlug,
+} from './utils/dateUtils';
+import { SITE_BASE_URL, DEFAULT_OG_IMAGE } from './utils/seoHelpers.js';
+
+export default function AllGuidesPage() {
+  const now = useMemo(() => getZonedDate(new Date(), PHILLY_TIME_ZONE), []);
+  const monthLabel = formatMonthYear(now, PHILLY_TIME_ZONE);
+  const monthSlug = indexToMonthSlug(now.getMonth() + 1);
+  const year = now.getFullYear();
+  const familyFriendlyPath = monthSlug
+    ? `/family-friendly-events-in-philadelphia-${monthSlug}-${year}/`
+    : '/family-friendly-events-in-philadelphia/';
+  const traditionsPath = monthSlug
+    ? `/philadelphia-events-${monthSlug}-${year}/`
+    : '/philadelphia-events/';
+
+  const guides = [
+    {
+      label: 'This Weekend in Philadelphia',
+      description: 'Curated festivals, markets, and concerts to help you plan a perfect Philly weekend.',
+      href: '/this-weekend-in-philadelphia/',
+    },
+    {
+      label: 'Philly Traditions Calendar',
+      description: 'Monthly traditions, markets, and perennial favorites happening all across the city.',
+      href: traditionsPath,
+    },
+    {
+      label: `Family-Friendly – ${monthLabel}`,
+      description: 'Kid-approved events, storytimes, and hands-on adventures happening throughout the city this month.',
+      href: familyFriendlyPath,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <Seo
+        title="All Guides – Our Philly"
+        description="Browse every Our Philly guide in one place, from weekend plans to family-friendly roundups."
+        canonicalUrl={`${SITE_BASE_URL}/all-guides/`}
+        ogImage={DEFAULT_OG_IMAGE}
+        ogType="website"
+      />
+      <Navbar />
+      <main className="flex-1 pt-36 md:pt-40 pb-16">
+        <div className="container mx-auto px-4 max-w-4xl">
+          <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e] text-center">All Our Philly Guides</h1>
+          <p className="mt-6 text-lg text-gray-700 text-center max-w-3xl mx-auto">
+            Everything we publish to help you explore Philadelphia, curated in one place.
+          </p>
+          <div className="mt-10 grid grid-cols-1 gap-6">
+            {guides.map(guide => (
+              <Link
+                key={guide.href}
+                to={guide.href}
+                className="block border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition p-6 bg-white"
+              >
+                <h2 className="text-2xl font-semibold text-[#28313e]">{guide.label}</h2>
+                <p className="mt-2 text-gray-600">{guide.description}</p>
+                <span className="mt-4 inline-flex items-center text-indigo-600 font-semibold">
+                  Explore guide →
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/FamilyFriendlyMonthlyPage.jsx
+++ b/src/FamilyFriendlyMonthlyPage.jsx
@@ -1,0 +1,835 @@
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { RRule } from 'rrule';
+import Navbar from './Navbar';
+import Footer from './Footer';
+import Seo from './components/Seo.jsx';
+import { supabase } from './supabaseClient';
+import { AuthContext } from './AuthProvider';
+import useEventFavorite from './utils/useEventFavorite';
+import { getDetailPathForItem } from './utils/eventDetailPaths.js';
+import {
+  PHILLY_TIME_ZONE,
+  monthSlugToIndex,
+  indexToMonthSlug,
+  getMonthWindow,
+  setEndOfDay,
+  setStartOfDay,
+  overlaps,
+  parseISODate,
+  parseMonthDayYear,
+  formatMonthYear,
+  formatEventDateRange,
+  getZonedDate,
+} from './utils/dateUtils';
+import {
+  SITE_BASE_URL,
+  DEFAULT_OG_IMAGE,
+  buildEventJsonLd,
+} from './utils/seoHelpers.js';
+
+const EVENTS_PER_PAGE = 24;
+const FAMILY_TAG_SLUGS = ['family', 'kids'];
+const CANONICAL_BASE = 'https://ourphilly.org/family-friendly-events-in-philadelphia-';
+const FALLBACK_DESCRIPTION =
+  'Plan kid-approved adventures across Philadelphia with family-friendly festivals, markets, and community events.';
+
+function FavoriteState({ event_id, source_table, children }) {
+  const state = useEventFavorite({ event_id, source_table });
+  return children(state);
+}
+
+function formatUpdatedStamp(date) {
+  if (!date) return '';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+export default function FamilyFriendlyMonthlyPage() {
+  const { user } = useContext(AuthContext);
+  const params = useParams();
+  const navigate = useNavigate();
+
+  const monthSlugParam = params.month ? params.month.toLowerCase() : null;
+  const yearParam = params.year || null;
+
+  const monthIndex = monthSlugParam ? monthSlugToIndex(monthSlugParam) : null;
+  const yearNum = yearParam ? Number(yearParam) : NaN;
+  const hasValidYear = Number.isInteger(yearNum) && yearNum >= 2000 && yearNum <= 2100;
+  const hasValidParams = Boolean(monthIndex && hasValidYear);
+
+  const monthWindow = useMemo(() => {
+    if (!hasValidParams) return { start: null, end: null };
+    return getMonthWindow(yearNum, monthIndex, PHILLY_TIME_ZONE);
+  }, [hasValidParams, monthIndex, yearNum]);
+
+  const monthStart = monthWindow.start;
+  const monthEnd = monthWindow.end;
+  const monthStartMs = monthStart ? monthStart.getTime() : null;
+  const monthEndMs = monthEnd ? monthEnd.getTime() : null;
+
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [ogImage, setOgImage] = useState(DEFAULT_OG_IMAGE);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  useEffect(() => {
+    if (hasValidParams) return;
+    const now = getZonedDate(new Date(), PHILLY_TIME_ZONE);
+    const fallbackSlug = indexToMonthSlug(now.getMonth() + 1);
+    const fallbackYear = now.getFullYear();
+    if (!fallbackSlug) return;
+    const timer = setTimeout(() => {
+      navigate(`/family-friendly-events-in-philadelphia-${fallbackSlug}-${fallbackYear}/`, { replace: true });
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [hasValidParams, navigate]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [monthSlugParam, yearParam]);
+
+  useEffect(() => {
+    if (!hasValidParams || !monthStart || !monthEnd) {
+      setEvents([]);
+      setLoading(false);
+      setOgImage(DEFAULT_OG_IMAGE);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setOgImage(DEFAULT_OG_IMAGE);
+
+    const startIso = monthStart.toISOString().slice(0, 10);
+    const endIso = monthEnd.toISOString().slice(0, 10);
+
+    (async () => {
+      try {
+        const [allRes, bigRes, tradRes, groupRes, recurringRes, seasonalRes, tagRes] = await Promise.all([
+          supabase
+            .from('all_events')
+            .select(`
+              id,
+              name,
+              description,
+              image,
+              start_date,
+              end_date,
+              start_time,
+              end_time,
+              slug,
+              venues:venue_id (
+                name,
+                slug
+              )
+            `)
+            .lte('start_date', endIso)
+            .or(`end_date.gte.${startIso},end_date.is.null`),
+          supabase
+            .from('big_board_events')
+            .select(`
+              id,
+              title,
+              description,
+              start_date,
+              end_date,
+              start_time,
+              end_time,
+              slug,
+              latitude,
+              longitude,
+              big_board_posts!big_board_posts_event_id_fkey (
+                image_url,
+                user_id
+              )
+            `)
+            .lte('start_date', endIso)
+            .or(`end_date.gte.${startIso},end_date.is.null`),
+          supabase
+            .from('events')
+            .select(`
+              id,
+              "E Name",
+              "E Description",
+              Dates,
+              "End Date",
+              "E Image",
+              slug
+            `),
+          supabase
+            .from('group_events')
+            .select(`
+              id,
+              title,
+              description,
+              image_url,
+              start_date,
+              end_date,
+              start_time,
+              end_time,
+              slug,
+              group_id,
+              groups:group_id (
+                Name,
+                imag,
+                slug
+              )
+            `)
+            .lte('start_date', endIso)
+            .or(`end_date.gte.${startIso},end_date.is.null`),
+          supabase
+            .from('recurring_events')
+            .select(`
+              id,
+              name,
+              slug,
+              description,
+              address,
+              link,
+              start_date,
+              end_date,
+              start_time,
+              end_time,
+              rrule,
+              image_url,
+              latitude,
+              longitude
+            `)
+            .eq('is_active', true),
+          supabase
+            .from('seasonal_events')
+            .select(`
+              id,
+              name,
+              description,
+              slug,
+              start_date,
+              end_date,
+              image_url,
+              location
+            `)
+            .lte('start_date', endIso)
+            .or(`end_date.gte.${startIso},end_date.is.null`),
+          supabase
+            .from('tags')
+            .select('id, slug')
+            .in('slug', FAMILY_TAG_SLUGS),
+        ]);
+
+        if (cancelled) return;
+
+        const tagRows = tagRes.data || [];
+        const allowedTagIds = tagRows.map(row => row.id);
+        if (!allowedTagIds.length) {
+          setEvents([]);
+          setLoading(false);
+          return;
+        }
+
+        const allRecords = (allRes.data || [])
+          .map(evt => {
+            const startDate = parseISODate(evt.start_date, PHILLY_TIME_ZONE);
+            const endDateBase = parseISODate(evt.end_date || evt.start_date, PHILLY_TIME_ZONE) || startDate;
+            if (!startDate || !endDateBase) return null;
+            const endDate = setEndOfDay(new Date(endDateBase));
+            if (!overlaps(startDate, endDate, monthStart, monthEnd)) return null;
+            const detailPath = getDetailPathForItem({
+              ...evt,
+              venues: evt.venues,
+              venue_slug: evt.venues?.slug,
+            });
+            return {
+              id: evt.id,
+              title: evt.name,
+              description: evt.description,
+              imageUrl: evt.image || '',
+              startDate,
+              endDate,
+              start_date: evt.start_date,
+              end_date: evt.end_date,
+              start_time: evt.start_time,
+              end_time: evt.end_time,
+              slug: evt.slug,
+              venueName: evt.venues?.name || '',
+              detailPath: detailPath || null,
+              source_table: 'all_events',
+              taggableId: String(evt.id),
+              favoriteId: evt.id,
+              isTradition: false,
+              isBigBoard: false,
+              isGroupEvent: false,
+              isRecurring: false,
+              isSeasonal: false,
+            };
+          })
+          .filter(Boolean);
+
+        const bigRecords = (bigRes.data || [])
+          .map(evt => {
+            const startDate = parseISODate(evt.start_date, PHILLY_TIME_ZONE);
+            const endDateBase = parseISODate(evt.end_date || evt.start_date, PHILLY_TIME_ZONE) || startDate;
+            if (!startDate || !endDateBase) return null;
+            const endDate = setEndOfDay(new Date(endDateBase));
+            if (!overlaps(startDate, endDate, monthStart, monthEnd)) return null;
+            let imageUrl = '';
+            const storageKey = evt.big_board_posts?.[0]?.image_url;
+            if (storageKey) {
+              const { data } = supabase.storage.from('big-board').getPublicUrl(storageKey);
+              imageUrl = data?.publicUrl || '';
+            }
+            const detailPath = getDetailPathForItem({
+              ...evt,
+              isBigBoard: true,
+            });
+            return {
+              id: evt.id,
+              title: evt.title,
+              description: evt.description,
+              imageUrl,
+              startDate,
+              endDate,
+              start_date: evt.start_date,
+              end_date: evt.end_date,
+              start_time: evt.start_time,
+              end_time: evt.end_time,
+              slug: evt.slug,
+              detailPath: detailPath || null,
+              source_table: 'big_board_events',
+              taggableId: String(evt.id),
+              favoriteId: evt.id,
+              isTradition: false,
+              isBigBoard: true,
+              isGroupEvent: false,
+              isRecurring: false,
+              isSeasonal: false,
+            };
+          })
+          .filter(Boolean);
+
+        const traditionRecords = (tradRes.data || [])
+          .map(evt => {
+            const startDate = parseMonthDayYear(evt.Dates, PHILLY_TIME_ZONE);
+            const endDateBase = parseMonthDayYear(evt['End Date'], PHILLY_TIME_ZONE) || startDate;
+            if (!startDate || !endDateBase) return null;
+            const endDate = setEndOfDay(new Date(endDateBase));
+            if (!overlaps(startDate, endDate, monthStart, monthEnd)) return null;
+            const detailPath = getDetailPathForItem({
+              ...evt,
+              isTradition: true,
+            });
+            return {
+              id: evt.id,
+              title: evt['E Name'],
+              description: evt['E Description'],
+              imageUrl: evt['E Image'] || '',
+              startDate,
+              endDate,
+              start_date: evt.Dates,
+              end_date: evt['End Date'],
+              slug: evt.slug,
+              detailPath: detailPath || null,
+              source_table: 'events',
+              taggableId: String(evt.id),
+              favoriteId: evt.id,
+              isTradition: true,
+              isBigBoard: false,
+              isGroupEvent: false,
+              isRecurring: false,
+              isSeasonal: false,
+            };
+          })
+          .filter(Boolean);
+
+        const groupRecords = (groupRes.data || [])
+          .map(evt => {
+            const startDate = parseISODate(evt.start_date, PHILLY_TIME_ZONE);
+            const endDateBase = parseISODate(evt.end_date || evt.start_date, PHILLY_TIME_ZONE) || startDate;
+            if (!startDate || !endDateBase) return null;
+            const endDate = setEndOfDay(new Date(endDateBase));
+            if (!overlaps(startDate, endDate, monthStart, monthEnd)) return null;
+            let imageUrl = '';
+            if (evt.image_url) {
+              imageUrl = evt.image_url.startsWith('http')
+                ? evt.image_url
+                : supabase.storage.from('big-board').getPublicUrl(evt.image_url).data?.publicUrl || '';
+            } else if (evt.groups?.imag) {
+              imageUrl = evt.groups.imag;
+            }
+            const detailPath = getDetailPathForItem({
+              ...evt,
+              group_slug: evt.groups?.slug,
+              isGroupEvent: true,
+            });
+            return {
+              id: evt.id,
+              title: evt.title,
+              description: evt.description,
+              imageUrl,
+              startDate,
+              endDate,
+              start_date: evt.start_date,
+              end_date: evt.end_date,
+              start_time: evt.start_time,
+              end_time: evt.end_time,
+              slug: evt.slug,
+              groupName: evt.groups?.Name || '',
+              detailPath: detailPath || null,
+              source_table: 'group_events',
+              taggableId: String(evt.id),
+              favoriteId: evt.id,
+              isTradition: false,
+              isBigBoard: false,
+              isGroupEvent: true,
+              isRecurring: false,
+              isSeasonal: false,
+            };
+          })
+          .filter(Boolean);
+
+        const seasonalRecords = (seasonalRes.data || [])
+          .map(evt => {
+            const startDate = parseISODate(evt.start_date, PHILLY_TIME_ZONE);
+            const endDateBase = parseISODate(evt.end_date || evt.start_date, PHILLY_TIME_ZONE) || startDate;
+            if (!startDate || !endDateBase) return null;
+            const endDate = setEndOfDay(new Date(endDateBase));
+            if (!overlaps(startDate, endDate, monthStart, monthEnd)) return null;
+            const detailPath = getDetailPathForItem({
+              ...evt,
+              isSeasonal: true,
+            });
+            return {
+              id: evt.id,
+              title: evt.name,
+              description: evt.description,
+              imageUrl: evt.image_url || '',
+              startDate,
+              endDate,
+              start_date: evt.start_date,
+              end_date: evt.end_date,
+              slug: evt.slug,
+              venueName: evt.location || '',
+              detailPath: detailPath || null,
+              source_table: 'seasonal_events',
+              taggableId: String(evt.id),
+              favoriteId: evt.id,
+              isTradition: false,
+              isBigBoard: false,
+              isGroupEvent: false,
+              isRecurring: false,
+              isSeasonal: true,
+            };
+          })
+          .filter(Boolean);
+
+        const recurringOccurrences = [];
+        (recurringRes.data || []).forEach(series => {
+          if (!series.start_date || !series.rrule) return;
+          let options;
+          try {
+            options = RRule.parseString(series.rrule);
+          } catch (error) {
+            console.error('Invalid recurring rule', series.id, error);
+            return;
+          }
+          const startTime = series.start_time || '00:00';
+          const dtstart = new Date(`${series.start_date}T${startTime}`);
+          if (Number.isNaN(dtstart.getTime())) return;
+          options.dtstart = dtstart;
+          if (series.end_date) {
+            options.until = new Date(`${series.end_date}T23:59:59`);
+          }
+          const rule = new RRule(options);
+          const occurrences = rule.between(monthStart, monthEnd, true);
+          occurrences.forEach(instance => {
+            const local = new Date(instance.getFullYear(), instance.getMonth(), instance.getDate());
+            const startDate = setStartOfDay(local);
+            const endDate = setEndOfDay(new Date(startDate));
+            const yyyy = local.getFullYear();
+            const mm = String(local.getMonth() + 1).padStart(2, '0');
+            const dd = String(local.getDate()).padStart(2, '0');
+            const dateStr = `${yyyy}-${mm}-${dd}`;
+            const detailPath = getDetailPathForItem({
+              ...series,
+              isRecurring: true,
+              occurrence_date: dateStr,
+              start_date: dateStr,
+            });
+            recurringOccurrences.push({
+              id: `${series.id}::${dateStr}`,
+              title: series.name,
+              description: series.description,
+              imageUrl: series.image_url || '',
+              startDate,
+              endDate,
+              start_date: dateStr,
+              end_date: dateStr,
+              start_time: series.start_time,
+              end_time: series.end_time,
+              slug: series.slug,
+              venueName: series.address || '',
+              detailPath: detailPath || null,
+              source_table: 'recurring_events',
+              taggableId: String(series.id),
+              favoriteId: String(series.id),
+              isTradition: false,
+              isBigBoard: false,
+              isGroupEvent: false,
+              isRecurring: true,
+              isSeasonal: false,
+            });
+          });
+        });
+
+        const combined = [
+          ...allRecords,
+          ...bigRecords,
+          ...traditionRecords,
+          ...groupRecords,
+          ...seasonalRecords,
+          ...recurringOccurrences,
+        ];
+
+        if (!combined.length) {
+          setEvents([]);
+          setLoading(false);
+          return;
+        }
+
+        const idsByType = combined.reduce((acc, evt) => {
+          const type = evt.source_table;
+          if (!type || !evt.taggableId) return acc;
+          if (!acc[type]) acc[type] = new Set();
+          acc[type].add(String(evt.taggableId));
+          return acc;
+        }, {});
+
+        const taggingPromises = Object.entries(idsByType).map(([type, idSet]) =>
+          supabase
+            .from('taggings')
+            .select('taggable_id, tag_id')
+            .eq('taggable_type', type)
+            .in('tag_id', allowedTagIds)
+            .in('taggable_id', Array.from(idSet))
+        );
+
+        const taggingResults = await Promise.all(taggingPromises);
+        if (cancelled) return;
+
+        const allowedByType = {};
+        taggingResults.forEach((res, index) => {
+          const type = Object.keys(idsByType)[index];
+          if (res.error) {
+            console.error('Failed to load taggings for type', type, res.error);
+            allowedByType[type] = new Set();
+            return;
+          }
+          allowedByType[type] = new Set((res.data || []).map(row => String(row.taggable_id)));
+        });
+
+        const filtered = combined.filter(evt => {
+          const type = evt.source_table;
+          const key = String(evt.taggableId);
+          return allowedByType[type]?.has(key);
+        });
+
+        const sorted = filtered
+          .slice()
+          .sort((a, b) => {
+            const diff = (a.startDate?.getTime() || 0) - (b.startDate?.getTime() || 0);
+            if (diff !== 0) return diff;
+            const timeDiff = (a.start_time || '').localeCompare(b.start_time || '');
+            if (timeDiff !== 0) return timeDiff;
+            return (a.title || '').localeCompare(b.title || '');
+          });
+
+        const dedupedMap = new Map();
+        sorted.forEach(evt => {
+          const key = evt.detailPath || `${evt.source_table}:${evt.id}`;
+          if (!dedupedMap.has(key)) {
+            dedupedMap.set(key, evt);
+          }
+        });
+
+        const dedupedList = Array.from(dedupedMap.values());
+        setEvents(dedupedList);
+        const firstWithImage = dedupedList.find(evt => evt.imageUrl);
+        if (firstWithImage?.imageUrl) {
+          setOgImage(firstWithImage.imageUrl);
+        } else {
+          setOgImage(DEFAULT_OG_IMAGE);
+        }
+        setLoading(false);
+      } catch (error) {
+        if (cancelled) return;
+        console.error('Error loading family-friendly events', error);
+        setEvents([]);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasValidParams, monthStartMs, monthEndMs, monthStart, monthEnd]);
+
+  const monthLabel = monthStart ? formatMonthYear(monthStart, PHILLY_TIME_ZONE) : '';
+  const monthSlug = monthIndex ? indexToMonthSlug(monthIndex) : null;
+  const canonicalUrl = hasValidParams && monthSlug
+    ? `${CANONICAL_BASE}${monthSlug}-${yearNum}/`
+    : `${SITE_BASE_URL}/family-friendly-events-in-philadelphia/`;
+
+  const seoTitle = hasValidParams && monthLabel
+    ? `Family-Friendly Events in Philadelphia – ${monthLabel}`
+    : 'Family-Friendly Events in Philadelphia – Our Philly';
+
+  const seoDescription = hasValidParams && monthLabel
+    ? `Discover family-friendly and kids events happening across Philadelphia during ${monthLabel}. Markets, storytimes, and community fun curated by Our Philly.`
+    : FALLBACK_DESCRIPTION;
+
+  const totalEvents = events.length;
+  const pageCount = Math.ceil(totalEvents / EVENTS_PER_PAGE);
+  const pagedEvents = useMemo(() => {
+    const startIndex = (currentPage - 1) * EVENTS_PER_PAGE;
+    return events.slice(startIndex, startIndex + EVENTS_PER_PAGE);
+  }, [events, currentPage]);
+
+  const updatedStamp = formatUpdatedStamp(getZonedDate(new Date(), PHILLY_TIME_ZONE));
+
+  const navLinks = useMemo(() => {
+    if (!hasValidParams || !monthSlug) return [];
+    return [
+      {
+        label: 'All Events',
+        path: `/philadelphia-events-${monthSlug}-${yearNum}/`,
+      },
+      {
+        label: 'Family-Friendly',
+        path: `/family-friendly-events-in-philadelphia-${monthSlug}-${yearNum}/`,
+      },
+      {
+        label: 'Arts & Culture',
+        path: `/arts-and-culture-events-in-philadelphia-${monthSlug}-${yearNum}/`,
+      },
+      {
+        label: 'Food & Drink',
+        path: `/food-and-drink-events-in-philadelphia-${monthSlug}-${yearNum}/`,
+      },
+      {
+        label: 'Fitness & Wellness',
+        path: `/fitness-and-wellness-events-in-philadelphia-${monthSlug}-${yearNum}/`,
+      },
+      {
+        label: 'Music',
+        path: `/music-events-in-philadelphia-${monthSlug}-${yearNum}/`,
+      },
+    ];
+  }, [hasValidParams, monthSlug, yearNum]);
+
+  const itemListJsonLd = useMemo(() => {
+    if (!hasValidParams || !monthLabel || !events.length) return null;
+    const elements = events.slice(0, 20).map((evt, index) => {
+      const detailPath = evt.detailPath;
+      if (!detailPath) return null;
+      const canonical = `${SITE_BASE_URL}${detailPath}`;
+      const eventJson = buildEventJsonLd({
+        name: evt.title,
+        canonicalUrl: canonical,
+        startDate: evt.startDate,
+        endDate: evt.endDate,
+        locationName: evt.venueName || evt.groupName || 'Philadelphia',
+        description: evt.description,
+        image: evt.imageUrl,
+      });
+      if (!eventJson) return null;
+      return {
+        '@type': 'ListItem',
+        position: index + 1,
+        item: eventJson,
+      };
+    }).filter(Boolean);
+    if (!elements.length) return null;
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      name: `Family-Friendly Events in Philadelphia – ${monthLabel}`,
+      itemListOrder: 'https://schema.org/ItemListOrderAscending',
+      numberOfItems: events.length,
+      itemListElement: elements,
+    };
+  }, [events, hasValidParams, monthLabel]);
+
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <Seo
+        title={seoTitle}
+        description={seoDescription}
+        canonicalUrl={canonicalUrl}
+        ogImage={ogImage}
+        ogType="website"
+        jsonLd={itemListJsonLd}
+      />
+      <Navbar />
+      <main className="flex-1 pt-36 md:pt-40 pb-16">
+        <div className="container mx-auto px-4 max-w-5xl">
+          {hasValidParams ? (
+            <>
+              <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e] text-center">
+                Family-Friendly Events in Philadelphia – {monthLabel}
+              </h1>
+              <p className="mt-6 text-lg text-gray-700 text-center max-w-3xl mx-auto">
+                {totalEvents
+                  ? `We found ${totalEvents} kid-approved events, storytimes, and hands-on adventures in Philadelphia for ${monthLabel}.`
+                  : `Explore kid-approved events, storytimes, and hands-on adventures happening throughout ${monthLabel}.`}
+              </p>
+              <p className="mt-2 text-sm text-gray-500 text-center">Updated {updatedStamp}</p>
+
+              {navLinks.length > 0 && (
+                <nav className="mt-8 flex flex-wrap justify-center gap-3">
+                  {navLinks.map(link => {
+                    const isActive = link.path === canonicalUrl.replace(SITE_BASE_URL, '');
+                    return (
+                      <Link
+                        key={link.path}
+                        to={link.path}
+                        className={`px-4 py-2 rounded-full border font-semibold text-sm transition ${
+                          isActive
+                            ? 'bg-indigo-600 text-white border-indigo-600'
+                            : 'bg-white text-indigo-600 border-indigo-600 hover:bg-indigo-600 hover:text-white'
+                        }`}
+                      >
+                        {link.label}
+                      </Link>
+                    );
+                  })}
+                </nav>
+              )}
+
+              <section className="mt-10 bg-white border border-gray-200 rounded-2xl shadow-sm">
+                {loading ? (
+                  <p className="p-6 text-gray-500">Loading family-friendly events…</p>
+                ) : pagedEvents.length === 0 ? (
+                  <p className="p-6 text-gray-500">
+                    No tagged family or kids events are listed for {monthLabel} yet. Check back soon or submit one!
+                  </p>
+                ) : (
+                  <div className="divide-y divide-gray-200">
+                    {pagedEvents.map(evt => {
+                      const detailPath = evt.detailPath || '/';
+                      const summary = evt.description?.trim() || 'Details coming soon.';
+                      return (
+                        <article key={`${evt.source_table}-${evt.id}`} className="flex flex-col md:flex-row gap-4 px-6 py-6">
+                          <div className="md:w-48 w-full flex-shrink-0">
+                            <div className="relative w-full overflow-hidden rounded-xl bg-gray-100 aspect-[4/3]">
+                              <img
+                                src={evt.imageUrl || DEFAULT_OG_IMAGE}
+                                alt={evt.title}
+                                loading="lazy"
+                                className="absolute inset-0 h-full w-full object-cover"
+                              />
+                              {evt.isTradition && (
+                                <span className="absolute top-2 left-2 bg-yellow-100 text-yellow-700 text-xs font-semibold px-2 py-0.5 rounded-full">
+                                  Tradition
+                                </span>
+                              )}
+                              {evt.isBigBoard && (
+                                <span className="absolute top-2 right-2 bg-indigo-600 text-white text-xs font-semibold px-2 py-0.5 rounded-full">
+                                  Submission
+                                </span>
+                              )}
+                              {evt.isGroupEvent && (
+                                <span className="absolute bottom-2 left-2 bg-green-600 text-white text-xs font-semibold px-2 py-0.5 rounded-full">
+                                  Group Event
+                                </span>
+                              )}
+                              {evt.isSeasonal && (
+                                <span className="absolute bottom-2 right-2 bg-orange-500 text-white text-xs font-semibold px-2 py-0.5 rounded-full">
+                                  Seasonal
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex-1 flex flex-col">
+                            <Link
+                              to={detailPath}
+                              className="text-2xl font-semibold text-[#28313e] hover:underline"
+                            >
+                              {evt.title}
+                            </Link>
+                            <p className="mt-2 text-sm font-semibold text-gray-700">
+                              {formatEventDateRange(evt.startDate, evt.endDate, PHILLY_TIME_ZONE)}
+                            </p>
+                            {(evt.venueName || evt.groupName) && (
+                              <p className="mt-1 text-sm text-gray-500">
+                                {evt.venueName || evt.groupName}
+                              </p>
+                            )}
+                            <p className="mt-2 text-sm text-gray-600 line-clamp-3">{summary}</p>
+                            <div className="mt-4">
+                              <FavoriteState event_id={evt.favoriteId} source_table={evt.source_table}>
+                                {({ isFavorite, toggleFavorite, loading: favLoading }) => (
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      if (!user) {
+                                        navigate('/login');
+                                        return;
+                                      }
+                                      toggleFavorite();
+                                    }}
+                                    disabled={favLoading}
+                                    className={`inline-flex items-center px-4 py-2 border border-indigo-600 rounded-full font-semibold transition-colors ${
+                                      isFavorite
+                                        ? 'bg-indigo-600 text-white'
+                                        : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'
+                                    }`}
+                                  >
+                                    {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                                  </button>
+                                )}
+                              </FavoriteState>
+                            </div>
+                          </div>
+                        </article>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+
+              {!loading && pageCount > 1 && (
+                <div className="flex justify-center mt-6 space-x-2">
+                  {Array.from({ length: pageCount }).map((_, index) => {
+                    const pageNumber = index + 1;
+                    return (
+                      <button
+                        key={pageNumber}
+                        onClick={() => setCurrentPage(pageNumber)}
+                        className={`px-4 py-2 rounded-full border font-semibold transition ${
+                          currentPage === pageNumber
+                            ? 'bg-[#28313e] text-white border-[#28313e]'
+                            : 'bg-white text-[#28313e] border-[#28313e] hover:bg-[#28313e] hover:text-white'
+                        }`}
+                      >
+                        {pageNumber}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="py-24 text-center text-gray-600">
+              <p>Loading the latest family-friendly events…</p>
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -137,6 +137,13 @@ export default function Navbar({ style }) {
                     >
                       Philly Traditions Calendar
                     </Link>
+                    <Link
+                      to="/all-guides/"
+                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-indigo-50 hover:text-indigo-700"
+                      onClick={() => setGuidesOpen(false)}
+                    >
+                      All Guides
+                    </Link>
                   </div>
                 )}
               </li>

--- a/src/components/SlashGuard.jsx
+++ b/src/components/SlashGuard.jsx
@@ -3,7 +3,8 @@ import { useLocation, useNavigate } from 'react-router-dom'
 
 const needsSlash = pathname =>
   pathname === '/this-weekend-in-philadelphia' ||
-  /^\/philadelphia-events-[a-z]+-\d{4}$/.test(pathname)
+  /^\/philadelphia-events-[a-z]+-\d{4}$/.test(pathname) ||
+  /^\/family-friendly-events-in-philadelphia-[a-z-]+-\d{4}$/.test(pathname)
 
 export default function SlashGuard() {
   const { pathname, search, hash } = useLocation()

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -56,6 +56,8 @@ import AboutPage from './AboutPage.jsx'
 import ThisWeekendInPhiladelphia from './ThisWeekendInPhiladelphia.jsx';
 import ThisMonthInPhiladelphia from './ThisMonthInPhiladelphia.jsx';
 import PhiladelphiaEventsIndex from './PhiladelphiaEventsIndex.jsx';
+import FamilyFriendlyMonthlyPage from './FamilyFriendlyMonthlyPage.jsx';
+import AllGuidesPage from './AllGuidesPage.jsx';
 import ViewRouter from './ViewRouter.jsx';
 import HeadProvider from './components/HeadProvider.jsx'
 import SlashGuard from './components/SlashGuard.jsx'
@@ -89,6 +91,11 @@ ReactDOM.createRoot(document.getElementById('root')).render(
               path="/philadelphia-events-:month-:year/"
               element={<ThisMonthInPhiladelphia />}
             />
+            <Route
+              path="/family-friendly-events-in-philadelphia-:month-:year/"
+              element={<FamilyFriendlyMonthlyPage />}
+            />
+            <Route path="/all-guides/" element={<AllGuidesPage />} />
             <Route path="/:view" element={<ViewRouter />} />
             <Route path="/old" element={<App />} />
             <Route path="/sports" element={<SportsPage />} />


### PR DESCRIPTION
## Summary
- add a dynamic family-friendly monthly events guide that aggregates every event source with tag filtering, pagination, and SEO metadata
- expose the guide at /family-friendly-events-in-philadelphia-{month}-{year}/, reuse the traditions UI, and surface the link from the All Guides hub and navbar
- extend the sitemap generator and slash guard to cover the new family-friendly routes and emit a rolling window of URLs

## Testing
- `yarn lint` *(fails: Invalid option '--ext' in upstream script)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7d649054832ca232b109eaa3ed89