### PR TITLE
Align group cards with home Add to Plans experience

### DIFF
--- a/src/GroupCard.jsx
+++ b/src/GroupCard.jsx
@@ -143,7 +143,7 @@ export default function GroupCard({ group, isAdmin, featuredGroupId }) {
           alt={group.Name}
           className="w-full h-full object-cover"
         />
-        <div className="absolute inset-0 bg-black/40" />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
 
         {/* Click overlay */}
         <Link to={`/groups/${group.slug}`} className="absolute inset-0 z-10" />

--- a/src/GroupEventDetailPage.jsx
+++ b/src/GroupEventDetailPage.jsx
@@ -9,6 +9,7 @@ import { AuthContext } from './AuthProvider'
 import EventFavorite from './EventFavorite.jsx'
 import CommentsSection from './CommentsSection'
 import Seo from './components/Seo.jsx'
+import PlansCard from './components/PlansCard.jsx'
 import {
   SITE_BASE_URL,
   DEFAULT_OG_IMAGE,
@@ -16,6 +17,7 @@ import {
   buildEventJsonLd,
   buildIsoDateTime,
 } from './utils/seoHelpers.js'
+import { getDetailPathForItem } from './utils/eventDetailPaths.js'
 
 const FALLBACK_GROUP_EVENT_TITLE = 'Group Event – Our Philly'
 const FALLBACK_GROUP_EVENT_DESCRIPTION =
@@ -50,6 +52,23 @@ function formatTime(t) {
   return `${h}:${String(m).padStart(2,'0')} ${ampm}`
 }
 
+function parseLegacyDate(str) {
+  if (!str) return null
+  const [first] = str.split(/through|–|-/)
+  const parts = first.trim().split('/')
+  if (parts.length !== 3) return null
+  const [m, d, y] = parts.map(Number)
+  const dt = new Date(y, m - 1, d)
+  return isNaN(dt) ? null : dt
+}
+
+function resolveGroupEventImage(imageUrl) {
+  if (!imageUrl) return ''
+  if (imageUrl.startsWith('http')) return imageUrl
+  const { data } = supabase.storage.from('big-board').getPublicUrl(imageUrl)
+  return data?.publicUrl || ''
+}
+
 export default function GroupEventDetailPage() {
   const { slug, eventId } = useParams()
   const navigate = useNavigate()
@@ -68,6 +87,8 @@ export default function GroupEventDetailPage() {
 
   const [subs, setSubs]             = useState([])
   const [loadingSubs, setLoadingSubs] = useState(true)
+  const [moreEvents, setMoreEvents] = useState([])
+  const [loadingMoreEvents, setLoadingMoreEvents] = useState(false)
 
   // ── LOAD GROUP, EVENT, TAGS, IMAGE ─────────────────────────────────
   useEffect(() => {
@@ -76,7 +97,7 @@ export default function GroupEventDetailPage() {
       // 1) group
       const { data: grp } = await supabase
         .from('groups')
-        .select('id,Name,slug,Description')
+        .select('id,Name,slug,Description,imag')
         .eq('slug', slug)
         .single()
 
@@ -160,6 +181,51 @@ export default function GroupEventDetailPage() {
     }
     loadSubs()
   }, [])
+
+  useEffect(() => {
+    if (!group?.id || !evt?.id) return
+    let active = true
+
+    const loadMore = async () => {
+      setLoadingMoreEvents(true)
+      try {
+        const today = new Date()
+        today.setHours(0, 0, 0, 0)
+        const todayStr = today.toISOString().slice(0, 10)
+        const { data, error } = await supabase
+          .from('group_events')
+          .select('*')
+          .eq('group_id', group.id)
+          .neq('id', evt.id)
+          .gte('start_date', todayStr)
+          .order('start_date', { ascending: true })
+          .limit(4)
+        if (error) throw error
+        const mapped = (data || []).map(item => {
+          const image =
+            resolveGroupEventImage(item.image_url) || evt.image || group.imag || ''
+          const href =
+            getDetailPathForItem({
+              ...item,
+              group_slug: group.slug,
+              isGroupEvent: true,
+            }) || `/groups/${group.slug}/events/${item.id}`
+          return { ...item, image, href }
+        })
+        if (active) setMoreEvents(mapped)
+      } catch (err) {
+        console.error('Error loading more group events:', err)
+        if (active) setMoreEvents([])
+      } finally {
+        if (active) setLoadingMoreEvents(false)
+      }
+    }
+
+    loadMore()
+    return () => {
+      active = false
+    }
+  }, [group?.id, group?.slug, group?.imag, evt?.id, evt?.image])
 
   // ── EDIT HANDLERS ─────────────────────────────────────────────────
   const startEditing = () => {
@@ -534,7 +600,52 @@ export default function GroupEventDetailPage() {
 
         <CommentsSection source_table="group_events" event_id={evt.id} />
 
-        <section className="w-full bg-neutral-100 py-12">
+        {(loadingMoreEvents || moreEvents.length > 0) && (
+          <section className="w-full bg-neutral-100 py-12 border-t border-neutral-200">
+            <div className="max-w-7xl mx-auto px-4">
+              <h2 className="text-2xl font-semibold text-center mb-6">
+                More from {group?.Name || 'this group'}
+              </h2>
+              {loadingMoreEvents ? (
+                <p className="text-center text-gray-500">Loading…</p>
+              ) : moreEvents.length === 0 ? (
+                <p className="text-center text-gray-600">
+                  No other upcoming events from this group.
+                </p>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+                  {moreEvents.map(ev => {
+                    const start = parseYMD(ev.start_date)
+                    const dateLabel = start
+                      ? start.toLocaleDateString('en-US', {
+                          weekday: 'short',
+                          month: 'short',
+                          day: 'numeric',
+                        })
+                      : ''
+                    const timeLabel = formatTime(ev.start_time)
+                    const secondary = [timeLabel, ev.address].filter(Boolean).join(' · ')
+                    return (
+                      <PlansCard
+                        key={ev.id}
+                        title={ev.title}
+                        imageUrl={ev.image}
+                        href={ev.href}
+                        badge={{ label: 'Group Event', className: 'bg-emerald-500 text-white' }}
+                        meta={dateLabel}
+                        secondaryMeta={secondary}
+                        eventId={ev.id}
+                        sourceTable="group_events"
+                      />
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+
+        <section className="w-full bg-neutral-100 py-12 border-t border-neutral-200">
           <div className="max-w-7xl mx-auto px-4">
             <h2 className="text-2xl font-semibold text-center mb-6">
               Upcoming Community Submissions
@@ -549,33 +660,22 @@ export default function GroupEventDetailPage() {
                   const d = parseYMD(s.start_date)
                   const label = d
                     ? d.toLocaleDateString('en-US', {
+                        weekday: 'short',
                         month: 'short',
                         day: 'numeric',
                       })
                     : ''
                   return (
-                    <Link
+                    <PlansCard
                       key={s.id}
-                      to={`/big-board/${s.slug}`}
-                      className="bg-white rounded-lg shadow hover:shadow-lg overflow-hidden"
-                    >
-                      <div className="relative h-32 bg-gray-100">
-                        <div className="absolute inset-x-0 bottom-0 bg-indigo-600 text-white text-xs uppercase text-center py-1 z-10">
-                          COMMUNITY SUBMISSION
-                        </div>
-                        {s.image && (
-                          <img
-                            src={s.image}
-                            alt={s.title}
-                            className="w-full h-full object-cover"
-                          />
-                        )}
-                      </div>
-                      <div className="p-4 text-center">
-                        <h3 className="font-semibold mb-1 line-clamp-2">{s.title}</h3>
-                        <p className="text-sm text-gray-600">{label}</p>
-                      </div>
-                    </Link>
+                      title={s.title}
+                      imageUrl={s.image}
+                      href={`/big-board/${s.slug}`}
+                      badge="Submission"
+                      meta={label}
+                      eventId={s.id}
+                      sourceTable="big_board_events"
+                    />
                   )
                 })}
               </div>

--- a/src/components/PlansCard.jsx
+++ b/src/components/PlansCard.jsx
@@ -1,0 +1,112 @@
+import React, { useContext } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../AuthProvider';
+import useEventFavorite from '../utils/useEventFavorite';
+
+function normalizeBadge(badge) {
+  if (!badge) return null;
+  if (typeof badge === 'string') {
+    return { label: badge, className: undefined };
+  }
+  return badge;
+}
+
+export default function PlansCard({
+  title,
+  imageUrl,
+  href,
+  badge,
+  meta,
+  secondaryMeta,
+  eventId,
+  sourceTable,
+  externalUrl,
+  className = '',
+}) {
+  const normalizedBadge = normalizeBadge(badge);
+  const navigate = useNavigate();
+  const { user } = useContext(AuthContext);
+  const { isFavorite, toggleFavorite, loading } = useEventFavorite({
+    event_id: eventId,
+    source_table: sourceTable,
+  });
+
+  const canFavorite = Boolean(eventId && sourceTable && !externalUrl);
+  const Wrapper = href ? Link : 'div';
+  const wrapperProps = href ? { to: href } : {};
+
+  const handleFavoriteClick = e => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!user) {
+      navigate('/login');
+      return;
+    }
+    toggleFavorite();
+  };
+
+  return (
+    <Wrapper
+      {...wrapperProps}
+      className={`group flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2 ${
+        isFavorite && canFavorite ? 'ring-2 ring-indigo-600' : ''
+      } ${className}`.trim()}
+    >
+      <div className="relative h-40 w-full overflow-hidden bg-gray-100">
+        {imageUrl ? (
+          <img src={imageUrl} alt={title} className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm font-semibold text-gray-500">
+            Photo coming soon
+          </div>
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+        {isFavorite && canFavorite && (
+          <div className="absolute right-3 top-3 rounded-full bg-indigo-600 px-3 py-1 text-xs font-semibold text-white shadow">
+            In the plans!
+          </div>
+        )}
+        {normalizedBadge?.label && (
+          <div
+            className={`absolute inset-x-0 bottom-0 text-center text-xs font-bold uppercase tracking-wide ${
+              normalizedBadge.className || 'bg-indigo-600 text-white'
+            }`}
+          >
+            {normalizedBadge.label}
+          </div>
+        )}
+      </div>
+      <div className="flex flex-1 flex-col items-center px-5 pb-5 pt-4 text-center">
+        <div className="flex w-full flex-1 flex-col items-center">
+          <h3 className="text-base font-semibold text-gray-900 line-clamp-2">{title}</h3>
+          {meta && <p className="mt-2 text-sm text-gray-600">{meta}</p>}
+          {secondaryMeta && <p className="mt-1 text-xs text-gray-500">{secondaryMeta}</p>}
+        </div>
+        <div className="mt-4 w-full">
+          {externalUrl ? (
+            <a
+              href={externalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center rounded-md border border-indigo-600 px-4 py-2 text-sm font-semibold text-indigo-600 transition hover:bg-indigo-600 hover:text-white"
+              onClick={e => e.stopPropagation()}
+            >
+              Get Tickets
+            </a>
+          ) : canFavorite ? (
+            <button
+              type="button"
+              onClick={handleFavoriteClick}
+              disabled={loading}
+              className={`inline-flex w-full items-center justify-center rounded-md border border-indigo-600 px-4 py-2 text-sm font-semibold transition ${
+                isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'
+              }`}
+            >
+              {isFavorite ? 'In the Plans' : 'Add to Plans'}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a shared PlansCard component that mirrors the home page styling and integrates the Add to Plans button logic
- restyle group detail upcoming events with the new card layout, including formatted date/time metadata
- update group event detail related sections to use the shared card style, surface four "More from" events, and remove the Philly traditions grid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db02d82334832ca20c7f3ee7f7934c