### PR TITLE
Fetch entire show roll call month and add pagination

### DIFF
--- a/src/AllGuidesPage.jsx
+++ b/src/AllGuidesPage.jsx
@@ -31,6 +31,9 @@ export default function AllGuidesPage() {
   const musicPath = monthSlug
     ? `/music-events-in-philadelphia-${monthSlug}-${year}/`
     : '/music-events-in-philadelphia/';
+  const showRollCallPath = monthSlug
+    ? `/philadelphia-show-roll-call-${monthSlug}-${year}/`
+    : '/philadelphia-show-roll-call/';
   const traditionsPath = monthSlug
     ? `/philadelphia-events-${monthSlug}-${year}/`
     : '/philadelphia-events/';
@@ -70,6 +73,11 @@ export default function AllGuidesPage() {
       label: `Music – ${monthLabel}`,
       description: 'Concerts, festivals, and live music picks happening across Philadelphia this month.',
       href: musicPath,
+    },
+    {
+      label: `Show Roll Call – ${monthLabel}`,
+      description: 'A month-long concert roll call with every show we can find plus direct ticket links.',
+      href: showRollCallPath,
     },
   ];
 

--- a/src/ShowRollCallMonthlyPage.jsx
+++ b/src/ShowRollCallMonthlyPage.jsx
@@ -1,0 +1,4 @@
+import createMonthlyGuidePage from './createMonthlyGuidePage.jsx';
+import { MONTHLY_GUIDE_CONFIGS } from './monthlyGuideConfigs.js';
+
+export default createMonthlyGuidePage(MONTHLY_GUIDE_CONFIGS.showRollCall);

--- a/src/ViewRouter.jsx
+++ b/src/ViewRouter.jsx
@@ -7,6 +7,7 @@ import ArtsCultureMonthlyPage from './ArtsCultureMonthlyPage.jsx';
 import FoodDrinkMonthlyPage from './FoodDrinkMonthlyPage.jsx';
 import FitnessWellnessMonthlyPage from './FitnessWellnessMonthlyPage.jsx';
 import MusicMonthlyPage from './MusicMonthlyPage.jsx';
+import ShowRollCallMonthlyPage from './ShowRollCallMonthlyPage.jsx';
 import { MONTHLY_GUIDE_CONFIGS } from './monthlyGuideConfigs.js';
 
 const MONTH_VIEW_REGEX = /^philadelphia-events-([a-z-]+)-(\d{4})$/i;
