### PR TITLE
Restyle traditions hero and hashtag seasonal scrollers

### DIFF
--- a/src/HeroLanding.jsx
+++ b/src/HeroLanding.jsx
@@ -85,7 +85,7 @@ export default function HeroLanding({ fullWidth = false }) {
   }, []);
 
   return (
-    <section className={`relative w-full bg-white border-b border-gray-200 py-16 overflow-hidden ${fullWidth ? 'px-0' : 'px-4'}`}>
+    <section className={`relative w-full bg-white border-b border-gray-200 py-16 overflow-hidden ${fullWidth ? 'px-0' : 'px-4 sm:px-6 lg:px-8'}`}>
       <img
         src="https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images/OurPhilly-CityHeart-1%20copy-min.png"
         alt=""
@@ -94,96 +94,104 @@ export default function HeroLanding({ fullWidth = false }) {
         className="absolute top-0 w-1/4 h-full object-contain pointer-events-none"
       />
 
-      <div className={`relative ${fullWidth ? 'text-center' : 'max-w-screen-xl mx-auto text-center'} z-20`}>
-        <div className="mb-6 text-center">
-          <h2 className="text-2xl font-[barrio] sm:text-4xl font-bold text-gray-700">
-            Upcoming Festivals, Fairs, and Philly Traditions
-          </h2>
-        </div>
-
-        {loading ? (
-          <p className="text-center">Loading…</p>
-        ) : !events.length ? (
-          <p className="text-center">No upcoming traditions.</p>
-        ) : (
-          <div className="overflow-x-auto scrollbar-hide">
-            <div className="flex gap-4 pb-4">
-              {events.map(evt => {
-                const { text, color, pulse } = getBubble(evt.start, evt.isActive);
-                const showWeekendBadge =
-                  isThisWeekend(evt.start) && [5, 6, 0].includes(evt.start.getDay());
-
-                return (
-                  <FavoriteState
-                    key={evt.id}
-                    event_id={evt.id}
-                    source_table="events"
-                  >
-                    {({ isFavorite, toggleFavorite, loading }) => {
-                      const handleToggle = async e => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        if (!user) {
-                          navigate('/login');
-                          return;
-                        }
-                        await toggleFavorite();
-                      };
-                      return (
-                        <div className="w-[260px] flex-shrink-0">
-                          <Link
-                            to={getDetailPathForItem(evt) || '/'}
-                            className={`relative block h-[380px] rounded-2xl overflow-hidden shadow-lg transition ${isFavorite ? 'ring-2 ring-indigo-600' : ''}`}
-                          >
-                            <img
-                              src={evt['E Image']}
-                              alt={evt['E Name']}
-                              className="absolute inset-0 w-full h-full object-cover"
-                            />
-                            <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent z-10" />
-
-                            {showWeekendBadge && (
-                              <span className="absolute top-3 left-3 bg-yellow-400 text-black text-xs font-bold px-2 py-1 rounded-full z-20">
-                                Weekend Pick
-                              </span>
-                            )}
-
-                            {isFavorite && (
-                              <div className="absolute top-3 right-3 bg-indigo-600 text-white text-xs px-2 py-1 rounded z-20">
-                                In the plans!
-                              </div>
-                            )}
-
-                            <h3 className="absolute bottom-16 left-4 right-4 text-center text-white text-3xl font-[Barrio] font-bold z-20 leading-tight">
-                              {evt['E Name']}
-                            </h3>
-
-                            <span
-                              className={`absolute bottom-6 left-1/2 transform -translate-x-1/2 ${color} text-white text-base font-bold px-6 py-1 rounded-full whitespace-nowrap min-w-[6rem] ${pulse ? 'animate-pulse' : ''} z-20`}
-                            >
-                              {text}
-                            </span>
-                          </Link>
-                          <button
-                            onClick={handleToggle}
-                            disabled={loading}
-                            className={`mt-2 w-full border border-indigo-600 rounded-md py-2 font-semibold transition-colors ${
-                              isFavorite
-                                ? 'bg-indigo-600 text-white'
-                                : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'
-                            }`}
-                          >
-                            {isFavorite ? 'In the Plans' : 'Add to Plans'}
-                          </button>
-                        </div>
-                      );
-                    }}
-                  </FavoriteState>
-                );
-              })}
-            </div>
+      <div className="relative z-20">
+        <div className={`mx-auto max-w-screen-xl ${fullWidth ? 'px-4' : ''}`}>
+          <div className="mb-10 space-y-3 text-left">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+              City traditions
+            </p>
+            <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+              Upcoming Festivals, Fairs, and Philly Traditions
+            </h2>
+            <p className="max-w-2xl text-sm text-gray-600 sm:text-base">
+              Line up your calendar with the parades, cultural festivals, and can't-miss Philly traditions happening soon.
+            </p>
           </div>
-        )}
+
+          {loading ? (
+            <p className="text-left text-gray-600">Loading…</p>
+          ) : !events.length ? (
+            <p className="text-left text-gray-600">No upcoming traditions.</p>
+          ) : (
+            <div className="overflow-x-auto pb-4 scrollbar-hide">
+              <div className="flex gap-4">
+                {events.map(evt => {
+                  const { text, color, pulse } = getBubble(evt.start, evt.isActive);
+                  const showWeekendBadge =
+                    isThisWeekend(evt.start) && [5, 6, 0].includes(evt.start.getDay());
+
+                  return (
+                    <FavoriteState
+                      key={evt.id}
+                      event_id={evt.id}
+                      source_table="events"
+                    >
+                      {({ isFavorite, toggleFavorite, loading }) => {
+                        const handleToggle = async e => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          if (!user) {
+                            navigate('/login');
+                            return;
+                          }
+                          await toggleFavorite();
+                        };
+                        return (
+                          <div className="w-[260px] flex-shrink-0">
+                            <Link
+                              to={getDetailPathForItem(evt) || '/'}
+                              className={`relative block h-[380px] rounded-2xl overflow-hidden shadow-lg transition ${isFavorite ? 'ring-2 ring-indigo-600' : ''}`}
+                            >
+                              <img
+                                src={evt['E Image']}
+                                alt={evt['E Name']}
+                                className="absolute inset-0 w-full h-full object-cover"
+                              />
+                              <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent z-10" />
+
+                              {showWeekendBadge && (
+                                <span className="absolute top-3 left-3 bg-yellow-400 text-black text-xs font-bold px-2 py-1 rounded-full z-20">
+                                  Weekend Pick
+                                </span>
+                              )}
+
+                              {isFavorite && (
+                                <div className="absolute top-3 right-3 bg-indigo-600 text-white text-xs px-2 py-1 rounded z-20">
+                                  In the plans!
+                                </div>
+                              )}
+
+                              <h3 className="absolute bottom-16 left-4 right-4 text-center text-white text-3xl font-[Barrio] font-bold z-20 leading-tight">
+                                {evt['E Name']}
+                              </h3>
+
+                              <span
+                                className={`absolute bottom-6 left-1/2 transform -translate-x-1/2 ${color} text-white text-base font-bold px-6 py-1 rounded-full whitespace-nowrap min-w-[6rem] ${pulse ? 'animate-pulse' : ''} z-20`}
+                              >
+                                {text}
+                              </span>
+                            </Link>
+                            <button
+                              onClick={handleToggle}
+                              disabled={loading}
+                              className={`mt-2 w-full border border-indigo-600 rounded-md py-2 font-semibold transition-colors ${
+                                isFavorite
+                                  ? 'bg-indigo-600 text-white'
+                                  : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'
+                              }`}
+                            >
+                              {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                            </button>
+                          </div>
+                        );
+                      }}
+                    </FavoriteState>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </section>
   );

--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -77,6 +77,26 @@ const popularTags = [
   { slug: 'arts', label: 'arts' },
 ];
 
+const taggedScrollerConfigs = [
+  {
+    slug: 'birds',
+    eyebrow: 'Seasonal Tag',
+    headline: 'Next in #Birds',
+  },
+  {
+    slug: 'arts',
+    eyebrow: 'Tag highlight',
+    headline: 'Next in Arts',
+    description: 'Plot out gallery walks, performances, and creative nights across the city.',
+  },
+  {
+    slug: 'nomnomslurp',
+    eyebrow: 'Tag highlight',
+    headline: 'Next in #NomNomSlurp',
+    description: 'Keep tabs on pop-ups, tastings, and foodie meetups worth savoring next.',
+  },
+];
+
 
 // ── Helpers ───────────────────────────────
 function parseISODateLocal(str) {
@@ -712,6 +732,29 @@ const hasFilters = selectedTags.length > 0 || selectedOption !== 'today';
   const [profileMap, setProfileMap] = useState({});
   const [savedEvents, setSavedEvents] = useState([]);
   const [loadingSaved, setLoadingSaved] = useState(true);
+
+  const savedPlansDescription = useMemo(() => {
+    if (loadingSaved) {
+      return 'Loading your saved plans…';
+    }
+
+    if (!user) {
+      return (
+        <>
+          <Link to="/login" className="text-indigo-600 underline">
+            Log in
+          </Link>{' '}
+          to add events to your plans.
+        </>
+      );
+    }
+
+    if (!savedEvents.length) {
+      return "You don't have any plans yet! Add some to get started.";
+    }
+
+    return 'A quick look at the events you have coming up next.';
+  }, [loadingSaved, user, savedEvents.length]);
 
   useEffect(() => {
     if (!user) {
@@ -1668,7 +1711,15 @@ if (loading) {
             />
 
             <main className="container mx-auto px-4 py-8">
-              <h2 className="text-3xl font-semibold mb-4 text-[#28313e]">{headerText}</h2>
+              <div className="mb-8 space-y-3 text-left">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                  Make Your Philly Plans
+                </p>
+                <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                  Upcoming Plans, Festivals, and Philly Traditions
+                </h2>
+                <p className="text-sm text-gray-600 sm:text-base">{headerText}</p>
+              </div>
 
               {!loading && (
                 <>
@@ -2021,43 +2072,54 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
               </div>
             </section>
             <section className="w-full max-w-screen-xl mx-auto mt-12 mb-12 px-4">
-              <h2 className="text-black text-4xl font-[Barrio] mb-4 text-left">
-                Your Upcoming Plans
-              </h2>
-              {loadingSaved ? null : user ? (
-                savedEvents.length ? (
-                  <>
-                    <SavedEventsScroller events={savedEvents} />
-                    <p className="text-gray-600 mt-2">
-                      <Link to="/profile" className="text-indigo-600 underline">
-                        See more plans on your profile
-                      </Link>
-                    </p>
-                  </>
-                ) : (
-                  <p className="text-gray-600">
-                    You don't have any plans yet! Add some to get started.
-                  </p>
-                )
-              ) : (
-                <p className="text-gray-600">
-                  <Link to="/login" className="text-indigo-600 underline">Log in</Link> to add events to your plans.
+              <div className="space-y-3 text-left mb-6">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                  Saved agenda
                 </p>
+                <h2 className="text-black text-4xl font-[Barrio] text-left">
+                  Your Upcoming Plans
+                </h2>
+                <p className="text-sm text-gray-600 sm:text-base">{savedPlansDescription}</p>
+              </div>
+              {!loadingSaved && user && savedEvents.length > 0 && (
+                <>
+                  <SavedEventsScroller events={savedEvents} />
+                  <p className="text-gray-600 mt-2">
+                    <Link to="/profile" className="text-indigo-600 underline">
+                      See more plans on your profile
+                    </Link>
+                  </p>
+                </>
               )}
             </section>
             <HeroLanding fullWidth />
-            <TaggedEventScroller
-              tags={['birds']}
-              fullWidth
-              header={
-                <Link
-                  to="/tags/birds"
-                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#FFD700] bg-[#FFD700] text-[#004C55] rounded-full"
-                >
-                  #Birds
-                </Link>
-              }
-            />
+            {taggedScrollerConfigs.map(({ slug, eyebrow, headline, description }) => (
+              <TaggedEventScroller
+                key={slug}
+                tags={[slug]}
+                fullWidth
+                header={
+                  <Link
+                    to={`/tags/${slug}`}
+                    className="block w-full max-w-screen-xl mx-auto px-4 mb-6 space-y-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                  >
+                    {eyebrow && (
+                      <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                        {eyebrow}
+                      </p>
+                    )}
+                    <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                      {headline}
+                    </h2>
+                    {description && (
+                      <p className="text-sm text-gray-600 sm:text-base">
+                        {description}
+                      </p>
+                    )}
+                  </Link>
+                }
+              />
+            ))}
             <section className="px-4 mt-12 mb-8">
               <Link to="/philadelphia-events/" className="block group">
                 <div className="max-w-screen-xl mx-auto">
@@ -2080,31 +2142,24 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
                 </div>
               </Link>
             </section>
-            <TaggedEventScroller
-              tags={['arts']}
-              fullWidth
-              header={
-                <Link
-                  to="/tags/arts"
-                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
-                >
-                  #Arts
-                </Link>
-              }
+            <RecurringEventsScroller
+              windowStart={startOfWeek}
+              windowEnd={endOfWeek}
+              eventType="open_mic"
+              header={(
+                <div className="max-w-screen-xl mx-auto px-4 space-y-3 text-left mb-6">
+                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                    Weekly regulars
+                  </p>
+                  <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                    Karaoke, Bingo, Open Mics & Other Weeklies
+                  </h2>
+                  <p className="text-sm text-gray-600 sm:text-base">
+                    Drop into rotating open mics, karaoke nights, and game sessions that come back every week.
+                  </p>
+                </div>
+              )}
             />
-            <TaggedEventScroller
-              tags={['nomnomslurp']}
-              fullWidth
-              header={
-                <Link
-                  to="/tags/nomnomslurp"
-                  className="text-3xl sm:text-5xl font-[Barrio] px-6 py-2 border-4 border-[#004C55] bg-[#d9e9ea] text-[#004C55] rounded-full hover:bg-gray-100"
-                >
-                  #NomNomSlurp
-                </Link>
-              }
-            />
-            <RecurringEventsScroller windowStart={startOfWeek} windowEnd={endOfWeek} eventType="open_mic" header="Karaoke, Bingo, Open Mics Coming Up..." />
 
           </div>
 

--- a/src/RecurringEventsScroller.jsx
+++ b/src/RecurringEventsScroller.jsx
@@ -101,7 +101,13 @@ export default function RecurringEventsScroller({
 
   return (
     <section className="py-8">
-      <h2 className="text-3xl font-[Barrio] font-bold text-center mb-6">{header}</h2>
+      {header ? (
+        typeof header === 'string' ? (
+          <h2 className="text-3xl font-[Barrio] font-bold text-center mb-6">{header}</h2>
+        ) : (
+          header
+        )
+      ) : null}
 
       {/* Filters: horizontally scrollable on mobile */}
       <div className="overflow-x-auto scrollbar-hide px-4 mb-8">


### PR DESCRIPTION
## Summary
- restyle the traditions hero header to use the shared left-aligned eyebrow, headline, and description layout while keeping the full-width presentation aligned with the page grid
- add the requested hashtag treatment to the Birds and NomNomSlurp seasonal scroller titles while only labeling the true seasonal carousel with the “Seasonal Tag” eyebrow and supplying highlight copy for the other tag carousels

## Testing
- npm run lint *(fails: repo lint script still passes the unsupported --ext flag with the flat ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68cf083dff9c832c8095469543ded3fd