### PR TITLE
Ensure tag pages include events from legacy sources

### DIFF
--- a/src/utils/taggings.js
+++ b/src/utils/taggings.js
@@ -1,0 +1,30 @@
+export function normalizeTaggableType(rawType) {
+  if (!rawType) return ''
+  const simplified = String(rawType)
+    .split('::')
+    .pop()
+    .split('\\')
+    .pop()
+    .toLowerCase()
+
+  const map = {
+    group: 'groups',
+    groups: 'groups',
+    event: 'events',
+    events: 'events',
+    legacy_event: 'events',
+    legacy_events: 'events',
+    tradition: 'events',
+    traditions: 'events',
+    big_board_event: 'big_board_events',
+    big_board_events: 'big_board_events',
+    all_event: 'all_events',
+    all_events: 'all_events',
+    group_event: 'group_events',
+    group_events: 'group_events',
+    recurring_event: 'recurring_events',
+    recurring_events: 'recurring_events',
+  }
+
+  return map[simplified] || simplified || ''
+}


### PR DESCRIPTION
## Summary
- normalize taggings to handle legacy `events` identifiers when building tag pages
- improve legacy event date parsing so start and end times are derived reliably
- share taggable type normalization with the tagged events scroller for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea4ed4b38832cbfbef9b4a397f473