@@ -17,6 +18,7 @@ const GUIDE_ROUTES = [
   { regex: MONTHLY_GUIDE_CONFIGS.foodDrink.viewRegex, Component: FoodDrinkMonthlyPage },
   { regex: MONTHLY_GUIDE_CONFIGS.fitnessWellness.viewRegex, Component: FitnessWellnessMonthlyPage },
   { regex: MONTHLY_GUIDE_CONFIGS.music.viewRegex, Component: MusicMonthlyPage },
+  { regex: MONTHLY_GUIDE_CONFIGS.showRollCall.viewRegex, Component: ShowRollCallMonthlyPage },
 ];
 
 export default function ViewRouter() {

--- a/src/monthlyGuideConfigs.js
+++ b/src/monthlyGuideConfigs.js
@@ -1,4 +1,4 @@
-export const MONTHLY_GUIDE_ORDER = ['family', 'artsCulture', 'foodDrink', 'fitnessWellness', 'music'];
+export const MONTHLY_GUIDE_ORDER = ['family', 'artsCulture', 'foodDrink', 'fitnessWellness', 'music', 'showRollCall'];
 
 export const MONTHLY_GUIDE_CONFIGS = {
   family: {
@@ -285,6 +285,65 @@ export const MONTHLY_GUIDE_CONFIGS = {
         `We refresh this guide as new events are published and last updated it on ${updatedStamp}. Bookmark it to catch new concerts each week.`,
     },
     errorLogMessage: 'Error loading music events',
+  },
+  showRollCall: {
+    key: 'showRollCall',
+    navLabel: 'Show Roll Call',
+    pathSegment: 'philadelphia-show-roll-call',
+    tagSlugs: [],
+    viewRegex: /^philadelphia-show-roll-call-([a-z-]+)-(\d{4})$/i,
+    fallbackDescription:
+      'Track every concert hitting Philadelphia this month with our always-updated show roll call.',
+    seoTitle: monthLabel => `Philadelphia Show Roll Call – ${monthLabel}`,
+    seoTitleFallback: 'Philadelphia Show Roll Call – Our Philly',
+    seoDescription: monthLabel =>
+      `Browse every concert happening in Philadelphia this ${monthLabel}: venue listings, ticket links, and what\'s on this weekend & today.`,
+    jsonLdName: monthLabel => `Philadelphia Show Roll Call – ${monthLabel}`,
+    hero: {
+      heading: monthLabel => `Philadelphia Show Roll Call – ${monthLabel}`,
+      withCount: (count, monthLabel) =>
+        `Browse ${count} concerts and live shows happening across Philadelphia in ${monthLabel}.`,
+      withoutCount: monthLabel =>
+        `Browse concerts and live shows happening across Philadelphia in ${monthLabel}.`,
+    },
+    weekend: {
+      summary: 'Concerts and shows happening Friday through Sunday in Philadelphia.',
+      intro: 'Shows this weekend include: ',
+      empty: "We don't have any shows listed for this weekend yet—check back soon.",
+    },
+    today: {
+      heading: 'Shows happening today',
+      summary: 'Quick look at tonight’s concerts across Philly.',
+      intro: 'Shows today include: ',
+      empty: "No shows are listed for today—browse the full roll call below for more concerts.",
+    },
+    monthEmpty: monthLabel =>
+      `No shows are listed for ${monthLabel} yet. Check back soon or submit one!`,
+    loadingText: 'Loading shows…',
+    concludingText:
+      'Our Philly tracks concerts and live shows across Philadelphia so you never miss a lineup.',
+    faq: {
+      monthlyQuestion: monthLabel => `What concerts are happening in Philadelphia in ${monthLabel}?`,
+      monthlyAnswerWithEvents: (count, monthLabel) =>
+        `Our Philly’s show roll call tracks ${count} concerts and live performances happening across Philadelphia in ${monthLabel}, pulling listings from venue calendars and ticketing pages.`,
+      monthlyAnswerWithoutEvents: monthLabel =>
+        `Our Philly’s show roll call tracks concerts and live performances happening across Philadelphia in ${monthLabel}, pulling listings from venue calendars and ticketing pages.`,
+      weekendQuestion: 'Which concerts are happening in Philadelphia this weekend?',
+      weekendAnswerWithEvents: names => `Concerts this weekend include ${names}.`,
+      weekendAnswerWithoutEvents:
+        'We’re gathering this weekend’s shows—check back soon or browse the monthly roll call below.',
+      todayQuestion: 'What concerts are happening in Philadelphia today?',
+      todayAnswerWithEvents: names => `Concerts today include ${names}.`,
+      todayAnswerWithoutEvents:
+        'No shows are listed for today yet—check back later or explore the monthly roll call for more concerts.',
+      updatedQuestion: 'How often is the Philadelphia show roll call updated?',
+      updatedAnswer: updatedStamp =>
+        `We refresh this show roll call as new concerts are added and last updated it on ${updatedStamp}. Check back each week for the latest listings.`,
+    },
+    errorLogMessage: 'Error loading show roll call events',
+    filterByTags: false,
+    allowedSources: ['all_events'],
+    showTicketsButton: true,
   },
 };
 


### PR DESCRIPTION
## Summary
- iterate through the supabase all_events listings in 200-item pages so the monthly show roll call pulls every concert within the target month
- reset visible result batches and add a View more button that reveals 50 additional events at a time while leaving the weekend/today highlights based on the full list

## Testing
- not run (lint command unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9409a3f1c832cbef527e2c34b8467