### PR TITLE
Align seasonal tag scrollers with refreshed headers

### DIFF
--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -713,6 +713,29 @@ const hasFilters = selectedTags.length > 0 || selectedOption !== 'today';
   const [savedEvents, setSavedEvents] = useState([]);
   const [loadingSaved, setLoadingSaved] = useState(true);
 
+  const savedPlansDescription = useMemo(() => {
+    if (loadingSaved) {
+      return 'Loading your saved plans…';
+    }
+
+    if (!user) {
+      return (
+        <>
+          <Link to="/login" className="text-indigo-600 underline">
+            Log in
+          </Link>{' '}
+          to add events to your plans.
+        </>
+      );
+    }
+
+    if (!savedEvents.length) {
+      return "You don't have any plans yet! Add some to get started.";
+    }
+
+    return 'A quick look at the events you have coming up next.';
+  }, [loadingSaved, user, savedEvents.length]);
+
   useEffect(() => {
     if (!user) {
       setSavedEvents([]);
@@ -1668,7 +1691,15 @@ if (loading) {
             />
 
             <main className="container mx-auto px-4 py-8">
-              <h2 className="text-3xl font-semibold mb-4 text-[#28313e]">{headerText}</h2>
+              <div className="mb-8 space-y-3 text-left">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                  Make Your Philly Plans
+                </p>
+                <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                  Upcoming Plans, Festivals, and Philly Traditions
+                </h2>
+                <p className="text-sm text-gray-600 sm:text-base">{headerText}</p>
+              </div>
 
               {!loading && (
                 <>
@@ -2021,28 +2052,24 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
               </div>
             </section>
             <section className="w-full max-w-screen-xl mx-auto mt-12 mb-12 px-4">
-              <h2 className="text-black text-4xl font-[Barrio] mb-4 text-left">
-                Your Upcoming Plans
-              </h2>
-              {loadingSaved ? null : user ? (
-                savedEvents.length ? (
-                  <>
-                    <SavedEventsScroller events={savedEvents} />
-                    <p className="text-gray-600 mt-2">
-                      <Link to="/profile" className="text-indigo-600 underline">
-                        See more plans on your profile
-                      </Link>
-                    </p>
-                  </>
-                ) : (
-                  <p className="text-gray-600">
-                    You don't have any plans yet! Add some to get started.
-                  </p>
-                )
-              ) : (
-                <p className="text-gray-600">
-                  <Link to="/login" className="text-indigo-600 underline">Log in</Link> to add events to your plans.
+              <div className="space-y-3 text-left mb-6">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                  Saved agenda
                 </p>
+                <h2 className="text-black text-4xl font-[Barrio] text-left">
+                  Your Upcoming Plans
+                </h2>
+                <p className="text-sm text-gray-600 sm:text-base">{savedPlansDescription}</p>
+              </div>
+              {!loadingSaved && user && savedEvents.length > 0 && (
+                <>
+                  <SavedEventsScroller events={savedEvents} />
+                  <p className="text-gray-600 mt-2">
+                    <Link to="/profile" className="text-indigo-600 underline">
+                      See more plans on your profile
+                    </Link>
+                  </p>
+                </>
               )}
             </section>
             <HeroLanding fullWidth />
@@ -2052,9 +2079,14 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
               header={
                 <Link
                   to="/tags/birds"
-                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#FFD700] bg-[#FFD700] text-[#004C55] rounded-full"
+                  className="block w-full max-w-screen-xl mx-auto px-4 mb-6 space-y-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
                 >
-                  #Birds
+                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                    Seasonal Tag
+                  </p>
+                  <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                    Next in Birds
+                  </h2>
                 </Link>
               }
             />
@@ -2086,9 +2118,14 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
               header={
                 <Link
                   to="/tags/arts"
-                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
+                  className="block w-full max-w-screen-xl mx-auto px-4 mb-6 space-y-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
                 >
-                  #Arts
+                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                    Seasonal Tag
+                  </p>
+                  <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                    Next in Arts
+                  </h2>
                 </Link>
               }
             />
@@ -2098,13 +2135,35 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
               header={
                 <Link
                   to="/tags/nomnomslurp"
-                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
+                  className="block w-full max-w-screen-xl mx-auto px-4 mb-6 space-y-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
                 >
-                  #NomNomSlurp
+                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                    Seasonal Tag
+                  </p>
+                  <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                    Next in NomNomSlurp
+                  </h2>
                 </Link>
               }
             />
-            <RecurringEventsScroller windowStart={startOfWeek} windowEnd={endOfWeek} eventType="open_mic" header="Karaoke, Bingo, Open Mics Coming Up..." />
+            <RecurringEventsScroller
+              windowStart={startOfWeek}
+              windowEnd={endOfWeek}
+              eventType="open_mic"
+              header={(
+                <div className="max-w-screen-xl mx-auto px-4 space-y-3 text-left mb-6">
+                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                    Weekly regulars
+                  </p>
+                  <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                    Karaoke, Bingo, Open Mics & Other Weeklies
+                  </h2>
+                  <p className="text-sm text-gray-600 sm:text-base">
+                    Drop into rotating open mics, karaoke nights, and game sessions that come back every week.
+                  </p>
+                </div>
+              )}
+            />
 
           </div>
 

--- a/src/RecurringEventsScroller.jsx
+++ b/src/RecurringEventsScroller.jsx
@@ -101,7 +101,13 @@ export default function RecurringEventsScroller({
 
   return (
     <section className="py-8">
-      <h2 className="text-3xl font-[Barrio] font-bold text-center mb-6">{header}</h2>
+      {header ? (
+        typeof header === 'string' ? (
+          <h2 className="text-3xl font-[Barrio] font-bold text-center mb-6">{header}</h2>
+        ) : (
+          header
+        )
+      ) : null}
 
       {/* Filters: horizontally scrollable on mobile */}
       <div className="overflow-x-auto scrollbar-hide px-4 mb-8">


### PR DESCRIPTION
## Summary
- rename the main events eyebrow copy to "Make Your Philly Plans" to match the requested phrasing
- remove the extra seasonal-scroller banner and supply each tagged scroller with the shared eyebrow/headline header markup
- title the birds, arts, and NomNomSlurp scrollers "Next in …" without descriptions while keeping each headline linked to its tag page

## Testing
- npm run lint *(fails: project script still invokes unsupported --ext flag with the flat ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68cf083dff9c832c8095469543ded3fd