### PR TITLE
Adjust guides layout and navigation

### DIFF
--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -1541,10 +1541,36 @@ if (loading) {
       
           <div className="flex flex-col min-h-screen overflow-x-visible">
             <Navbar />
-      
-            <div className="mt-32"></div>
-      
-            <div className="relative mt-12">
+
+            <div className="flex-1 pt-28 sm:pt-32">
+              <section className="px-4 mb-12">
+                <Link
+                  to="/this-weekend-in-philadelphia/"
+                  className="block group"
+                >
+                  <div className="max-w-screen-xl mx-auto">
+                    <div className="relative overflow-hidden rounded-3xl bg-[#bf3d35] text-white px-6 py-10 sm:px-12 sm:py-12 shadow-xl transition-transform duration-300 group-hover:-translate-y-1 group-hover:shadow-2xl">
+                      <div className="absolute -top-20 -right-10 w-48 h-48 bg-white/20 rounded-full blur-3xl"></div>
+                      <div className="absolute -bottom-24 -left-16 w-64 h-64 bg-white/10 rounded-full blur-3xl"></div>
+                      <div className="relative z-10 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <h2 className="text-3xl sm:text-5xl font-[Barrio] uppercase tracking-wider">
+                            THIS WEEKEND IN THE CITY
+                          </h2>
+                          <p className="mt-3 text-lg sm:text-xl font-semibold">
+                            {weekendPromoLabel}
+                          </p>
+                        </div>
+                        <span className="inline-flex items-center justify-center self-start sm:self-auto px-6 py-3 rounded-full bg-white text-[#bf3d35] font-semibold uppercase tracking-wide shadow-lg transition-colors duration-300 group-hover:bg-[#ffe1dd] group-hover:text-[#7f2622]">
+                          Plan my weekend →
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </Link>
+              </section>
+
+              <div className="relative mt-12">
               <FallingPills />
               <div className="relative z-10 text-center">
                 <h2 className="text-4xl sm:text-5xl font-[Barrio] font-black text-indigo-900">PICK YOUR DATES!</h2>
@@ -1924,64 +1950,12 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
       
             {/* ─── Recent Activity ─── */}
             <RecentActivity />
-            <section className="w-full max-w-screen-xl mx-auto mt-12 mb-12 px-4">
-              <h2 className="text-black text-4xl font-[Barrio] mb-4 text-left">
-                Your Upcoming Plans
-              </h2>
-              {loadingSaved ? null : user ? (
-                savedEvents.length ? (
-                  <>
-                    <SavedEventsScroller events={savedEvents} />
-                    <p className="text-gray-600 mt-2">
-                      <Link to="/profile" className="text-indigo-600 underline">
-                        See more plans on your profile
-                      </Link>
-                    </p>
-                  </>
-                ) : (
-                  <p className="text-gray-600">
-                    You don't have any plans yet! Add some to get started.
-                  </p>
-                )
-              ) : (
-                <p className="text-gray-600">
-                  <Link to="/login" className="text-indigo-600 underline">Log in</Link> to add events to your plans.
-                </p>
-              )}
-            </section>
-            <section className="px-4 mb-12">
-              <Link
-                to="/this-weekend-in-philadelphia/"
-                className="block group"
-              >
-                <div className="max-w-screen-xl mx-auto">
-                  <div className="relative overflow-hidden rounded-3xl bg-[#bf3d35] text-white px-6 py-10 sm:px-12 sm:py-12 shadow-xl transition-transform duration-300 group-hover:-translate-y-1 group-hover:shadow-2xl">
-                    <div className="absolute -top-20 -right-10 w-48 h-48 bg-white/20 rounded-full blur-3xl"></div>
-                    <div className="absolute -bottom-24 -left-16 w-64 h-64 bg-white/10 rounded-full blur-3xl"></div>
-                    <div className="relative z-10 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
-                      <div>
-                        <h2 className="text-3xl sm:text-5xl font-[Barrio] uppercase tracking-wider">
-                          THIS WEEKEND IN THE CITY
-                        </h2>
-                        <p className="mt-3 text-lg sm:text-xl font-semibold">
-                          {weekendPromoLabel}
-                        </p>
-                      </div>
-                      <span className="inline-flex items-center justify-center self-start sm:self-auto px-6 py-3 rounded-full bg-white text-[#bf3d35] font-semibold uppercase tracking-wide shadow-lg transition-colors duration-300 group-hover:bg-[#ffe1dd] group-hover:text-[#7f2622]">
-                        Plan my weekend →
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </Link>
-            </section>
-            <HeroLanding fullWidth />
             <section
               aria-labelledby="other-guides-heading"
-              className="mt-16 overflow-hidden bg-slate-900 text-white"
+              className="overflow-hidden bg-slate-900 text-white"
               style={{ marginInline: 'calc(50% - 50vw)', width: '100vw' }}
             >
-              <div className="px-6 py-10 sm:px-10">
+              <div className="px-6 pb-10 pt-8 sm:px-10">
                 <div className="mx-auto flex max-w-screen-xl flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
                   <div className="space-y-3 text-left">
                     <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-200">
@@ -2046,6 +2020,32 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
                 </div>
               </div>
             </section>
+            <section className="w-full max-w-screen-xl mx-auto mt-12 mb-12 px-4">
+              <h2 className="text-black text-4xl font-[Barrio] mb-4 text-left">
+                Your Upcoming Plans
+              </h2>
+              {loadingSaved ? null : user ? (
+                savedEvents.length ? (
+                  <>
+                    <SavedEventsScroller events={savedEvents} />
+                    <p className="text-gray-600 mt-2">
+                      <Link to="/profile" className="text-indigo-600 underline">
+                        See more plans on your profile
+                      </Link>
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-gray-600">
+                    You don't have any plans yet! Add some to get started.
+                  </p>
+                )
+              ) : (
+                <p className="text-gray-600">
+                  <Link to="/login" className="text-indigo-600 underline">Log in</Link> to add events to your plans.
+                </p>
+              )}
+            </section>
+            <HeroLanding fullWidth />
             <TaggedEventScroller
               tags={['birds']}
               fullWidth
@@ -2106,15 +2106,17 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
             />
             <RecurringEventsScroller windowStart={startOfWeek} windowEnd={endOfWeek} eventType="open_mic" header="Karaoke, Bingo, Open Mics Coming Up..." />
 
+          </div>
+
             {/* ─── Floating “+” (always on top) ─── */}
             <FloatingAddButton onClick={() => setShowFlyerModal(true)} />
-      
+
             {/* ─── PostFlyerModal ─── */}
             <PostFlyerModal
               isOpen={showFlyerModal}
               onClose={() => setShowFlyerModal(false)}
             />
-      
+
             <Footer />
           </div>
         </>

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -2,13 +2,14 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { ChevronDown, Menu, X } from 'lucide-react';
-import { FaTiktok, FaInstagram } from 'react-icons/fa';
+import { FaInstagram } from 'react-icons/fa';
 import SubmitGroupModal from './SubmitGroupModal';
 import PostFlyerModal from './PostFlyerModal';
 import { AuthContext } from './AuthProvider';
 import { supabase } from './supabaseClient';
 import NavTagMenu from './NavTagMenu';
 import LoginPromptModal from './LoginPromptModal';
+import { getZonedDate, PHILLY_TIME_ZONE, indexToMonthSlug } from './utils/dateUtils';
 
 export default function Navbar({ style }) {
   const { user } = useContext(AuthContext);
@@ -56,6 +57,39 @@ export default function Navbar({ style }) {
     location.pathname.startsWith('/this-weekend-in-philadelphia') ||
     location.pathname.startsWith('/philadelphia-events');
 
+  const now = getZonedDate(new Date(), PHILLY_TIME_ZONE);
+  const monthSlug = indexToMonthSlug(now.getMonth() + 1);
+  const currentYear = now.getFullYear();
+  const traditionsPath = monthSlug
+    ? `/philadelphia-events-${monthSlug}-${currentYear}/`
+    : '/philadelphia-events/';
+  const familyGuidePath = monthSlug
+    ? `/family-friendly-events-in-philadelphia-${monthSlug}-${currentYear}/`
+    : '/family-friendly-events-in-philadelphia/';
+  const artsGuidePath = monthSlug
+    ? `/arts-culture-events-in-philadelphia-${monthSlug}-${currentYear}/`
+    : '/arts-culture-events-in-philadelphia/';
+  const foodGuidePath = monthSlug
+    ? `/food-drink-events-in-philadelphia-${monthSlug}-${currentYear}/`
+    : '/food-drink-events-in-philadelphia/';
+  const fitnessGuidePath = monthSlug
+    ? `/fitness-events-in-philadelphia-${monthSlug}-${currentYear}/`
+    : '/fitness-events-in-philadelphia/';
+  const musicGuidePath = monthSlug
+    ? `/music-events-in-philadelphia-${monthSlug}-${currentYear}/`
+    : '/music-events-in-philadelphia/';
+
+  const guideMenuLinks = [
+    { label: 'All Guides', href: '/all-guides/' },
+    { label: 'This Weekend in Philadelphia', href: '/this-weekend-in-philadelphia/' },
+    { label: 'Philly Traditions Calendar', href: traditionsPath },
+    { label: 'Family-Friendly Guide', href: familyGuidePath },
+    { label: 'Arts Guide', href: artsGuidePath },
+    { label: 'Food & Drink Guide', href: foodGuidePath },
+    { label: 'Fitness & Wellness Guide', href: fitnessGuidePath },
+    { label: 'Music Guide', href: musicGuidePath },
+  ];
+
   return (
     <>
       <nav className="fixed top-0 w-full bg-white shadow z-50" style={style}>
@@ -73,14 +107,6 @@ export default function Navbar({ style }) {
           <div className="hidden md:flex items-center space-x-8 text-base">
             {/* Social links */}
             <div className="flex items-center space-x-4">
-              <a
-                href="https://www.tiktok.com/@ourphilly?lang=en"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="TikTok"
-              >
-                <FaTiktok className="w-5 h-5 text-gray-700 hover:text-gray-900 transition" />
-              </a>
               <a
                 href="https://www.instagram.com/ourphillydotorg/"
                 target="_blank"
@@ -107,9 +133,19 @@ export default function Navbar({ style }) {
                 className="relative"
                 onMouseEnter={() => setGuidesOpen(true)}
                 onMouseLeave={() => setGuidesOpen(false)}
+                onBlur={event => {
+                  if (!event.currentTarget.contains(event.relatedTarget)) {
+                    setGuidesOpen(false);
+                  }
+                }}
               >
                 <button
-                  onClick={() => setGuidesOpen(open => !open)}
+                  type="button"
+                  onClick={() => {
+                    setGuidesOpen(false);
+                    navigate('/all-guides/');
+                  }}
+                  onFocus={() => setGuidesOpen(true)}
                   className={`flex items-center space-x-1 ${
                     exploreActive ? 'text-gray-900 font-semibold' : 'text-gray-700'
                   } hover:text-gray-900 transition`}
@@ -123,27 +159,16 @@ export default function Navbar({ style }) {
                 </button>
                 {guidesOpen && (
                   <div className="absolute right-0 mt-3 w-64 bg-white border border-gray-200 rounded-xl shadow-lg py-3 z-50">
-                    <Link
-                      to="/this-weekend-in-philadelphia/"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-indigo-50 hover:text-indigo-700"
-                      onClick={() => setGuidesOpen(false)}
-                    >
-                      This Weekend in Philadelphia
-                    </Link>
-                    <Link
-                      to="/philadelphia-events/"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-indigo-50 hover:text-indigo-700"
-                      onClick={() => setGuidesOpen(false)}
-                    >
-                      Philly Traditions Calendar
-                    </Link>
-                    <Link
-                      to="/all-guides/"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-indigo-50 hover:text-indigo-700"
-                      onClick={() => setGuidesOpen(false)}
-                    >
-                      All Guides
-                    </Link>
+                    {guideMenuLinks.map(link => (
+                      <Link
+                        key={link.href}
+                        to={link.href}
+                        className="block px-4 py-2 text-sm text-gray-700 hover:bg-indigo-50 hover:text-indigo-700"
+                        onClick={() => setGuidesOpen(false)}
+                      >
+                        {link.label}
+                      </Link>
+                    ))}
                   </div>
                 )}
               </li>
@@ -225,14 +250,6 @@ export default function Navbar({ style }) {
           <div className="md:hidden bg-white shadow-lg px-4 py-6 space-y-4 text-base font-medium">
             <div className="flex space-x-4">
               <a
-                href="https://www.tiktok.com/@ourphilly?lang=en"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="TikTok"
-              >
-                <FaTiktok className="w-5 h-5 text-gray-700 hover:text-gray-900" />
-              </a>
-              <a
                 href="https://www.instagram.com/ourphillydotorg/"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -242,18 +259,11 @@ export default function Navbar({ style }) {
               </a>
             </div>
             <Link
-              to="/this-weekend-in-philadelphia/"
+              to="/all-guides/"
               className="block"
               onClick={() => setMenuOpen(false)}
             >
-              This Weekend in Philly
-            </Link>
-            <Link
-              to="/philadelphia-events/"
-              className="block"
-              onClick={() => setMenuOpen(false)}
-            >
-              Philly Traditions Calendar
+              All Guides
             </Link>
             <Link to="/groups" className="block" onClick={() => setMenuOpen(false)}>
               Claim Your Group

--- a/src/createMonthlyGuidePage.jsx
+++ b/src/createMonthlyGuidePage.jsx
@@ -3,6 +3,8 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { RRule } from 'rrule';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import FloatingAddButton from './FloatingAddButton';
+import PostFlyerModal from './PostFlyerModal';
 import Seo from './components/Seo.jsx';
 import { supabase } from './supabaseClient';
 import { AuthContext } from './AuthProvider';
@@ -134,6 +136,7 @@ export default function createMonthlyGuidePage(config) {
     const { user } = useContext(AuthContext);
     const params = useParams();
     const navigate = useNavigate();
+    const [showFlyerModal, setShowFlyerModal] = useState(false);
 
     const viewParam = params.view;
     const viewMatch = useMemo(() => {
@@ -892,14 +895,12 @@ export default function createMonthlyGuidePage(config) {
                   </a>
                 </div>
                 <p className="mt-3 text-sm text-gray-600 text-center">
-                  Planning sooner? Explore the{' '}
                   <Link
                     to="/this-weekend-in-philadelphia/"
                     className="text-indigo-600 hover:text-indigo-800 font-semibold"
                   >
-                    This Weekend in Philadelphia guide
+                    Weekend Guide: Explore all of This Weekend's Events in Philly.
                   </Link>
-                  .
                 </p>
 
                 {navLinks.length > 0 && (
@@ -1109,6 +1110,11 @@ export default function createMonthlyGuidePage(config) {
             <p className="text-center text-sm text-gray-500">{concludingText}</p>
           </div>
         </main>
+        <FloatingAddButton onClick={() => setShowFlyerModal(true)} />
+        <PostFlyerModal
+          isOpen={showFlyerModal}
+          onClose={() => setShowFlyerModal(false)}
+        />
         <Footer />
       </div>
     );


### PR DESCRIPTION
## Summary
- surface the weekend hero banner at the top of the main events page and reposition the "Other Our Philly guides" showcase before saved plans
- add the floating add-event control to monthly guide templates and update the weekend guide CTA copy
- expand the desktop Events & Guides dropdown with all guide links, route the trigger to All Guides, and remove TikTok links from the navigation
- fine-tune the spacing between the recent reviews ticker and the "Other Our Philly guides" section so the content has a touch of top padding without reintroducing a gap between sections

## Testing
- npm run lint *(fails: repository script still passes the unsupported `--ext` flag when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cedbb0f2f8832c9b3135cbd92ccfb1