### PR TITLE
Fix group event detail lookup in calendar view

### DIFF
--- a/src/GroupDetailPage.jsx
+++ b/src/GroupDetailPage.jsx
@@ -84,11 +84,15 @@ export default function GroupDetailPage() {
         setIsApprovedForGroup(!!data)
       }
 
+      const today = new Date().toISOString().slice(0, 10)
       const { data: evts } = await supabase
-        .from('group_events')
+        .from('group_events_calendar')
         .select('*')
         .eq('group_id', grp.id)
+        .gte('start_date', today)
         .order('start_date', { ascending: true })
+        .order('start_time', { ascending: true })
+        .limit(50)
       setEvents(evts || [])
     }
     fetchData()

--- a/src/GroupEventDetailPage.jsx
+++ b/src/GroupEventDetailPage.jsx
@@ -110,7 +110,7 @@ export default function GroupEventDetailPage() {
 
       // 2) event
       const { data: ev } = await supabase
-        .from('group_events')
+        .from('group_events_calendar')
         .select('*')
         .eq('id', eventId)
         .single()
@@ -200,7 +200,7 @@ export default function GroupEventDetailPage() {
         today.setHours(0, 0, 0, 0)
         const todayStr = today.toISOString().slice(0, 10)
         const { data, error } = await supabase
-          .from('group_events')
+          .from('group_events_calendar')
           .select('*')
           .eq('group_id', group.id)
           .neq('id', evt.id)


### PR DESCRIPTION
## Summary
- update the group detail page to load upcoming events from the `group_events_calendar` view with a future-date filter and consistent ordering
- fetch group event detail rows from `group_events_calendar` by id so synthetic instance URLs return data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbc7b12bb0832caf2aa8ff9f30bfaf