### PR TITLE
Add promoted event hero and cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,13 +32,15 @@ import GroupProgressBar from './GroupProgressBar';
 import PlatformPromoBillboard from './PlatformPromoBillboard';
 import GroupRecommender from './components/GroupRecommender';
 import EventsGrid from './EventsGrid';
-import SeasonalEventsGrid from './SeasonalEvents'; 
+import SeasonalEventsGrid from './SeasonalEvents';
 import Bulletin from './Bulletin';
 import NewsletterBar from './NewsletterBar';
 import RecentActivity from './RecentActivity';
 import BigBoardEventsGrid from './BigBoardEventsGrid';
 import CityHolidayAlert from './CityHolidayAlert';
 import MoreEventsBanner from './MoreEventsBanner';
+import PromotedEventHero from './PromotedEventHero';
+import { usePromotedEvent } from './utils/usePromotedEvent';
 
 
 
@@ -51,6 +53,7 @@ function App() {
   const [allGroups, setAllGroups] = useState([]);
   const [typeCounts, setTypeCounts] = useState({});
   const [isAdmin, setIsAdmin] = useState(false);
+  const { promotedEvent } = usePromotedEvent();
 
   useEffect(() => {
     async function loadGroups() {
@@ -127,11 +130,12 @@ function App() {
      
       
       <div className="overflow-x-hidden  min-h-screen flex flex-col bg-white-100 pt-20 relative">
-        <Navbar /> 
+        <Navbar />
         <CityHolidayAlert />
+        <PromotedEventHero event={promotedEvent} pageName="home" className="mt-6" />
 
 
-          
+
 <div className="relative flex flex-col md:flex-row items-center justify-center mt-12 mb-1">
   {/* we need a positioning context for the line + mascot */}
   <div className="relative inline-block text-center">

--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -44,6 +44,8 @@ import { FaStar } from 'react-icons/fa';
 import FallingPills from './FallingPills';
 import SavedEventsScroller from './SavedEventsScroller';
 import { COMMUNITY_REGIONS } from './communityIndexData.js';
+import PromotedEventCard from './PromotedEventCard';
+import { usePromotedEvent } from './utils/usePromotedEvent';
 import {
   getWeekendWindow,
   PHILLY_TIME_ZONE,
@@ -292,6 +294,7 @@ export default function MainEvents() {
   const params = useParams();
   const navigate = useNavigate();
   const { user } = useContext(AuthContext);
+  const { promotedEvent } = usePromotedEvent();
 
   const weekendBaseRef = useRef({
     loaded: false,
@@ -1348,14 +1351,32 @@ useEffect(() => {
 }, [selectedOption, customDate, params.view, sportsEventsRaw]);
 
 
+  const promotedEventId = promotedEvent ? String(promotedEvent.id) : null;
+
+  const displayTraditionEvents = useMemo(
+    () =>
+      promotedEventId
+        ? traditionEvents.filter(evt => String(evt.id) !== promotedEventId)
+        : traditionEvents,
+    [traditionEvents, promotedEventId]
+  );
+
+  const displayPrimaryEvents = useMemo(
+    () =>
+      promotedEventId
+        ? events.filter(evt => String(evt.id) !== promotedEventId)
+        : events,
+    [events, promotedEventId]
+  );
+
   // Combine all events
   const combinedEvents = [
     ...sportsEvents,
     ...bigBoardEvents,
     ...groupEvents,
     ...recurringOccs,
-    ...traditionEvents,
-    ...events
+    ...displayTraditionEvents,
+    ...displayPrimaryEvents
   ];
 
   // Filter by selected tags
@@ -1524,7 +1545,7 @@ if (!loading) {
   }
 }
 // how many of our results are “traditions”?
-const traditionsCount = traditionEvents.length;
+const traditionsCount = displayTraditionEvents.length;
 
 // after you’ve calculated headerDateStr and traditionsCount…
 let headerText
@@ -1759,6 +1780,12 @@ if (!loading) {
                 </h2>
                 <p className="text-sm text-gray-600 sm:text-base">{headerText}</p>
               </div>
+
+              <PromotedEventCard
+                event={promotedEvent}
+                pageName={selectedOption || 'list'}
+                className="mb-12"
+              />
 
               {!loading && (
                 <>

--- a/src/PromotedEventCard.jsx
+++ b/src/PromotedEventCard.jsx
@@ -1,0 +1,186 @@
+import React, { useContext, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from './AuthProvider';
+import useEventFavorite from './utils/useEventFavorite';
+import {
+  trackPromotedEventImpression,
+  trackPromotedEventClick,
+} from './utils/analytics';
+import { ensureAbsoluteUrl, DEFAULT_OG_IMAGE } from './utils/seoHelpers';
+
+function formatDateLine(date) {
+  if (!date || Number.isNaN(date.getTime())) return '';
+  const weekday = date.toLocaleDateString('en-US', { weekday: 'short' });
+  const month = date.toLocaleDateString('en-US', { month: 'short' });
+  const day = date.toLocaleDateString('en-US', { day: 'numeric' });
+  return `${weekday}, ${month} ${day}`;
+}
+
+function stripMeridiem(value) {
+  if (!value) return '';
+  return value.replace(/\s?(AM|PM)$/i, '');
+}
+
+function formatSingleTime(date) {
+  if (!date || Number.isNaN(date.getTime())) return '';
+  return date
+    .toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+    .replace(':00', '')
+    .replace(' a.m.', ' AM')
+    .replace(' p.m.', ' PM');
+}
+
+function formatTimeRange(start, end) {
+  const startLabel = start ? formatSingleTime(start) : '';
+  const endLabel = end ? formatSingleTime(end) : '';
+  if (!startLabel && !endLabel) return '';
+  if (startLabel && !endLabel) return startLabel;
+  if (!startLabel && endLabel) return endLabel;
+  const startMeridiem = /AM|PM$/i.exec(startLabel)?.[0] || '';
+  const endMeridiem = /AM|PM$/i.exec(endLabel)?.[0] || '';
+  if (startMeridiem && endMeridiem && startMeridiem === endMeridiem) {
+    return `${stripMeridiem(startLabel)}–${endLabel}`;
+  }
+  return `${startLabel} – ${endLabel}`;
+}
+
+function buildDateTimeSummary(event) {
+  const dateLine = formatDateLine(event.startDateTime || event.startDate);
+  const timeLine = formatTimeRange(event.startDateTime, event.endDateTime);
+  if (dateLine && timeLine) return `${dateLine} • ${timeLine}`;
+  return dateLine || timeLine || '';
+}
+
+function resolveLocation(event) {
+  if (event.venueName && event.venueAddress) {
+    return `${event.venueName}, ${event.venueAddress}`;
+  }
+  return event.venueName || event.venueAddress || '';
+}
+
+function resolveLearnMore(event) {
+  if (event.detailPath) {
+    return {
+      Component: Link,
+      props: { to: event.detailPath },
+    };
+  }
+  if (event.externalUrl) {
+    return {
+      Component: 'a',
+      props: {
+        href: event.externalUrl,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      },
+    };
+  }
+  return { Component: 'span', props: { 'aria-disabled': true } };
+}
+
+export default function PromotedEventCard({ event, pageName = 'list', className = '' }) {
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const { isFavorite, toggleFavorite, loading } = useEventFavorite({
+    event_id: event?.id,
+    source_table: 'events',
+  });
+
+  useEffect(() => {
+    if (!event?.id) return;
+    trackPromotedEventImpression({ page: pageName, position: 'card', eventId: event.id });
+  }, [event?.id, pageName]);
+
+  if (!event) return null;
+
+  const learnMore = resolveLearnMore(event);
+  const learnMoreDisabled = learnMore.Component === 'span';
+  const dateSummary = buildDateTimeSummary(event);
+  const locationSummary = resolveLocation(event);
+  const imageUrl = ensureAbsoluteUrl(event.imageUrl) || event.imageUrl || DEFAULT_OG_IMAGE;
+
+  const handleAddToPlans = e => {
+    e.preventDefault();
+    if (!event?.id) return;
+    if (!user) {
+      navigate('/login');
+      return;
+    }
+    trackPromotedEventClick({ cta: 'add_to_plans', eventId: event.id });
+    toggleFavorite();
+  };
+
+  const handleLearnMoreClick = () => {
+    if (!event?.id || learnMoreDisabled) return;
+    trackPromotedEventClick({ cta: 'learn_more', eventId: event.id });
+  };
+
+  return (
+    <article
+      className={`relative overflow-hidden rounded-3xl border border-indigo-100 bg-indigo-50 shadow-lg transition ${className}`.trim()}
+    >
+      <div className="flex flex-col md:flex-row">
+        <div className="flex-1 space-y-4 p-6 md:p-8">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">Featured Tradition</p>
+            <h3 className="text-3xl font-[Barrio] text-indigo-900">{event.headline || event.title}</h3>
+          </div>
+          <div className="space-y-3">
+            {event.title && (
+              <learnMore.Component
+                {...learnMore.props}
+                onClick={handleLearnMoreClick}
+                className={`inline-block text-xl font-semibold text-indigo-900 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 ${
+                  learnMoreDisabled ? 'pointer-events-none opacity-70' : ''
+                }`}
+              >
+                {event.title}
+              </learnMore.Component>
+            )}
+            {dateSummary && <p className="text-base font-medium text-indigo-900">{dateSummary}</p>}
+            {locationSummary && <p className="text-sm text-indigo-800/90">{locationSummary}</p>}
+            {(event.summary || event.fullSummary) && (
+              <p className="text-sm text-indigo-900/80 md:text-base">{event.summary || event.fullSummary}</p>
+            )}
+            {event.nationality && (
+              <span className="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1 text-xs font-semibold text-indigo-900">
+                {event.nationalityEmoji && <span aria-hidden="true">{event.nationalityEmoji}</span>}
+                <span>{event.nationality}</span>
+              </span>
+            )}
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            {!learnMoreDisabled && (
+              <learnMore.Component
+                {...learnMore.props}
+                onClick={handleLearnMoreClick}
+                className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+              >
+                Learn More
+              </learnMore.Component>
+            )}
+            <button
+              type="button"
+              onClick={handleAddToPlans}
+              disabled={loading}
+              className={`inline-flex items-center justify-center rounded-full border-2 border-indigo-600 px-5 py-2.5 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 ${
+                isFavorite ? 'bg-indigo-600 text-white' : 'text-indigo-600 hover:bg-indigo-50'
+              } ${loading ? 'opacity-70' : ''}`}
+            >
+              {isFavorite ? 'In the Plans' : 'Add to Plans'}
+            </button>
+          </div>
+        </div>
+        <div className="relative h-64 w-full md:h-auto md:w-80">
+          <img
+            src={imageUrl}
+            alt={event.headline || event.title}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        </div>
+      </div>
+    </article>
+  );
+}
+

--- a/src/PromotedEventHero.jsx
+++ b/src/PromotedEventHero.jsx
@@ -1,0 +1,268 @@
+import React, { useContext, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import { AuthContext } from './AuthProvider';
+import useEventFavorite from './utils/useEventFavorite';
+import {
+  trackPromotedEventImpression,
+  trackPromotedEventClick,
+  trackPromotedRelatedGroupClick,
+} from './utils/analytics';
+import {
+  ensureAbsoluteUrl,
+  DEFAULT_OG_IMAGE,
+  buildEventJsonLd,
+} from './utils/seoHelpers';
+
+function formatDateLine(startDate) {
+  if (!startDate || Number.isNaN(startDate.getTime())) return '';
+  const weekday = startDate.toLocaleDateString('en-US', { weekday: 'short' });
+  const month = startDate.toLocaleDateString('en-US', { month: 'short' });
+  const day = startDate.toLocaleDateString('en-US', { day: 'numeric' });
+  return `${weekday}, ${month} ${day}`;
+}
+
+function stripMeridiem(value) {
+  if (!value) return '';
+  return value.replace(/\s?(AM|PM)$/i, '');
+}
+
+function formatSingleTime(date) {
+  if (!date || Number.isNaN(date.getTime())) return '';
+  return date
+    .toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+    .replace(':00', '')
+    .replace(' a.m.', ' AM')
+    .replace(' p.m.', ' PM');
+}
+
+function formatTimeRange(start, end) {
+  const startLabel = start ? formatSingleTime(start) : '';
+  const endLabel = end ? formatSingleTime(end) : '';
+  if (!startLabel && !endLabel) return '';
+  if (startLabel && !endLabel) return startLabel;
+  if (!startLabel && endLabel) return endLabel;
+  const startMeridiem = /AM|PM$/i.exec(startLabel)?.[0] || '';
+  const endMeridiem = /AM|PM$/i.exec(endLabel)?.[0] || '';
+  if (startMeridiem && endMeridiem && startMeridiem === endMeridiem) {
+    return `${stripMeridiem(startLabel)}–${endLabel}`;
+  }
+  return `${startLabel} – ${endLabel}`;
+}
+
+function buildDateTimeSummary(event) {
+  const dateLine = formatDateLine(event.startDateTime || event.startDate);
+  const timeLine = formatTimeRange(event.startDateTime, event.endDateTime);
+  if (dateLine && timeLine) return `${dateLine} • ${timeLine}`;
+  return dateLine || timeLine || '';
+}
+
+function resolveLocation(event) {
+  if (event.venueName && event.venueAddress) {
+    return `${event.venueName}, ${event.venueAddress}`;
+  }
+  return event.venueName || event.venueAddress || '';
+}
+
+function resolveLearnMore(event) {
+  if (event.detailPath) {
+    return {
+      Component: Link,
+      props: { to: event.detailPath },
+      isExternal: false,
+    };
+  }
+  if (event.externalUrl) {
+    return {
+      Component: 'a',
+      props: {
+        href: event.externalUrl,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      },
+      isExternal: true,
+    };
+  }
+  return { Component: 'span', props: { 'aria-disabled': true }, isExternal: false };
+}
+
+export default function PromotedEventHero({ event, pageName = 'home', className = '', enableSeo = true }) {
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const { isFavorite, toggleFavorite, loading } = useEventFavorite({
+    event_id: event?.id,
+    source_table: 'events',
+  });
+
+  useEffect(() => {
+    if (!event?.id) return;
+    trackPromotedEventImpression({ page: pageName, position: 'hero', eventId: event.id });
+  }, [event?.id, pageName]);
+
+  if (!event) return null;
+
+  const learnMore = resolveLearnMore(event);
+  const learnMoreDisabled = learnMore.Component === 'span';
+  const metaDescription = event.fullSummary || event.summary || '';
+  const heroImage = ensureAbsoluteUrl(event.imageUrl) || event.imageUrl || DEFAULT_OG_IMAGE;
+  const canonicalUrl = event.canonicalUrl || ensureAbsoluteUrl(event.learnMoreUrl || event.detailPath || event.externalUrl);
+  const dateSummary = buildDateTimeSummary(event);
+  const locationSummary = resolveLocation(event);
+  const jsonLd = enableSeo
+    ? buildEventJsonLd({
+        name: event.title,
+        canonicalUrl: canonicalUrl || undefined,
+        startDate: event.startDateTime || event.startDate,
+        endDate: event.endDateTime || event.endDate || event.startDate,
+        locationName: locationSummary,
+        description: metaDescription,
+        image: heroImage,
+      })
+    : null;
+
+  const handleAddToPlans = e => {
+    e.preventDefault();
+    if (!event?.id) return;
+    if (!user) {
+      navigate('/login');
+      return;
+    }
+    trackPromotedEventClick({ cta: 'add_to_plans', eventId: event.id });
+    toggleFavorite();
+  };
+
+  const handleLearnMoreClick = () => {
+    if (!event?.id || learnMoreDisabled) return;
+    trackPromotedEventClick({ cta: 'learn_more', eventId: event.id });
+  };
+
+  return (
+    <section
+      className={`relative isolate overflow-hidden bg-slate-950 text-white ${className}`.trim()}
+      style={{ marginInline: 'calc(50% - 50vw)', width: '100vw' }}
+    >
+      {enableSeo && (
+        <Helmet>
+          {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
+          <meta property="og:title" content={event.title} />
+          {metaDescription && <meta property="og:description" content={metaDescription} />}
+          <meta property="og:image" content={heroImage || DEFAULT_OG_IMAGE} />
+          {metaDescription && <meta name="description" content={metaDescription} />}
+          {jsonLd && (
+            <script type="application/ld+json" key="promoted-event-jsonld">
+              {JSON.stringify(jsonLd)}
+            </script>
+          )}
+        </Helmet>
+      )}
+      <div className="relative flex w-full flex-col justify-end">
+        <div className="absolute inset-0">
+          <img
+            src={heroImage || DEFAULT_OG_IMAGE}
+            alt={event.headline || event.title}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-black/10" />
+        </div>
+        <div className="relative z-10 mx-auto flex w-full max-w-screen-xl flex-col gap-10 px-4 py-20 sm:px-6 md:flex-row md:items-end md:gap-12 md:py-24">
+          <div className="flex-1 space-y-6">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/80">Featured Tradition</p>
+              <h2 className="text-4xl font-[Barrio] text-white sm:text-5xl">{event.headline || event.title}</h2>
+            </div>
+            <div className="space-y-3 text-white/90">
+              {event.title && (
+                <learnMore.Component
+                  {...learnMore.props}
+                  onClick={handleLearnMoreClick}
+                  className={`block text-2xl font-semibold text-white hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${
+                    learnMoreDisabled ? 'pointer-events-none opacity-80' : ''
+                  }`}
+                >
+                  {event.title}
+                </learnMore.Component>
+              )}
+              {dateSummary && <p className="text-lg font-medium">{dateSummary}</p>}
+              {locationSummary && <p className="text-base text-white/80">{locationSummary}</p>}
+              {(event.summary || event.fullSummary) && (
+                <p className="max-w-2xl text-base text-white/80 md:text-lg">{event.summary || event.fullSummary}</p>
+              )}
+              {event.nationality && (
+                <span className="inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-sm font-semibold text-white/90">
+                  {event.nationalityEmoji && <span aria-hidden="true">{event.nationalityEmoji}</span>}
+                  <span>{event.nationality}</span>
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              {!learnMoreDisabled && (
+                <learnMore.Component
+                  {...learnMore.props}
+                  onClick={handleLearnMoreClick}
+                  className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 transition hover:bg-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                >
+                  Learn More
+                </learnMore.Component>
+              )}
+              <button
+                type="button"
+                onClick={handleAddToPlans}
+                disabled={loading}
+                className={`inline-flex items-center justify-center rounded-full border-2 border-white px-6 py-3 text-base font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${
+                  isFavorite ? 'bg-white/20 text-white' : 'text-white hover:bg-white/10'
+                } ${loading ? 'opacity-70' : ''}`}
+              >
+                {isFavorite ? 'In the Plans' : 'Add to Plans'}
+              </button>
+            </div>
+          </div>
+          <div className="w-full max-w-md self-stretch overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur-lg md:max-w-sm">
+            <div className="space-y-3 text-sm text-white/80">
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">Event Snapshot</p>
+              {dateSummary && <p className="text-base">{dateSummary}</p>}
+              {locationSummary && <p>{locationSummary}</p>}
+              {(event.summary || event.fullSummary) && <p>{event.summary || event.fullSummary}</p>}
+            </div>
+          </div>
+        </div>
+        {event.relatedGroups && event.relatedGroups.length > 0 && event.nationality && (
+          <div className="relative z-10 border-t border-white/20 bg-black/40">
+            <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-4 px-4 py-6 sm:px-6">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <p className="text-sm font-semibold uppercase tracking-[0.25em] text-white/80">
+                  Explore {event.nationality} community groups →
+                </p>
+              </div>
+              <div className="flex gap-4 overflow-x-auto pb-2">
+                {event.relatedGroups.map(group => {
+                  if (!group?.slug) return null;
+                  const href = `/groups/${group.slug}`;
+                  const image = ensureAbsoluteUrl(group.imageUrl) || group.imageUrl || DEFAULT_OG_IMAGE;
+                  const handleClick = () =>
+                    trackPromotedRelatedGroupClick({ groupId: group.id, eventId: event.id });
+                  return (
+                    <Link
+                      key={group.id || group.slug}
+                      to={href}
+                      className="group flex min-w-[160px] flex-col items-center gap-3 rounded-2xl border border-white/20 bg-white/5 px-4 py-4 text-center transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                      onClick={handleClick}
+                    >
+                      <div className="h-14 w-14 overflow-hidden rounded-full border border-white/30 bg-white/20">
+                        <img src={image} alt={group.name || 'Community group'} className="h-full w-full object-cover" loading="lazy" />
+                      </div>
+                      <p className="text-sm font-semibold text-white group-hover:text-white">
+                        {group.name || 'View group'}
+                      </p>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -1,0 +1,50 @@
+function pushToDataLayer(eventName, payload = {}) {
+  const globalObj = typeof globalThis !== 'undefined' ? globalThis : undefined;
+  if (!globalObj) return;
+  const isProduction =
+    typeof import.meta !== 'undefined' &&
+    import.meta?.env?.MODE === 'production';
+  try {
+    if (Array.isArray(globalObj.dataLayer)) {
+      globalObj.dataLayer.push({ event: eventName, ...payload });
+      return;
+    }
+    if (typeof globalObj.gtag === 'function') {
+      globalObj.gtag('event', eventName, payload);
+      return;
+    }
+  } catch (error) {
+    if (typeof console !== 'undefined') {
+      console.error('Analytics dispatch failed', error);
+    }
+  }
+  if (!isProduction && typeof console !== 'undefined') {
+    console.debug(`[analytics] ${eventName}`, payload);
+  }
+}
+
+export function trackPromotedEventImpression({ page, position, eventId }) {
+  if (!eventId) return;
+  pushToDataLayer('promoted_event_impression', {
+    page,
+    position,
+    event_id: eventId,
+  });
+}
+
+export function trackPromotedEventClick({ cta, eventId }) {
+  if (!eventId) return;
+  pushToDataLayer('promoted_event_click', {
+    cta,
+    event_id: eventId,
+  });
+}
+
+export function trackPromotedRelatedGroupClick({ groupId, eventId }) {
+  if (!groupId || !eventId) return;
+  pushToDataLayer('promoted_related_group_click', {
+    group_id: groupId,
+    event_id: eventId,
+  });
+}
+

--- a/src/utils/promotedEvent.js
+++ b/src/utils/promotedEvent.js
@@ -1,0 +1,277 @@
+import { supabase } from '../supabaseClient';
+import {
+  PHILLY_TIME_ZONE,
+  getZonedDate,
+  parseEventDateValue,
+  setEndOfDay,
+} from './dateUtils';
+import { getDetailPathForItem } from './eventDetailPaths';
+import { ensureAbsoluteUrl, DEFAULT_OG_IMAGE, SITE_BASE_URL } from './seoHelpers';
+
+const CACHE_TTL_MS = 1000 * 60 * 3;
+
+let cachedValue = null;
+let cacheExpiresAt = 0;
+let inflightPromise = null;
+
+function normalizeText(value) {
+  if (!value) return '';
+  if (typeof value !== 'string') return String(value);
+  return value.trim();
+}
+
+function truncateText(text, maxLength = 200) {
+  if (!text) return '';
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  const truncated = trimmed.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  if (lastSpace > maxLength - 40) {
+    return `${truncated.slice(0, lastSpace)}…`;
+  }
+  return `${truncated}…`;
+}
+
+function parseTimeValue(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const ampmMatch = trimmed.match(/^(\d{1,2})(?::(\d{2}))?\s*(a\.?m\.?|p\.?m\.?)?$/i);
+  if (ampmMatch) {
+    let hours = Number(ampmMatch[1]);
+    const minutes = Number(ampmMatch[2] || '0');
+    const suffix = ampmMatch[3]?.toLowerCase();
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
+    if (suffix) {
+      const isPm = suffix.includes('p');
+      hours = hours % 12 + (isPm ? 12 : 0);
+    }
+    return { hours, minutes };
+  }
+
+  const twentyFourMatch = trimmed.match(/^(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?$/);
+  if (twentyFourMatch) {
+    const hours = Number(twentyFourMatch[1]);
+    const minutes = Number(twentyFourMatch[2] || '0');
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
+    return { hours, minutes };
+  }
+
+  return null;
+}
+
+function combineDateAndTime(date, timeString) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null;
+  const parts = parseTimeValue(timeString);
+  if (!parts) return new Date(date);
+  const combined = new Date(date);
+  combined.setHours(parts.hours, parts.minutes, 0, 0);
+  return combined;
+}
+
+function normalizeNationality(value) {
+  const text = normalizeText(value);
+  if (!text) return { label: null, emoji: null };
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  const lookup = normalized.toLowerCase();
+  const emojiMap = {
+    'puerto rican': '🇵🇷',
+    'mexican': '🇲🇽',
+    'irish': '🇮🇪',
+    'italian': '🇮🇹',
+    'german': '🇩🇪',
+    'polish': '🇵🇱',
+    'ukrainian': '🇺🇦',
+    'indian': '🇮🇳',
+    'chinese': '🇨🇳',
+    'japanese': '🇯🇵',
+    'korean': '🇰🇷',
+    'vietnamese': '🇻🇳',
+    'jamaican': '🇯🇲',
+    'dominican': '🇩🇴',
+    'haitian': '🇭🇹',
+    'nigerian': '🇳🇬',
+    'ethiopian': '🇪🇹',
+    'french': '🇫🇷',
+    'spanish': '🇪🇸',
+    'philippine': '🇵🇭',
+    'filipino': '🇵🇭',
+    'thai': '🇹🇭',
+    'cambodian': '🇰🇭',
+  };
+  const emoji = emojiMap[lookup] || null;
+  return { label: normalized, emoji };
+}
+
+function normalizeGroup(group) {
+  if (!group) return null;
+  return {
+    id: group.id,
+    name: normalizeText(group.Name || group.name),
+    slug: normalizeText(group.slug),
+    imageUrl: normalizeText(group.imag || group.image_url || ''),
+    nationality: normalizeText(group.Nationality || group.nationality || ''),
+  };
+}
+
+function normalizeEventRow(row) {
+  if (!row) return null;
+  const startRaw = row['E Start Date'] || row.Dates || row['Start Date'] || row.start_date;
+  const endRaw = row['E End Date'] || row['End Date'] || row.end_date || startRaw;
+  const startDate = parseEventDateValue(startRaw, PHILLY_TIME_ZONE);
+  const endDate = setEndOfDay(parseEventDateValue(endRaw, PHILLY_TIME_ZONE) || startDate || null);
+  if (!startDate) return null;
+
+  const startDateTime = combineDateAndTime(startDate, row['Start Time'] || row.start_time);
+  const endDateTime = combineDateAndTime(endDate || startDate, row['End Time'] || row.end_time);
+
+  const title = normalizeText(row['E Name'] || row.title || row.name);
+  const headline = normalizeText(row.Headline) || title;
+  const description = normalizeText(row['E Description'] || row.description || '');
+  const summary = normalizeText(row['E Summary']) || description;
+  const trimmedSummary = truncateText(summary || description || '', 200);
+  const detailPath = getDetailPathForItem(row);
+  const externalUrl = normalizeText(row['E Link'] || row.link || '');
+  const learnMoreUrl = detailPath || externalUrl || null;
+  const canonicalUrl = ensureAbsoluteUrl(learnMoreUrl, SITE_BASE_URL);
+  const imageUrl = ensureAbsoluteUrl(row['E Image']) || normalizeText(row['E Image']) || DEFAULT_OG_IMAGE;
+  const venueName = normalizeText(row['Venue Name'] || row.venue_name || row.venue);
+  const venueAddress = normalizeText(row['Venue Address'] || row.venue_address || row.address);
+  const { label: nationality, emoji: nationalityEmoji } = normalizeNationality(row.Nationality || row.nationality);
+
+  return {
+    id: row.id,
+    slug: normalizeText(row.slug || row.event_slug),
+    title,
+    headline,
+    description,
+    summary: trimmedSummary,
+    fullSummary: summary || description,
+    startDate,
+    endDate,
+    startDateTime,
+    endDateTime,
+    startTimeLabel: normalizeText(row['Start Time'] || row.start_time),
+    endTimeLabel: normalizeText(row['End Time'] || row.end_time),
+    imageUrl: imageUrl || DEFAULT_OG_IMAGE,
+    venueName,
+    venueAddress,
+    nationality,
+    nationalityEmoji,
+    detailPath,
+    externalUrl,
+    learnMoreUrl,
+    canonicalUrl,
+    sourceRow: row,
+  };
+}
+
+function isUpcoming(event, now) {
+  if (!event) return false;
+  const start = event.startDateTime || event.startDate;
+  if (!start) return false;
+  return start.getTime() >= now.getTime();
+}
+
+export async function fetchPromotedEvent(forceRefresh = false) {
+  const now = Date.now();
+  if (!forceRefresh && cachedValue && cacheExpiresAt > now) {
+    return cachedValue;
+  }
+  if (!forceRefresh && inflightPromise) {
+    return inflightPromise;
+  }
+
+  inflightPromise = (async () => {
+    const nowInPhilly = getZonedDate(new Date(), PHILLY_TIME_ZONE);
+    const { data, error } = await supabase
+      .from('events')
+      .select(`
+        id,
+        slug,
+        "E Name",
+        "E Description",
+        "E Summary",
+        "E Start Date",
+        "E End Date",
+        "E Image",
+        "E Link",
+        "Venue Name",
+        "Venue Address",
+        Dates,
+        "End Date",
+        "Start Time",
+        "End Time",
+        Nationality,
+        Headline,
+        Promoted
+      `)
+      .eq('Promoted', 'Yes')
+      .order('Dates', { ascending: true })
+      .limit(12);
+
+    if (error) {
+      if (typeof console !== 'undefined') {
+        console.error('Failed to load promoted event', error);
+      }
+      cachedValue = null;
+      cacheExpiresAt = 0;
+      inflightPromise = null;
+      return null;
+    }
+
+    const normalized = (data || [])
+      .map(normalizeEventRow)
+      .filter(Boolean)
+      .filter(evt => isUpcoming(evt, nowInPhilly))
+      .sort((a, b) => {
+        const aStart = a.startDateTime || a.startDate || new Date(8640000000000000);
+        const bStart = b.startDateTime || b.startDate || new Date(8640000000000000);
+        return aStart.getTime() - bStart.getTime();
+      });
+
+    const nextEvent = normalized[0] || null;
+    if (!nextEvent) {
+      cachedValue = null;
+      cacheExpiresAt = now + CACHE_TTL_MS;
+      inflightPromise = null;
+      return null;
+    }
+
+    let relatedGroups = [];
+    if (nextEvent.nationality) {
+      const { data: groupsData, error: groupsError } = await supabase
+        .from('groups')
+        .select('id, Name, slug, imag, Nationality')
+        .ilike('Nationality', nextEvent.nationality);
+
+      if (!groupsError && Array.isArray(groupsData)) {
+        relatedGroups = groupsData.map(normalizeGroup).filter(Boolean).slice(0, 6);
+      }
+    }
+
+    const result = { ...nextEvent, relatedGroups };
+    cachedValue = result;
+    cacheExpiresAt = Date.now() + CACHE_TTL_MS;
+    inflightPromise = null;
+    return result;
+  })().catch(err => {
+    if (typeof console !== 'undefined') {
+      console.error('Failed to load promoted event', err);
+    }
+    cachedValue = null;
+    cacheExpiresAt = 0;
+    inflightPromise = null;
+    return null;
+  });
+
+  return inflightPromise;
+}
+
+export function clearPromotedEventCache() {
+  cachedValue = null;
+  cacheExpiresAt = 0;
+  inflightPromise = null;
+}
+

--- a/src/utils/usePromotedEvent.js
+++ b/src/utils/usePromotedEvent.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { fetchPromotedEvent } from './promotedEvent';
+
+export function usePromotedEvent() {
+  const [promotedEvent, setPromotedEvent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    fetchPromotedEvent()
+      .then(result => {
+        if (!active) return;
+        setPromotedEvent(result);
+        setError(null);
+        setLoading(false);
+      })
+      .catch(err => {
+        if (!active) return;
+        if (typeof console !== 'undefined') {
+          console.error('Failed to fetch promoted event', err);
+        }
+        setPromotedEvent(null);
+        setError(err);
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { promotedEvent, loading, error };
+}
+


### PR DESCRIPTION
## Summary
- add cached promoted-event fetching utilities along with analytics helpers and reusable hero/card components
- render the promoted hero on the home, weekend, and monthly pages with SEO metadata and community callouts when groups match
- inject the promoted-event card into main event listings while deduplicating the promoted entry from other data sources

## Testing
- `npx eslint src/PromotedEventHero.jsx src/PromotedEventCard.jsx src/utils/analytics.js src/utils/promotedEvent.js src/utils/usePromotedEvent.js src/App.jsx src/MainEvents.jsx src/ThisWeekendInPhiladelphia.jsx src/ThisMonthInPhiladelphia.jsx` *(fails: existing ESLint config cannot parse JSX and flags numerous pre-existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d13e73571c832cac99f98bf7d4dc58