### PR TITLE
Restyle tag highlights and weekly scroller

### DIFF
--- a/src/MainEvents.jsx
+++ b/src/MainEvents.jsx
@@ -82,21 +82,20 @@ const TAG_PILL_STYLES = [
 
 const taggedScrollerConfigs = [
   {
-    slug: 'birds',
-    eyebrow: 'Seasonal Tag',
-    headline: 'Next in #Birds',
-  },
-  {
     slug: 'arts',
     eyebrow: 'Tag highlight',
     headline: 'Next in Arts',
-    description: 'Plot out gallery walks, performances, and creative nights across the city.',
+    supportingCopy: 'Plot out gallery walks, performances, and creative nights across the city.',
+    ctaLabel: 'See all arts events',
+    ctaHref: '/tags/arts',
   },
   {
     slug: 'nomnomslurp',
     eyebrow: 'Tag highlight',
     headline: 'Next in #NomNomSlurp',
-    description: 'Keep tabs on pop-ups, tastings, and foodie meetups worth savoring next.',
+    supportingCopy: 'Keep tabs on pop-ups, tastings, and foodie meetups worth savoring next.',
+    ctaLabel: 'See all #NomNomSlurp events',
+    ctaHref: '/tags/nomnomslurp',
   },
 ];
 
@@ -1559,41 +1558,27 @@ export default function MainEvents() {
         </section>
 
         <HeroLanding fullWidth />
-        {taggedScrollerConfigs.map(({ slug, eyebrow, headline, description }) => (
+        {taggedScrollerConfigs.map(({ slug, eyebrow, headline, supportingCopy, ctaLabel, ctaHref }) => (
           <TaggedEventScroller
             key={slug}
             tags={[slug]}
-            fullWidth
-            header={
-              <Link
-                to={`/tags/${slug}`}
-                className="block w-full max-w-screen-xl mx-auto px-4 mb-6 space-y-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-              >
-                {eyebrow && (
-                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">{eyebrow}</p>
-                )}
-                <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">{headline}</h2>
-                {description && (
-                  <p className="text-sm text-gray-600 sm:text-base">{description}</p>
-                )}
-              </Link>
-            }
+            variant="section"
+            eyebrow={eyebrow}
+            headline={headline}
+            supportingCopy={supportingCopy}
+            ctaLabel={ctaLabel}
+            ctaHref={ctaHref}
           />
         ))}
 
         <RecurringEventsScroller
           windowStart={startOfWeek}
           windowEnd={endOfWeek}
-          eventType="open_mic"
-          header={(
-            <div className="max-w-screen-xl mx-auto px-4 space-y-3 text-left mb-6">
-              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">Weekly regulars</p>
-              <h2 className="text-3xl sm:text-4xl font-bold text-[#28313e]">Karaoke, Bingo, Open Mics & Other Weeklies</h2>
-              <p className="text-sm text-gray-600 sm:text-base">
-                Drop into rotating open mics, karaoke nights, and game sessions that come back every week.
-              </p>
-            </div>
-          )}
+          eyebrow="Weekly regulars"
+          headline="Karaoke, Bingo, Open Mics & Other Weeklies"
+          description="Drop into rotating open mics, karaoke nights, and game sessions that come back every week."
+          ctaLabel="Browse all recurring series"
+          ctaHref="/series"
         />
       </main>
       <FloatingAddButton onClick={() => setShowFlyerModal(true)} />

--- a/src/RecurringEventsScroller.jsx
+++ b/src/RecurringEventsScroller.jsx
@@ -1,10 +1,11 @@
 // src/RecurringEventsScroller.jsx
-import React, { useState, useEffect, useContext } from 'react'
+import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { RRule } from 'rrule'
 import { supabase } from './supabaseClient'
 import { Link, useNavigate } from 'react-router-dom'
 import useEventFavorite from './utils/useEventFavorite'
 import { AuthContext } from './AuthProvider'
+import { ArrowRight } from 'lucide-react'
 
 const TYPE_OPTIONS = [
   { key: null,       label: 'All',      icon: null },
@@ -12,6 +13,11 @@ const TYPE_OPTIONS = [
   { key: 'karaoke',  label: 'Karaoke',  icon: 'https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images//karaoke.png' },
   { key: 'games',    label: 'Games',    icon: 'https://qdartpzrxmftmaftfdbd.supabase.co/storage/v1/object/public/group-images//bingo.png' },
 ]
+
+const TYPE_LABEL_MAP = TYPE_OPTIONS.reduce((acc, opt) => {
+  if (opt.key) acc[opt.key] = opt.label
+  return acc
+}, {})
 
 function FavoriteState({ event_id, source_table, children }) {
   const state = useEventFavorite({ event_id, source_table })
@@ -21,35 +27,51 @@ function FavoriteState({ event_id, source_table, children }) {
 export default function RecurringEventsScroller({
   windowStart,
   windowEnd,
-  header = 'Recurring Series'
+  eyebrow,
+  headline,
+  description,
+  ctaLabel,
+  ctaHref,
+  defaultType = null,
 }) {
   const [occs, setOccs] = useState([])
   const [loading, setLoading] = useState(true)
-  const [selectedType, setSelectedType] = useState(null)
+  const [selectedType, setSelectedType] = useState(defaultType ?? null)
   const { user } = useContext(AuthContext)
   const navigate = useNavigate()
 
-  function parseISO(d) {
+  useEffect(() => {
+    setSelectedType(defaultType ?? null)
+  }, [defaultType])
+
+  const parseISO = useMemo(() => (d) => {
     const [y, m, dd] = d.split('-').map(Number)
     return new Date(y, m - 1, dd)
-  }
+  }, [])
 
-  function getDayLabel(dateStr) {
-    const d = parseISO(dateStr)
-    const today = new Date(); today.setHours(0, 0, 0, 0)
-    const diff = Math.floor((d - today) / (1000 * 60 * 60 * 24))
-    if (diff === 0) return 'Today'
-    if (diff === 1) return 'Tomorrow'
-    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-  }
+  const getDayLabel = useMemo(
+    () => (dateStr) => {
+      const d = parseISO(dateStr)
+      const today = new Date(); today.setHours(0, 0, 0, 0)
+      const diff = Math.floor((d - today) / (1000 * 60 * 60 * 24))
+      if (diff === 0) return 'Today'
+      if (diff === 1) return 'Tomorrow'
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    },
+    [parseISO]
+  )
 
-  function formatTime(t) {
-    if (!t) return ''
-    let [h, m] = t.split(':')
-    let hh = parseInt(h, 10) % 12 || 12
-    const ampm = parseInt(h, 10) >= 12 ? 'p.m.' : 'a.m.'
-    return `${hh}:${(m || '00').padStart(2, '0')} ${ampm}`
-  }
+  const formatTime = useMemo(
+    () => (t) => {
+      if (!t) return ''
+      const [h, m = '00'] = t.split(':')
+      const hour = parseInt(h, 10)
+      const displayHour = hour % 12 || 12
+      const ampm = hour >= 12 ? 'p.m.' : 'a.m.'
+      return `${displayHour}:${m.padStart(2, '0')} ${ampm}`
+    },
+    []
+  )
 
   useEffect(() => {
     setLoading(true)
@@ -68,30 +90,42 @@ export default function RecurringEventsScroller({
             event_type
           `)
           .eq('is_active', true)
+
         if (selectedType) q = q.eq('event_type', selectedType)
+
         const { data: series = [] } = await q
+        const todayStart = new Date()
+        todayStart.setHours(0, 0, 0, 0)
 
         const allOccs = series.flatMap((s) => {
-          const opts = RRule.parseString(s.rrule)
-          opts.dtstart = new Date(`${s.start_date}T${s.start_time}`)
-          const rule = new RRule(opts)
-          return rule.between(windowStart, windowEnd, true).map((dt) => ({
-            id:       `${s.id}::${dt.toISOString().slice(0, 10)}`,
-            seriesId: s.id,
-            title:    s.name,
-            slug:     s.slug,
-            image:    s.image_url,
-            date:     dt.toISOString().slice(0, 10),
-            time:     s.start_time,
-            type:     s.event_type,
-            href:     `/series/${s.slug}/${dt.toISOString().slice(0, 10)}`,
-          }))
+          try {
+            const opts = RRule.parseString(s.rrule)
+            opts.dtstart = new Date(`${s.start_date}T${s.start_time}`)
+            const rule = new RRule(opts)
+            return rule
+              .between(windowStart, windowEnd, true)
+              .filter((dt) => dt >= todayStart)
+              .map((dt) => ({
+                id:       `${s.id}::${dt.toISOString().slice(0, 10)}`,
+                seriesId: s.id,
+                title:    s.name,
+                slug:     s.slug,
+                image:    s.image_url,
+                date:     dt.toISOString().slice(0, 10),
+                time:     s.start_time,
+                type:     s.event_type,
+                href:     `/series/${s.slug}/${dt.toISOString().slice(0, 10)}`,
+              }))
+          } catch (err) {
+            console.error('Recurring rule parse error', err)
+            return []
+          }
         })
 
-        allOccs.sort((a, b) => (a.date < b.date ? -1 : 1))
+        allOccs.sort((a, b) => (a.date === b.date ? 0 : a.date < b.date ? -1 : 1))
         setOccs(allOccs)
-      } catch (e) {
-        console.error(e)
+      } catch (err) {
+        console.error(err)
         setOccs([])
       } finally {
         setLoading(false)
@@ -99,102 +133,143 @@ export default function RecurringEventsScroller({
     })()
   }, [windowStart, windowEnd, selectedType])
 
+  const activeFilter = TYPE_OPTIONS.find((opt) => opt.key === selectedType) || TYPE_OPTIONS[0]
+  const filterDescription = activeFilter.key ? `${activeFilter.label.toLowerCase()} events` : 'weeklies'
+  const cardsToShow = occs.slice(0, 8)
+
+  const summaryText = loading
+    ? 'Loading weekly events…'
+    : occs.length === 0
+    ? `No upcoming ${filterDescription} right now — check back soon!`
+    : occs.length <= cardsToShow.length
+    ? `Showing ${occs.length} upcoming ${filterDescription} happening this week.`
+    : `Showing ${cardsToShow.length} of ${occs.length} upcoming ${filterDescription} happening this week.`
+
+  const resolvedHeadline = headline || 'Recurring Series'
+  const ctaDestination = ctaHref || '/series'
+  const resolvedCtaLabel = ctaLabel || 'See all recurring events'
+
   return (
-    <section className="py-8">
-      {header ? (
-        typeof header === 'string' ? (
-          <h2 className="text-3xl font-[Barrio] font-bold text-center mb-6">{header}</h2>
-        ) : (
-          header
-        )
-      ) : null}
-
-      {/* Filters: horizontally scrollable on mobile */}
-      <div className="overflow-x-auto scrollbar-hide px-4 mb-8">
-        <div className="flex space-x-2 whitespace-nowrap">
-          {TYPE_OPTIONS.map((opt) => (
-            <button
-              key={opt.key ?? 'all'}
-              onClick={() => setSelectedType(opt.key)}
-              className={`
-                flex items-center space-x-1
-                text-xs sm:text-sm font-semibold
-                px-3 sm:px-4 py-1 sm:py-2 rounded-full
-                transition
-                ${selectedType === opt.key
-                  ? 'bg-indigo-600 text-white'
-                  : 'bg-gray-200 text-gray-700 hover:bg-indigo-100'}
-              `}
-            >
-              {opt.icon && <img src={opt.icon} alt={opt.label} className="h-5 w-5" />}
-              <span>{opt.label}</span>
-            </button>
-          ))}
+    <section className="mt-16">
+      <div className="max-w-screen-xl mx-auto px-4">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            {eyebrow && (
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600">{eyebrow}</p>
+            )}
+            <h2 className={`text-2xl sm:text-3xl font-bold text-[#28313e] ${eyebrow ? 'mt-2' : ''}`}>
+              {resolvedHeadline}
+            </h2>
+            <p className="mt-2 text-sm text-gray-600 sm:text-base">{summaryText}</p>
+            {description && (
+              <p className="mt-2 text-sm text-gray-600 sm:text-base">{description}</p>
+            )}
+          </div>
+          <Link
+            to={ctaDestination}
+            className="inline-flex items-center gap-2 self-start md:self-auto px-5 py-2.5 bg-indigo-600 text-white text-sm font-semibold rounded-full shadow hover:bg-indigo-700 transition"
+          >
+            {resolvedCtaLabel}
+            <ArrowRight className="w-4 h-4" aria-hidden="true" />
+          </Link>
         </div>
-      </div>
 
-      {loading ? (
-        <p className="text-center py-8 text-gray-600">Loading…</p>
-      ) : occs.length === 0 ? (
-        <p className="text-center py-8 text-gray-600">No events found.</p>
-      ) : (
-        <div className="overflow-x-auto scrollbar-hide">
-          <div className="flex gap-4 sm:gap-6 pb-4 px-4">
-            {occs.map((evt) => {
-              const day = getDayLabel(evt.date)
-              const time = formatTime(evt.time)
-              const bubbleText = time ? `${day} ${time}` : day
-
-              return (
-                <FavoriteState key={evt.id} event_id={evt.seriesId} source_table="recurring_events">
-                  {({ isFavorite, toggleFavorite, loading }) => (
-                    <div className="w-[220px] sm:w-[260px] flex-shrink-0 flex flex-col">
-                      <Link
-                        to={evt.href}
-                        className={`relative w-full h-[340px] sm:h-[380px] rounded-2xl overflow-hidden shadow-lg hover:shadow-xl transition ${isFavorite ? 'ring-2 ring-indigo-600' : ''}`}
-                      >
-                        <img
-                          src={evt.image}
-                          alt={evt.title}
-                          className="absolute inset-0 w-full h-full object-cover"
-                        />
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent z-10" />
-                        {isFavorite && (
-                          <div className="absolute top-3 right-3 bg-indigo-600 text-white text-xs px-2 py-1 rounded z-20">
-                            In the plans!
-                          </div>
-                        )}
-
-                        <h3 className="absolute bottom-20 left-3 sm:left-4 right-3 sm:right-4 text-center text-white text-xl sm:text-2xl font-[Barrio] font-bold z-20 leading-tight">
-                          {evt.title}
-                        </h3>
-
-                        <span
-                          className="absolute bottom-6 left-1/2 transform -translate-x-1/2 bg-indigo-600 text-white text-xs sm:text-sm font-semibold px-4 py-1 rounded-full whitespace-nowrap min-w-max z-20"
-                        >
-                          {bubbleText}
-                        </span>
-                      </Link>
-                      <button
-                        onClick={(e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-                          if (!user) { navigate('/login'); return }
-                          toggleFavorite()
-                        }}
-                        disabled={loading}
-                        className={`mt-2 w-full border border-indigo-600 rounded-md py-2 font-semibold transition-colors ${isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'}`}
-                      >
-                        {isFavorite ? 'In the Plans' : 'Add to Plans'}
-                      </button>
-                    </div>
-                  )}
-                </FavoriteState>
-              )
-            })}
+        <div className="mt-6 overflow-x-auto scrollbar-hide -mx-4 px-4 md:mx-0 md:px-0">
+          <div className="flex gap-2 whitespace-nowrap">
+            {TYPE_OPTIONS.map((opt) => (
+              <button
+                key={opt.key ?? 'all'}
+                onClick={() => setSelectedType(opt.key)}
+                className={`
+                  flex items-center gap-2
+                  text-xs sm:text-sm font-semibold
+                  px-3 sm:px-4 py-1.5 sm:py-2 rounded-full transition
+                  ${selectedType === opt.key
+                    ? 'bg-indigo-600 text-white shadow'
+                    : 'bg-gray-200 text-gray-700 hover:bg-indigo-100'}
+                `}
+              >
+                {opt.icon && <img src={opt.icon} alt={opt.label} className="h-5 w-5" />}
+                <span>{opt.label}</span>
+              </button>
+            ))}
           </div>
         </div>
-      )}
+
+        <div className="mt-8">
+          {loading ? (
+            <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0 sm:grid sm:grid-cols-2 sm:gap-6 sm:overflow-visible sm:pb-0 lg:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, idx) => (
+                <div key={idx} className="w-[16rem] flex-shrink-0 snap-start sm:w-auto sm:min-w-0 sm:flex-shrink">
+                  <div className="h-[18rem] w-full rounded-2xl bg-gray-100 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          ) : cardsToShow.length === 0 ? (
+            <p className="text-sm text-gray-600 sm:text-base">No events found for this filter just yet.</p>
+          ) : (
+            <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0 sm:grid sm:grid-cols-2 sm:gap-6 sm:overflow-visible sm:pb-0 lg:grid-cols-4">
+              {cardsToShow.map((evt) => {
+                const day = getDayLabel(evt.date)
+                const time = formatTime(evt.time)
+                const bubbleText = time ? `${day} • ${time}` : day
+                const typeLabel = evt.type ? TYPE_LABEL_MAP[evt.type] : null
+
+                return (
+                  <FavoriteState key={evt.id} event_id={evt.seriesId} source_table="recurring_events">
+                    {({ isFavorite, toggleFavorite, loading: favLoading }) => (
+                      <div className="w-[16rem] flex-shrink-0 snap-start sm:w-auto sm:min-w-0 sm:flex-shrink">
+                        <Link
+                          to={evt.href}
+                          className={`flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-xl ${
+                            isFavorite ? 'ring-2 ring-indigo-600' : ''
+                          }`}
+                        >
+                          <div className="relative h-40 w-full overflow-hidden bg-gray-100">
+                            {evt.image ? (
+                              <img src={evt.image} alt={evt.title} className="h-full w-full object-cover" loading="lazy" />
+                            ) : (
+                              <div className="flex h-full items-center justify-center text-sm font-semibold text-gray-500">
+                                Photo coming soon
+                              </div>
+                            )}
+                            <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+                            <div className="absolute left-3 top-3 rounded-full bg-white/90 px-3 py-1 text-[0.65rem] font-semibold text-indigo-900 shadow-sm backdrop-blur">
+                              {bubbleText}
+                            </div>
+                          </div>
+                          <div className="flex flex-1 flex-col items-center px-5 pb-5 pt-4 text-center">
+                            <div className="flex w-full flex-1 flex-col items-center">
+                              <h3 className="text-base font-semibold text-gray-900 line-clamp-2">{evt.title}</h3>
+                              {typeLabel && (
+                                <p className="mt-1 text-xs font-semibold uppercase tracking-wide text-gray-500">{typeLabel}</p>
+                              )}
+                            </div>
+                          </div>
+                        </Link>
+                        <button
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            if (!user) { navigate('/login'); return }
+                            toggleFavorite()
+                          }}
+                          disabled={favLoading}
+                          className={`mt-2 inline-flex w-full items-center justify-center rounded-md border border-indigo-600 px-4 py-2 text-sm font-semibold transition ${
+                            isFavorite ? 'bg-indigo-600 text-white' : 'bg-white text-indigo-600 hover:bg-indigo-600 hover:text-white'
+                          }`}
+                        >
+                          {isFavorite ? 'In the Plans' : 'Add to Plans'}
+                        </button>
+                      </div>
+                    )}
+                  </FavoriteState>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- align the tag highlight sections on the homepage with the events grid styling and remove the redundant #Birds block
- extend the tagged events scroller with a section variant that renders cards, CTAs, and summaries consistent with the primary event grids
- refresh the recurring weekly scroller to share the same card layout, filter out past occurrences, and add CTA and filter polish

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfa592f74c832c8c7975f32fcc6522