### PR TITLE
Show featured tradition hero across guides

### DIFF
--- a/src/FeaturedTraditionHero.jsx
+++ b/src/FeaturedTraditionHero.jsx
@@ -1,0 +1,471 @@
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import { supabase } from './supabaseClient';
+import { AuthContext } from './AuthProvider';
+import useEventFavorite from './utils/useEventFavorite';
+import {
+  getDetailPathForItem,
+  getCanonicalUrlForItem,
+} from './utils/eventDetailPaths';
+import {
+  DEFAULT_OG_IMAGE,
+  SITE_BASE_URL,
+  ensureAbsoluteUrl,
+  buildEventJsonLd,
+  buildIsoDateTime,
+} from './utils/seoHelpers';
+import {
+  PHILLY_TIME_ZONE,
+  parseEventDateValue,
+  getZonedDate,
+  setStartOfDay,
+} from './utils/dateUtils';
+
+const HERO_MIN_HEIGHT = 'min-h-[420px] sm:min-h-[480px]';
+const HERO_INNER_SPACING =
+  'px-4 pt-28 pb-12 sm:px-6 sm:pt-32 sm:pb-14 lg:px-8 lg:pt-36 lg:pb-16';
+const FALLBACK_IMAGE = DEFAULT_OG_IMAGE;
+const SECTION_BG = 'bg-slate-950';
+
+function combineDateAndTime(date, timeStr) {
+  if (!date) return null;
+  if (!timeStr || typeof timeStr !== 'string') return new Date(date);
+  const [h, m = '0', s = '0'] = timeStr.split(':');
+  const hours = Number(h);
+  const minutes = Number(m);
+  const seconds = Number(s);
+  const combined = new Date(date);
+  if (!Number.isNaN(hours)) {
+    combined.setHours(hours, Number.isNaN(minutes) ? 0 : minutes, Number.isNaN(seconds) ? 0 : seconds, 0);
+  }
+  return combined;
+}
+
+function formatHeroDateTime(date, hasTime, timeZone = PHILLY_TIME_ZONE) {
+  if (!date) return '';
+  const opts = hasTime
+    ? {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      }
+    : {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+      };
+  try {
+    return new Intl.DateTimeFormat('en-US', { timeZone, ...opts }).format(date);
+  } catch {
+    return date.toLocaleString('en-US', opts);
+  }
+}
+
+function buildShortDescription(text, maxLength = 220) {
+  if (!text) return '';
+  const normalized = String(text).replace(/\s+/g, ' ').trim();
+  if (!normalized) return '';
+  if (normalized.length <= maxLength) return normalized;
+  const sliced = normalized.slice(0, maxLength - 1).trimEnd();
+  return `${sliced}\u2026`;
+}
+
+function getVenueLabel(event) {
+  if (!event) return '';
+  const candidates = [
+    event['Venue Name'],
+    event.venue_name,
+    event.venue,
+    event['E Address'],
+    event.address,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return '';
+}
+
+function getEventImage(event) {
+  if (!event) return null;
+  const candidates = [event['E Image'], event.image_url, event.image, event.cover_image];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function normalizeNationality(value) {
+  if (typeof value !== 'string') return '';
+  return value.trim();
+}
+
+const NATIONALITY_TAG_OVERRIDES = {
+  'Puerto Rican': 'Puerto Rico',
+};
+
+function formatNationalityTag(value) {
+  const normalized = normalizeNationality(value);
+  if (!normalized) return '';
+  return NATIONALITY_TAG_OVERRIDES[normalized] || normalized;
+}
+
+export default function FeaturedTraditionHero() {
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [event, setEvent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [groupMatches, setGroupMatches] = useState([]);
+
+  const favoriteState = useEventFavorite({ event_id: event?.id, source_table: 'events' });
+  const eventNationality = useMemo(() => normalizeNationality(event?.Nationality || event?.nationality), [event]);
+  const calloutTagLabel = useMemo(() => formatNationalityTag(eventNationality), [eventNationality]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadEvent() {
+      setLoading(true);
+      try {
+        const now = getZonedDate(new Date(), PHILLY_TIME_ZONE);
+        const startOfToday = setStartOfDay(new Date(now));
+
+        const { data, error } = await supabase
+          .from('events')
+          .select(`
+            id,
+            slug,
+            "E Name",
+            "E Description",
+            "E Image",
+            Dates,
+            "End Date",
+            address,
+            start_time,
+            end_time,
+            Nationality
+          `)
+          .eq('Promoted', 'Yes')
+          .order('Dates', { ascending: true, nullsFirst: false })
+          .order('start_time', { ascending: true, nullsFirst: true })
+          .limit(25);
+
+        if (error) throw error;
+        if (!isActive) return;
+
+        const upcoming = (data || [])
+          .map(item => {
+            const startDateRaw =
+              item?.Dates ?? item?.['Start Date'] ?? item?.['E Start Date'] ?? item?.start_date ?? null;
+            const startTimeRaw = item?.start_time ?? item?.time ?? item?.['Start Time'] ?? null;
+            const parsedStart = parseEventDateValue(startDateRaw, PHILLY_TIME_ZONE);
+            const startDateTime = parsedStart ? combineDateAndTime(parsedStart, startTimeRaw) || parsedStart : null;
+
+            return {
+              item,
+              startDate: parsedStart,
+              startDateTime,
+              startTimeRaw,
+            };
+          })
+          .filter(entry => entry.startDate && entry.startDateTime)
+          .filter(entry => {
+            if (!entry.startDate) return false;
+            if (entry.startTimeRaw) {
+              return entry.startDateTime.getTime() >= now.getTime();
+            }
+            return entry.startDate.getTime() >= startOfToday.getTime();
+          })
+          .sort((a, b) => a.startDateTime.getTime() - b.startDateTime.getTime());
+
+        const selected = upcoming[0]?.item ?? null;
+        setEvent(selected);
+      } catch (err) {
+        console.error('Failed to load featured tradition', err);
+        if (isActive) setEvent(null);
+      } finally {
+        if (isActive) setLoading(false);
+      }
+    }
+
+    loadEvent();
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!eventNationality) {
+      setGroupMatches([]);
+      return;
+    }
+
+    let isActive = true;
+    supabase
+      .from('groups')
+      .select('id, Name, slug, imag, Nationality')
+      .eq('Nationality', eventNationality)
+      .order('Name', { ascending: true })
+      .limit(6)
+      .then(({ data, error }) => {
+        if (!isActive) return;
+        if (error) {
+          console.error('Failed to load related groups', error);
+          setGroupMatches([]);
+          return;
+        }
+        const filtered = Array.isArray(data) ? data.filter(Boolean) : [];
+        setGroupMatches(filtered);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [eventNationality]);
+
+  const detailPath = useMemo(() => (event ? getDetailPathForItem(event) : null), [event]);
+  const canonicalUrl = useMemo(
+    () => (event ? getCanonicalUrlForItem(event, SITE_BASE_URL) : null),
+    [event]
+  );
+
+  const title = useMemo(() => {
+    if (!event) return '';
+    const candidates = [event['E Name'], event.name, event.title];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return candidate.trim();
+      }
+    }
+    return '';
+  }, [event]);
+
+  const description = useMemo(() => {
+    if (!event) return '';
+    const candidates = [event['E Description'], event.description, event.summary, event.notes];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return buildShortDescription(candidate);
+      }
+    }
+    return '';
+  }, [event]);
+
+  const imageUrl = useMemo(() => {
+    const raw = getEventImage(event);
+    return raw || FALLBACK_IMAGE;
+  }, [event]);
+
+  const absoluteImage = useMemo(() => ensureAbsoluteUrl(imageUrl) || FALLBACK_IMAGE, [imageUrl]);
+
+  const startDateRaw =
+    event?.Dates || event?.['Start Date'] || event?.['E Start Date'] || event?.start_date || null;
+  const startTimeRaw = event?.start_time || event?.time || event?.['Start Time'] || null;
+  const endDateRaw = event?.['End Date'] || event?.end_date || event?.['E End Date'] || null;
+  const endTimeRaw = event?.end_time || event?.['End Time'] || null;
+
+  const startDate = useMemo(() => parseEventDateValue(startDateRaw, PHILLY_TIME_ZONE), [startDateRaw]);
+  const endDate = useMemo(() => parseEventDateValue(endDateRaw, PHILLY_TIME_ZONE), [endDateRaw]);
+  const startDateTime = useMemo(() => combineDateAndTime(startDate, startTimeRaw), [startDate, startTimeRaw]);
+  const endDateTime = useMemo(() => combineDateAndTime(endDate, endTimeRaw), [endDate, endTimeRaw]);
+
+  const formattedDate = useMemo(() => {
+    if (startDateTime) return formatHeroDateTime(startDateTime, Boolean(startTimeRaw));
+    if (startDate) return formatHeroDateTime(startDate, false);
+    return '';
+  }, [startDateTime, startDate, startTimeRaw]);
+
+  const venueLabel = useMemo(() => getVenueLabel(event), [event]);
+
+  const ogTitle = title ? `${title} – Our Philly` : 'Our Philly';
+  const ogDescription = description || 'Discover Philadelphia traditions with Our Philly.';
+
+  const jsonLd = useMemo(() => {
+    if (!event || !title || !canonicalUrl) return null;
+    return buildEventJsonLd({
+      name: title,
+      canonicalUrl,
+      startDate: buildIsoDateTime(startDateRaw || startDateTime, startTimeRaw) || startDateTime || startDateRaw,
+      endDate: buildIsoDateTime(endDateRaw || endDateTime, endTimeRaw) || endDateTime || endDateRaw,
+      locationName: venueLabel,
+      description,
+      image: absoluteImage,
+    });
+  }, [
+    event,
+    title,
+    canonicalUrl,
+    startDateRaw,
+    startDateTime,
+    startTimeRaw,
+    endDateRaw,
+    endDateTime,
+    endTimeRaw,
+    venueLabel,
+    description,
+    absoluteImage,
+  ]);
+
+  if (loading) {
+    return (
+      <section className="w-full">
+        <div className={`relative w-full ${SECTION_BG} text-white`}>
+          <div className={`w-full ${HERO_MIN_HEIGHT} bg-slate-900/80 animate-pulse`} />
+        </div>
+      </section>
+    );
+  }
+
+  if (!event || !title || !detailPath) {
+    return null;
+  }
+
+  const handleFavoriteClick = async () => {
+    if (!event?.id) return;
+    if (!user) {
+      navigate('/login');
+      return;
+    }
+    await favoriteState.toggleFavorite();
+  };
+
+  const isFavorite = favoriteState.isFavorite;
+  const favoriteLoading = favoriteState.loading;
+
+  return (
+    <section className="w-full">
+      <div className={`relative isolate w-full overflow-hidden ${SECTION_BG} text-white`}>
+        <img
+          src={imageUrl}
+          alt={title}
+          loading="eager"
+          fetchPriority="high"
+          className={`absolute inset-0 h-full w-full object-cover ${HERO_MIN_HEIGHT}`}
+        />
+        <div className="absolute inset-0 bg-gradient-to-r from-slate-950 via-slate-950/80 to-slate-950/30" aria-hidden="true" />
+        <div className={`relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-8 ${HERO_INNER_SPACING} ${HERO_MIN_HEIGHT}`}>
+          <div className="max-w-2xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.35em] text-amber-300">Featured Tradition</p>
+            <h1 className="mt-3 text-4xl font-[Barrio] font-black tracking-tight text-white sm:text-5xl lg:text-6xl">
+              Mi Gentes!
+            </h1>
+          </div>
+          <div className="max-w-3xl space-y-4">
+            <Link
+              to={detailPath}
+              className="inline-flex items-center gap-2 text-3xl font-bold text-white transition hover:text-amber-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-amber-300 sm:text-4xl"
+            >
+              {title}
+            </Link>
+            {formattedDate && (
+              <p className="text-lg font-semibold text-white/90">{formattedDate}</p>
+            )}
+            {venueLabel && (
+              <p className="text-base text-white/80">@ {venueLabel}</p>
+            )}
+            {description && (
+              <p
+                className="text-base leading-relaxed text-white/90 sm:text-lg"
+                style={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: 3,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {description}
+              </p>
+            )}
+            <div className="mt-6 flex flex-wrap items-center gap-3">
+              <Link
+                to={detailPath}
+                className="inline-flex items-center justify-center rounded-full bg-amber-300 px-5 py-2 text-base font-semibold text-slate-950 transition hover:bg-amber-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-100"
+              >
+                Learn More
+              </Link>
+              <button
+                type="button"
+                onClick={handleFavoriteClick}
+                disabled={favoriteLoading || !event?.id}
+                className={`inline-flex items-center justify-center rounded-full border-2 px-5 py-2 text-base font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-100 ${
+                  isFavorite
+                    ? 'border-amber-300 bg-amber-200 text-slate-900 hover:bg-amber-100'
+                    : 'border-white text-white hover:bg-white hover:text-slate-950'
+                } ${favoriteLoading ? 'opacity-75' : ''}`}
+              >
+                {isFavorite ? 'In the Plans' : 'Add to Plans'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {groupMatches.length > 0 && (
+        <div className="border-t border-slate-200 bg-white">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">Communities</p>
+              <h2 className="mt-2 text-2xl font-bold text-slate-900">
+                {calloutTagLabel ? `Also tagged ${calloutTagLabel}` : 'Also tagged'}
+              </h2>
+              <p className="text-sm text-slate-600">
+                Connect with local groups sharing this tradition.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {groupMatches.map(group => (
+                <Link
+                  key={group.id}
+                  to={group.slug ? `/groups/${group.slug}` : '/groups'}
+                  className="group flex items-center gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-indigo-400 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+                >
+                  <div className="h-14 w-14 flex-shrink-0 overflow-hidden rounded-full border border-slate-200 bg-slate-100">
+                    {group.imag ? (
+                      <img
+                        src={group.imag}
+                        alt={group.Name}
+                        loading="lazy"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center text-lg font-semibold text-slate-500">
+                        {group.Name?.charAt(0) || '?'}
+                      </div>
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-base font-semibold text-slate-900 group-hover:text-indigo-600">
+                      {group.Name || 'Community Group'}
+                    </p>
+                    <p className="text-sm text-slate-500">{group.Nationality}</p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Helmet>
+        <meta property="og:title" content={ogTitle} />
+        <meta property="og:description" content={ogDescription} />
+        <meta property="og:image" content={absoluteImage} />
+        <meta property="og:url" content={canonicalUrl || SITE_BASE_URL} />
+        <meta property="og:type" content="website" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={ogTitle} />
+        <meta name="twitter:description" content={ogDescription} />
+        <meta name="twitter:image" content={absoluteImage} />
+        {jsonLd && (
+          <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+        )}
+      </Helmet>
+    </section>
+  );
+}

--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -11,6 +11,7 @@ import RecentActivity from './RecentActivity';
 import EventsPageHero from './EventsPageHero';
 import CityHolidayAlert from './CityHolidayAlert';
 import HeroLanding from './HeroLanding';
+import FeaturedTraditionHero from './FeaturedTraditionHero';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css'
 import SportsEventsGrid from './SportsEventsGrid';
@@ -1650,6 +1651,8 @@ if (!loading) {
           <div className="flex flex-col min-h-screen overflow-x-visible">
             <Navbar bottomBanner={guidePromoBanner} />
 
+            <FeaturedTraditionHero />
+
             <div className="flex-1 pt-12 sm:pt-16">
               <div className="relative mt-10 sm:mt-12">
                 <FallingPills />
@@ -2110,56 +2113,6 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
                 </div>
               </div>
             </section>
-            <section className="w-full max-w-screen-xl mx-auto mt-12 mb-12 px-4">
-              <div className="space-y-3 text-left mb-6">
-                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
-                  Saved agenda
-                </p>
-                <h2 className="text-black text-4xl font-[Barrio] text-left">
-                  Your Upcoming Plans
-                </h2>
-                <p className="text-sm text-gray-600 sm:text-base">{savedPlansDescription}</p>
-              </div>
-              {!loadingSaved && user && savedEvents.length > 0 && (
-                <>
-                  <SavedEventsScroller events={savedEvents} />
-                  <p className="text-gray-600 mt-2">
-                    <Link to="/profile" className="text-indigo-600 underline">
-                      See more plans on your profile
-                    </Link>
-                  </p>
-                </>
-              )}
-            </section>
-            <HeroLanding fullWidth />
-            {taggedScrollerConfigs.map(({ slug, eyebrow, headline, description }) => (
-              <TaggedEventScroller
-                key={slug}
-                tags={[slug]}
-                fullWidth
-                header={
-                  <Link
-                    to={`/tags/${slug}`}
-                    className="block w-full max-w-screen-xl mx-auto px-4 mb-6 space-y-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-                  >
-                    {eyebrow && (
-                      <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
-                        {eyebrow}
-                      </p>
-                    )}
-                    <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
-                      {headline}
-                    </h2>
-                    {description && (
-                      <p className="text-sm text-gray-600 sm:text-base">
-                        {description}
-                      </p>
-                    )}
-                  </Link>
-                }
-              />
-            ))}
-
             <section
               aria-labelledby="community-indexes-heading"
               className="overflow-hidden bg-[#bf3d35] text-white"
@@ -2220,6 +2173,55 @@ const mapped = allPagedEvents.filter(e => e.latitude && e.longitude);
                 </div>
               </div>
             </section>
+            <section className="w-full max-w-screen-xl mx-auto mt-12 mb-12 px-4">
+              <div className="space-y-3 text-left mb-6">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                  Saved agenda
+                </p>
+                <h2 className="text-black text-4xl font-[Barrio] text-left">
+                  Your Upcoming Plans
+                </h2>
+                <p className="text-sm text-gray-600 sm:text-base">{savedPlansDescription}</p>
+              </div>
+              {!loadingSaved && user && savedEvents.length > 0 && (
+                <>
+                  <SavedEventsScroller events={savedEvents} />
+                  <p className="text-gray-600 mt-2">
+                    <Link to="/profile" className="text-indigo-600 underline">
+                      See more plans on your profile
+                    </Link>
+                  </p>
+                </>
+              )}
+            </section>
+            <HeroLanding fullWidth />
+            {taggedScrollerConfigs.map(({ slug, eyebrow, headline, description }) => (
+              <TaggedEventScroller
+                key={slug}
+                tags={[slug]}
+                fullWidth
+                header={
+                  <Link
+                    to={`/tags/${slug}`}
+                    className="block w-full max-w-screen-xl mx-auto px-4 mb-6 space-y-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                  >
+                    {eyebrow && (
+                      <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">
+                        {eyebrow}
+                      </p>
+                    )}
+                    <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">
+                      {headline}
+                    </h2>
+                    {description && (
+                      <p className="text-sm text-gray-600 sm:text-base">
+                        {description}
+                      </p>
+                    )}
+                  </Link>
+                }
+              />
+            ))}
 
             <RecurringEventsScroller
               windowStart={startOfWeek}

--- a/src/ThisMonthInPhiladelphia.jsx
+++ b/src/ThisMonthInPhiladelphia.jsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import FeaturedTraditionHero from './FeaturedTraditionHero';
 import { supabase } from './supabaseClient';
 import { AuthContext } from './AuthProvider';
 import useEventFavorite from './utils/useEventFavorite';
@@ -179,6 +180,7 @@ export default function ThisMonthInPhiladelphia({ monthSlugOverride, yearOverrid
         ogType="website"
       />
       <Navbar />
+      <FeaturedTraditionHero />
       <main className="flex-1 pt-36 md:pt-40 pb-16">
         <div className="container mx-auto px-4 max-w-5xl">
           {hasValidParams ? (

--- a/src/ThisWeekendInPhiladelphia.jsx
+++ b/src/ThisWeekendInPhiladelphia.jsx
@@ -5,6 +5,7 @@ import { RRule } from 'rrule';
 import { FaStar } from 'react-icons/fa';
 import Navbar from './Navbar';
 import Footer from './Footer';
+import FeaturedTraditionHero from './FeaturedTraditionHero';
 import Seo from './components/Seo.jsx';
 import { supabase } from './supabaseClient';
 import { AuthContext } from './AuthProvider';
@@ -754,6 +755,7 @@ export default function ThisWeekendInPhiladelphia() {
         ogType="website"
       />
       <Navbar />
+      <FeaturedTraditionHero />
       <main className="flex-1 pt-36 md:pt-40 pb-16">
         <div className="container mx-auto px-4 max-w-6xl">
           <h1 className="text-4xl sm:text-5xl font-[Barrio] text-[#28313e] text-center">


### PR DESCRIPTION
## Summary
- update the Featured Tradition hero to show an "Also tagged" communities heading and normalize the event nationality used for related groups
- include the featured hero on the monthly traditions and weekend guide pages so promoted events lead each guide
- move the Community Indexes strip directly beneath the Other Our Philly guides section on the homepage
- add additional top spacing inside the hero so the fixed navbar no longer overlaps the featured content on the weekend and monthly guide pages

## Testing
- npm run lint *(fails: the repo's lint script still passes the deprecated --ext flag when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d1476fb684832cb60e11ed2aff0257