### PR TITLE
Show tradition start times on day pages

### DIFF
--- a/src/DayEventsPage.jsx
+++ b/src/DayEventsPage.jsx
@@ -256,7 +256,8 @@ async function fetchBaseData(rangeStartDay, rangeEndDay) {
         Dates,
         "End Date",
         "E Image",
-        slug
+        slug,
+        start_time
       `)
       .order('Dates', { ascending: true }),
     supabase
@@ -361,6 +362,7 @@ function collectEventsForRange(rangeStart, rangeEnd, baseData) {
         startDate: start,
         endDate: end,
         slug: row.slug,
+        start_time: row.start_time || null,
       };
     })
     .filter(Boolean)


### PR DESCRIPTION
## Summary
- query the Supabase `events` table for `start_time`
- include the fetched start time when shaping tradition entries so they can display it on day pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e42493b178832c8960032776d7e1d8