### PR TITLE
Adjust traditions date format and group filters

### DIFF
--- a/src/CommunityIndexPage.jsx
+++ b/src/CommunityIndexPage.jsx
@@ -108,8 +108,6 @@ function formatDateRange(start, end) {
   if (sameDay) {
     return start.toLocaleDateString('en-US', {
       month: 'long',
-      day: 'numeric',
-      year: 'numeric',
     })
   }
 
@@ -120,24 +118,22 @@ function formatDateRange(start, end) {
 
   if (sameYear && sameMonth) {
     const monthName = start.toLocaleDateString('en-US', { month: 'long' })
-    return `${monthName} ${start.getDate()}–${end.getDate()}, ${startYear}`
+    return `${monthName} ${start.getDate()}–${end.getDate()}`
   }
 
   if (sameYear) {
     const startLabel = start.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
     const endLabel = end.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
-    return `${startLabel} – ${endLabel}, ${startYear}`
+    return `${startLabel} – ${endLabel}`
   }
 
   const startLabel = start.toLocaleDateString('en-US', {
     month: 'long',
     day: 'numeric',
-    year: 'numeric',
   })
   const endLabel = end.toLocaleDateString('en-US', {
     month: 'long',
     day: 'numeric',
-    year: 'numeric',
   })
   return `${startLabel} – ${endLabel}`
 }
@@ -581,38 +577,40 @@ export default function CommunityIndexPage({ region }) {
             ) : (
               <>
                 {groupTypeOptions.length > 0 && (
-                  <div className="flex flex-wrap gap-3 mb-8">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setGroupTypeFilter('all')
-                        setShowAllGroups(false)
-                      }}
-                      className={`px-4 py-2 rounded-full border text-sm font-medium transition ${
-                        groupTypeFilter === 'all'
-                          ? 'bg-indigo-600 text-white border-indigo-600'
-                          : 'border-indigo-100 text-indigo-600 hover:bg-indigo-50'
-                      }`}
-                    >
-                      All types
-                    </button>
-                    {groupTypeOptions.map(type => (
+                  <div className="mb-8 -mx-4 sm:mx-0">
+                    <div className="flex gap-3 overflow-x-auto flex-nowrap pb-2 px-4 sm:px-0">
                       <button
-                        key={type}
                         type="button"
                         onClick={() => {
-                          setGroupTypeFilter(type)
+                          setGroupTypeFilter('all')
                           setShowAllGroups(false)
                         }}
-                        className={`px-4 py-2 rounded-full border text-sm font-medium transition ${
-                          groupTypeFilter === type
+                        className={`px-4 py-2 rounded-full border text-sm font-medium transition flex-shrink-0 whitespace-nowrap ${
+                          groupTypeFilter === 'all'
                             ? 'bg-indigo-600 text-white border-indigo-600'
                             : 'border-indigo-100 text-indigo-600 hover:bg-indigo-50'
                         }`}
                       >
-                        {type}
+                        All types
                       </button>
-                    ))}
+                      {groupTypeOptions.map(type => (
+                        <button
+                          key={type}
+                          type="button"
+                          onClick={() => {
+                            setGroupTypeFilter(type)
+                            setShowAllGroups(false)
+                          }}
+                          className={`px-4 py-2 rounded-full border text-sm font-medium transition flex-shrink-0 whitespace-nowrap ${
+                            groupTypeFilter === type
+                              ? 'bg-indigo-600 text-white border-indigo-600'
+                              : 'border-indigo-100 text-indigo-600 hover:bg-indigo-50'
+                          }`}
+                        >
+                          {type}
+                        </button>
+                      ))}
+                    </div>
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary
- hide the year from the date labels shown in the All Traditions list
- switch the All Groups filter chips to a horizontal, scrollable row so they take less space on small screens

## Testing
- `npm run lint` *(fails: project script still uses deprecated --ext flag with eslint.config.js)*
- `npx eslint .` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d55b97e8ac832ca8dbf55569791c7e