### PR TITLE
Fix group event card date handling

### DIFF
--- a/src/GroupEventDetailPage.jsx
+++ b/src/GroupEventDetailPage.jsx
@@ -110,7 +110,7 @@ export default function GroupEventDetailPage() {
 
       // 2) event
       const { data: ev } = await supabase
-        .from('group_events')
+        .from('group_events_calendar')
         .select('*')
         .eq('id', eventId)
         .single()
@@ -200,7 +200,7 @@ export default function GroupEventDetailPage() {
         today.setHours(0, 0, 0, 0)
         const todayStr = today.toISOString().slice(0, 10)
         const { data, error } = await supabase
-          .from('group_events')
+          .from('group_events_calendar')
           .select('*')
           .eq('group_id', group.id)
           .neq('id', evt.id)


### PR DESCRIPTION
## Summary
- update the group detail page to load upcoming events from the `group_events_calendar` view with a future-date filter and consistent ordering
- fetch group event detail rows from `group_events_calendar` by id so synthetic instance URLs return data
- fix group event cards to format start and end dates without timezone shifts so the occurrence day matches the detail page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbc7b12bb0832caf2aa8ff9f30bfaf